### PR TITLE
Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ pluggy install placeholderapi@2.11.6
 # Add local JAR file
 pluggy install ./libs/custom-library.jar
 
+# Add Maven dependency
+pluggy install maven:net.kyori:adventure-api@4.22.0
+
 # Include pre-release versions in search
 pluggy install some-plugin --beta
 


### PR DESCRIPTION
This pull request introduces support for managing Maven dependencies in the project, alongside several enhancements to improve dependency handling and user guidance. The most significant changes include adding support for Maven dependencies, updating the `Project` interface to include registries, and improving CLI examples for better user understanding.

### Maven Dependency Support:
* Added the ability to install Maven dependencies using the `maven:` prefix, including validation of dependency format, registry lookup, and downloading the JAR file if found. (`mod.ts`, [[1]](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734L532-R569) [[2]](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734R682-R728)
* Updated the `installDependencies` function to handle Maven dependencies, ensuring proper file placement and registry validation. (`mod.ts`, [mod.tsR682-R728](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734R682-R728))

### Project Interface Enhancements:
* Extended the `Project` interface to include an optional `registries` array, enabling users to specify custom Maven registries. (`mod.ts`, [mod.tsR108](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734R108))
* Updated the `buildProject` function to handle the new `registries` property, defaulting to an empty array if not provided. (`mod.ts`, [mod.tsR340](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734R340))

### Documentation and User Guidance:
* Added an example for installing Maven dependencies to the CLI help text and `README.md` to improve user awareness of the new feature. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R72); `mod.ts`, [[2]](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734L906-R993)