### PR TITLE
feat(cli): cross-platform compile checks and doctor/init UX polish

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -120,6 +120,41 @@ export async function buildProject(
   };
 }
 
+/**
+ * Compile the project against a specific platform's API without producing a
+ * JAR. Used by multi-platform validation to check each declared platform
+ * independently of the primary build.
+ *
+ * Throws with a javac error message on failure.
+ */
+export async function checkPlatformCompile(
+  project: ResolvedProject,
+  platformId: string,
+  opts: Pick<BuildOptions, "clean"> = {},
+): Promise<void> {
+  const stagingId = createHash("sha256")
+    .update(`${project.name}\0${project.version}\0${project.rootDir}\0${platformId}`)
+    .digest("hex")
+    .slice(0, 12);
+  const stagingDir = join(project.rootDir, STAGING_ROOT, `${stagingId}-check`);
+
+  if (opts.clean) await rm(stagingDir, { recursive: true, force: true });
+  await mkdir(stagingDir, { recursive: true });
+
+  const registries = collectRegistries(project);
+  const resolvedDeps = await resolveDeclaredDependencies(project, registries);
+  const platformApiJars = await resolvePlatformApiJars(project, registries, platformId);
+
+  const depJars = resolvedDeps.flatMap(flattenJarPaths);
+  const classpath = dedupePreservingOrder([...depJars, ...platformApiJars]);
+
+  await compileJava(project, {
+    sourceDir: join(project.rootDir, "src"),
+    outputDir: stagingDir,
+    classpath,
+  });
+}
+
 function hasUserDescriptor(project: ResolvedProject, descriptorPath: string): boolean {
   const resources = project.resources;
   if (resources === undefined || resources === null) return false;
@@ -162,12 +197,13 @@ async function resolveDeclaredDependencies(
 async function resolvePlatformApiJars(
   project: ResolvedProject,
   projectRegistries: string[],
+  platformId?: string,
 ): Promise<string[]> {
   const platforms = project.compatibility?.platforms ?? [];
   const versions = project.compatibility?.versions ?? [];
   if (platforms.length === 0 || versions.length === 0) return [];
 
-  const primaryId = platforms[0];
+  const primaryId = platformId ?? platforms[0];
   const primaryVersion = versions[0];
 
   let primary;

--- a/src/build/platform-compat.test.ts
+++ b/src/build/platform-compat.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Multi-platform compile-compatibility tests.
+ *
+ * These tests call real javac and download real platform API JARs (paper-api,
+ * spigot-api). JARs are cached in the pluggy cache after the first run, so
+ * subsequent runs are fast. A JDK with `javac` on PATH is required.
+ *
+ * Three fixtures cover the interesting cases:
+ *
+ *   basic-plugin      — only Bukkit API         → paper ✔  spigot ✔
+ *   paper-plugin      — uses Paper-specific API  → paper ✔  spigot ✖
+ *   reflection-plugin — reaches Paper via        → paper ✔  spigot ✔
+ *                       Class.forName (no import)
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vite-plus/test";
+
+import { checkPlatformCompile } from "./index.ts";
+import type { ResolvedProject } from "../project.ts";
+
+// ---------------------------------------------------------------------------
+// Java source fixtures
+// ---------------------------------------------------------------------------
+
+const BASIC_PLUGIN_JAVA = `
+package com.example;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class BasicPlugin extends JavaPlugin {
+    @Override public void onEnable()  { getLogger().info("enabled");  }
+    @Override public void onDisable() { getLogger().info("disabled"); }
+}
+`.trimStart();
+
+// AsyncChatEvent exists in paper-api but not in spigot-api.
+const PAPER_PLUGIN_JAVA = `
+package com.example;
+
+import io.papermc.paper.event.player.AsyncChatEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PaperPlugin extends JavaPlugin implements Listener {
+    @Override
+    public void onEnable() {
+        getServer().getPluginManager().registerEvents(this, this);
+    }
+
+    @EventHandler
+    public void onChat(AsyncChatEvent event) {
+        // Paper-specific event — not available in spigot-api
+    }
+}
+`.trimStart();
+
+// Uses Class.forName instead of an import: compiles on any API.
+const REFLECTION_PLUGIN_JAVA = `
+package com.example;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ReflectionPlugin extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        try {
+            Class<?> cls = Class.forName("io.papermc.paper.event.player.AsyncChatEvent");
+            getLogger().info("Paper detected: " + cls.getSimpleName());
+        } catch (ClassNotFoundException e) {
+            getLogger().info("Not running on Paper, using fallback");
+        }
+    }
+}
+`.trimStart();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeFixture(
+  rootDir: string,
+  javaSource: string,
+  className: string,
+  platforms: string[],
+): Promise<ResolvedProject> {
+  const srcPkg = join(rootDir, "src", "com", "example");
+  await mkdir(srcPkg, { recursive: true });
+  await writeFile(join(srcPkg, `${className}.java`), javaSource);
+  const project: ResolvedProject = {
+    name: className.toLowerCase(),
+    version: "1.0.0",
+    main: `com.example.${className}`,
+    compatibility: { versions: ["1.21.4"], platforms },
+    rootDir,
+    projectFile: join(rootDir, "project.json"),
+  };
+  await writeFile(join(rootDir, "project.json"), JSON.stringify(project, null, 2));
+  return project;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("checkPlatformCompile — basic plugin (Bukkit-only API)", { timeout: 120_000 }, () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pluggy-compat-basic-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("compiles against paper", async () => {
+    const project = await makeFixture(dir, BASIC_PLUGIN_JAVA, "BasicPlugin", ["paper"]);
+    await expect(checkPlatformCompile(project, "paper")).resolves.toBeUndefined();
+  });
+
+  test("compiles against spigot", async () => {
+    const project = await makeFixture(dir, BASIC_PLUGIN_JAVA, "BasicPlugin", ["spigot"]);
+    await expect(checkPlatformCompile(project, "spigot")).resolves.toBeUndefined();
+  });
+});
+
+describe("checkPlatformCompile — paper plugin (Paper-specific API)", { timeout: 120_000 }, () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pluggy-compat-paper-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("compiles against paper", async () => {
+    const project = await makeFixture(dir, PAPER_PLUGIN_JAVA, "PaperPlugin", ["paper"]);
+    await expect(checkPlatformCompile(project, "paper")).resolves.toBeUndefined();
+  });
+
+  test("fails to compile against spigot (AsyncChatEvent not in spigot-api)", async () => {
+    const project = await makeFixture(dir, PAPER_PLUGIN_JAVA, "PaperPlugin", ["spigot"]);
+    await expect(checkPlatformCompile(project, "spigot")).rejects.toThrow();
+  });
+});
+
+describe(
+  "checkPlatformCompile — reflection plugin (runtime-agnostic)",
+  { timeout: 120_000 },
+  () => {
+    let dir: string;
+
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), "pluggy-compat-reflect-"));
+    });
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    test("compiles against paper", async () => {
+      const project = await makeFixture(dir, REFLECTION_PLUGIN_JAVA, "ReflectionPlugin", ["paper"]);
+      await expect(checkPlatformCompile(project, "paper")).resolves.toBeUndefined();
+    });
+
+    test("compiles against spigot (no hard import — reflection only)", async () => {
+      const project = await makeFixture(dir, REFLECTION_PLUGIN_JAVA, "ReflectionPlugin", [
+        "spigot",
+      ]);
+      await expect(checkPlatformCompile(project, "spigot")).resolves.toBeUndefined();
+    });
+  },
+);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 
 import { Command, InvalidArgumentError } from "commander";
 
-import { buildProject, type BuildResult } from "../build/index.ts";
+import { buildProject, checkPlatformCompile, type BuildResult } from "../build/index.ts";
 import { bold, log } from "../logging.ts";
 import type { ResolvedProject } from "../project.ts";
 import {
@@ -22,6 +22,13 @@ export interface BuildCommandOptions {
   cwd?: string;
 }
 
+export interface PlatformCheckResult {
+  platform: string;
+  ok: boolean;
+  durationMs: number;
+  error?: string;
+}
+
 export interface BuildCommandResult {
   status: "success" | "partial";
   /** Zero on full success, 1 when at least one workspace failed. */
@@ -34,6 +41,8 @@ export interface BuildCommandResult {
     sizeBytes?: number;
     durationMs: number;
     error?: string;
+    /** Compile-only results for each non-primary platform declared in project.json. */
+    platformChecks?: PlatformCheckResult[];
   }>;
 }
 
@@ -70,6 +79,29 @@ export async function runBuildCommand(opts: BuildCommandOptions): Promise<BuildC
         clean: opts.clean,
         skipClasspath: opts.skipClasspath,
       });
+
+      // Compile-check every non-primary platform declared in project.json.
+      const extraPlatforms = (target.compatibility?.platforms ?? []).slice(1);
+      const platformChecks: PlatformCheckResult[] = [];
+      for (const platform of extraPlatforms) {
+        const pStart = Date.now();
+        try {
+          await checkPlatformCompile(target, platform, { clean: opts.clean });
+          platformChecks.push({ platform, ok: true, durationMs: Date.now() - pStart });
+          if (!opts.json) log.success(`  ${platform}: compiles`);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          platformChecks.push({
+            platform,
+            ok: false,
+            durationMs: Date.now() - pStart,
+            error: message,
+          });
+          if (!opts.json) log.warn(`  ${platform}: ${message}`);
+          anyFailed = true;
+        }
+      }
+
       results.push({
         workspace: label,
         rootDir,
@@ -77,6 +109,7 @@ export async function runBuildCommand(opts: BuildCommandOptions): Promise<BuildC
         outputPath: res.outputPath,
         sizeBytes: res.sizeBytes,
         durationMs: res.durationMs,
+        platformChecks: platformChecks.length > 0 ? platformChecks : undefined,
       });
       if (!opts.json) {
         log.success(
@@ -116,6 +149,7 @@ export async function runBuildCommand(opts: BuildCommandOptions): Promise<BuildC
         sizeBytes: r.sizeBytes,
         durationMs: r.durationMs,
         error: r.error,
+        platformChecks: r.platformChecks,
       })),
     };
     if (anyFailed) {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -11,8 +11,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/tes
 
 import type { ResolvedProject } from "../project.ts";
 
+import yazl from "yazl";
+import { createWriteStream } from "node:fs";
+
 import {
+  checkDependencyJars,
   checkDescriptors,
+  checkJava,
   checkProjectValid,
   checkWorkspaceGraph,
   type CheckResult,
@@ -36,6 +41,7 @@ function passingHooks(): DoctorCommandOptions["checks"] {
     workspace: () => pass("workspace", "Workspace graph"),
     descriptor: () => [pass("descriptor", "Descriptor family")],
     outdated: async () => pass("outdated", "Outdated dependencies"),
+    dependencyJars: async () => pass("dep-jars", "Dependency compatibility"),
   };
 }
 
@@ -157,6 +163,11 @@ describe("checkProjectValid", () => {
 
   test("valid project passes", () => {
     const r = checkProjectValid(makeProject());
+    expect(r.status).toBe("pass");
+  });
+
+  test("hyphenated name passes", () => {
+    const r = checkProjectValid(makeProject({ name: "my-plugin" }));
     expect(r.status).toBe("pass");
   });
 
@@ -284,5 +295,242 @@ describe("checkDescriptors", () => {
     const failing = results.filter((r) => r.status === "fail");
     expect(failing.length).toBeGreaterThan(0);
     expect(failing[0].detail).toMatch(/different descriptor families|family/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkJava
+// ---------------------------------------------------------------------------
+
+describe("checkJava", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pluggy-doctor-java-"));
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("passes when java version is provided for non-BuildTools platform", async () => {
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkJava(ctx, 21);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toBe("Java 21");
+  });
+
+  test("fails when javaError is provided", async () => {
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkJava(ctx, undefined, "not found");
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/not found/);
+  });
+
+  test("fails when userJava is undefined and no error", async () => {
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkJava(ctx, undefined);
+    expect(r.status).toBe("fail");
+  });
+
+  test("warns for spigot when java is below BuildTools floor (no jar cached)", async () => {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["spigot"] },
+      }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    // No BuildTools.jar cached → floor defaults to 8. Java 7 < 8 → warn.
+    const r = await checkJava(ctx, 7);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/BuildTools requires Java/);
+  });
+
+  test("passes for spigot when java meets the floor", async () => {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["spigot"] },
+      }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkJava(ctx, 21);
+    expect(r.status).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDependencyJars
+// ---------------------------------------------------------------------------
+
+async function makeJar(path: string, entries: Record<string, Buffer | string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const zip = new yazl.ZipFile();
+    const ws = createWriteStream(path);
+    ws.once("error", reject);
+    ws.once("close", resolve);
+    zip.outputStream.pipe(ws);
+    for (const [name, content] of Object.entries(entries)) {
+      const buf = typeof content === "string" ? Buffer.from(content, "utf8") : content;
+      zip.addBuffer(buf, name);
+    }
+    zip.end();
+  });
+}
+
+function classBytes(major: number): Buffer {
+  const buf = Buffer.alloc(8);
+  buf.writeUInt32BE(0xcafebabe, 0);
+  buf.writeUInt16BE(0, 4);
+  buf.writeUInt16BE(major, 6);
+  return buf;
+}
+
+describe("checkDependencyJars", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pluggy-doctor-depjars-"));
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("passes with no lockfile", async () => {
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkDependencyJars(ctx, 21);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toMatch(/no dependencies/);
+  });
+
+  test("skips when userJava is undefined", async () => {
+    await writeFile(
+      join(rootDir, "pluggy.lock"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "some-plugin": {
+            source: { kind: "modrinth", slug: "some-plugin", version: "1.0.0" },
+            resolvedVersion: "1.0.0",
+            integrity: "sha256-aaa",
+            declaredBy: ["test"],
+          },
+        },
+      }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkDependencyJars(ctx, undefined);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toMatch(/skipped/);
+  });
+
+  test("passes when no cached jars exist on disk", async () => {
+    await writeFile(
+      join(rootDir, "pluggy.lock"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "some-plugin": {
+            source: { kind: "modrinth", slug: "some-plugin", version: "1.0.0" },
+            resolvedVersion: "1.0.0",
+            integrity: "sha256-aaa",
+            declaredBy: ["test"],
+          },
+        },
+      }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkDependencyJars(ctx, 21);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toMatch(/no cached jars/);
+  });
+
+  test("warns when a cached jar requires higher Java than available", async () => {
+    const { getCachePath } = await import("../project.ts");
+    const cacheDir = join(getCachePath(), "dependencies", "modrinth", "heavy-dep");
+    await mkdir(cacheDir, { recursive: true });
+    const jarPath = join(cacheDir, "2.0.0.jar");
+    await makeJar(jarPath, { "com/example/Plugin.class": classBytes(65) }); // Java 21
+
+    await writeFile(
+      join(rootDir, "pluggy.lock"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "heavy-dep": {
+            source: { kind: "modrinth", slug: "heavy-dep", version: "2.0.0" },
+            resolvedVersion: "2.0.0",
+            integrity: "sha256-aaa",
+            declaredBy: ["test"],
+          },
+        },
+      }),
+    );
+
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkDependencyJars(ctx, 17); // user has Java 17, dep needs 21
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/heavy-dep/);
+    expect(r.detail).toMatch(/Java 21/);
+
+    // cleanup
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  test("passes when all cached jars are compatible", async () => {
+    const { getCachePath } = await import("../project.ts");
+    const cacheDir = join(getCachePath(), "dependencies", "modrinth", "compat-dep");
+    await mkdir(cacheDir, { recursive: true });
+    const jarPath = join(cacheDir, "1.0.0.jar");
+    await makeJar(jarPath, { "com/example/Plugin.class": classBytes(61) }); // Java 17
+
+    await writeFile(
+      join(rootDir, "pluggy.lock"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "compat-dep": {
+            source: { kind: "modrinth", slug: "compat-dep", version: "1.0.0" },
+            resolvedVersion: "1.0.0",
+            integrity: "sha256-aaa",
+            declaredBy: ["test"],
+          },
+        },
+      }),
+    );
+
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    const r = await checkDependencyJars(ctx, 21); // user has Java 21, dep needs 17
+    expect(r.status).toBe("pass");
+    expect(r.detail).toMatch(/compatible with Java 21/);
+
+    // cleanup
+    await rm(cacheDir, { recursive: true, force: true });
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import process from "node:process";
@@ -6,7 +7,8 @@ import process from "node:process";
 import { Command } from "commander";
 
 import { pickDescriptor } from "../build/descriptor.ts";
-import { type LockfileEntry, readLock } from "../lockfile.ts";
+import { classMajorToJava, readJarClassMajor, readManifestAttribute } from "../jar.ts";
+import { type LockfileEntry, type TransitiveEntry, readLock } from "../lockfile.ts";
 import { bold, green, log, red, yellow } from "../logging.ts";
 import { getRegisteredPlatforms } from "../platform/index.ts";
 import { getCachePath, type ResolvedProject } from "../project.ts";
@@ -34,6 +36,7 @@ export interface DoctorCommandOptions {
     workspace?: (ctx: WorkspaceContext) => CheckResult;
     descriptor?: (ctx: WorkspaceContext) => CheckResult[];
     outdated?: () => Promise<CheckResult>;
+    dependencyJars?: () => Promise<CheckResult>;
   };
 }
 
@@ -60,7 +63,15 @@ export async function runDoctorCommand(
   const hooks = opts.checks ?? {};
   const all: CheckResult[] = [];
 
-  all.push(await (hooks.java ? hooks.java() : checkJava(context)));
+  let userJava: number | undefined;
+  let javaError: string | undefined;
+  try {
+    userJava = await getJavaMajor();
+  } catch (err) {
+    javaError = err instanceof Error ? err.message : String(err);
+  }
+
+  all.push(await (hooks.java ? hooks.java() : checkJava(context, userJava, javaError)));
   all.push(await (hooks.cache ? hooks.cache() : checkCache()));
 
   const registryProject = context.current?.project ?? context.root;
@@ -81,6 +92,9 @@ export async function runDoctorCommand(
   all.push(...descResults);
 
   all.push(await (hooks.outdated ? hooks.outdated() : checkOutdated(context)));
+  all.push(
+    await (hooks.dependencyJars ? hooks.dependencyJars() : checkDependencyJars(context, userJava)),
+  );
 
   const hardFailures = all.filter((c) => c.status === "fail");
   const ok = hardFailures.length === 0;
@@ -115,49 +129,69 @@ export async function runDoctorCommand(
 }
 
 /**
- * Probe `java -version`, parsing the major version from its output. Warns
- * when the toolchain is outside the 8-21 window required by BuildTools-based
- * platforms (spigot, bukkit).
+ * Spawn `java -version` and return the parsed major version number.
+ * Returns `undefined` if the version string cannot be parsed.
+ * Throws if Java is not installed or the process fails.
  */
-export async function checkJava(context: WorkspaceContext): Promise<CheckResult> {
-  const target = context.current?.project ?? context.root;
-  const primaryPlatform = target.compatibility?.platforms?.[0];
+export async function getJavaMajor(): Promise<number | undefined> {
+  const out = await runJavaVersion();
+  const combined = `${out.stdout}\n${out.stderr}`;
+  const match =
+    combined.match(/version "(\d+)(?:\.(\d+))?[^"]*"/) ??
+    combined.match(/version (\d+)(?:\.(\d+))?/);
+  if (!match) return undefined;
+  return Number.parseInt(match[1] === "1" && match[2] !== undefined ? match[2] : match[1], 10);
+}
 
-  try {
-    const out = await runJavaVersion();
-    // `java -version` writes to stderr on most JDKs.
-    const combined = `${out.stdout}\n${out.stderr}`;
-    const match =
-      combined.match(/version "(\d+)(?:\.(\d+))?[^"]*"/) ??
-      combined.match(/version (\d+)(?:\.(\d+))?/);
-    const major = match
-      ? Number.parseInt(match[1] === "1" && match[2] !== undefined ? match[2] : match[1], 10)
-      : undefined;
-    const detail = major === undefined ? combined.split("\n")[0] : `Java ${major}`;
-
-    if (
-      primaryPlatform !== undefined &&
-      (primaryPlatform === "spigot" || primaryPlatform === "bukkit") &&
-      major !== undefined &&
-      (major < 8 || major > 21)
-    ) {
-      return {
-        id: "java",
-        label: "Java toolchain",
-        status: "warn",
-        detail: `${detail} — spigot/bukkit BuildTools needs Java 8-21`,
-      };
-    }
-    return { id: "java", label: "Java toolchain", status: "pass", detail };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+/**
+ * Check the Java toolchain version. For spigot/bukkit projects, reads the
+ * minimum required Java version from the cached `BuildTools.jar` manifest
+ * so the check stays accurate as BuildTools is updated.
+ *
+ * Accepts pre-resolved `userJava` / `javaError` from `runDoctorCommand` to
+ * avoid spawning `java -version` more than once per doctor run.
+ */
+export async function checkJava(
+  context: WorkspaceContext,
+  userJava?: number,
+  javaError?: string,
+): Promise<CheckResult> {
+  if (javaError !== undefined) {
     return {
       id: "java",
       label: "Java toolchain",
       status: "fail",
-      detail: `java not found or failed to run: ${message}`,
+      detail: `java not found or failed to run: ${javaError}`,
     };
   }
+  if (userJava === undefined) {
+    return {
+      id: "java",
+      label: "Java toolchain",
+      status: "fail",
+      detail: "java not found or could not parse version",
+    };
+  }
+
+  const detail = `Java ${userJava}`;
+  const target = context.current?.project ?? context.root;
+  const primaryPlatform = target.compatibility?.platforms?.[0];
+
+  if (primaryPlatform === "spigot" || primaryPlatform === "bukkit") {
+    const buildToolsPath = join(getCachePath(), "BuildTools.jar");
+    const jdkSpec = await readManifestAttribute(buildToolsPath, "Build-Jdk-Spec");
+    const minJava = jdkSpec !== undefined ? Number.parseInt(jdkSpec, 10) : 8;
+    if (!Number.isNaN(minJava) && userJava < minJava) {
+      return {
+        id: "java",
+        label: "Java toolchain",
+        status: "warn",
+        detail: `${detail} — BuildTools requires Java ${minJava}+`,
+      };
+    }
+  }
+
+  return { id: "java", label: "Java toolchain", status: "pass", detail };
 }
 
 async function runJavaVersion(): Promise<{ stdout: string; stderr: string }> {
@@ -307,7 +341,7 @@ async function checkOneRegistry(url: string): Promise<CheckResult> {
   }
 }
 
-const NAME_RE = /^[a-zA-Z0-9_]+$/;
+const NAME_RE = /^[a-zA-Z0-9_-]+$/;
 const VERSION_RE = /^\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?$/;
 
 /**
@@ -483,6 +517,116 @@ export async function checkOutdated(context: WorkspaceContext): Promise<CheckRes
     label: "Outdated dependencies",
     status: "warn",
     detail: outdated.join("; "),
+  };
+}
+
+/**
+ * For every cached dependency JAR in the lockfile, read its class-file
+ * bytecode version and warn if any require a higher Java release than the
+ * active toolchain provides.
+ */
+export async function checkDependencyJars(
+  context: WorkspaceContext,
+  userJava?: number,
+): Promise<CheckResult> {
+  const lock = readLock(context.root.rootDir);
+  if (lock === null || Object.keys(lock.entries).length === 0) {
+    return {
+      id: "dep-jars",
+      label: "Dependency compatibility",
+      status: "pass",
+      detail: "no dependencies locked",
+    };
+  }
+
+  if (userJava === undefined) {
+    return {
+      id: "dep-jars",
+      label: "Dependency compatibility",
+      status: "pass",
+      detail: "java not available, skipped",
+    };
+  }
+
+  type FlatEntry = { name: string; entry: LockfileEntry | TransitiveEntry };
+  const flat: FlatEntry[] = [];
+
+  function collect(name: string, entry: LockfileEntry | TransitiveEntry): void {
+    flat.push({ name, entry });
+    for (const t of entry.transitives ?? []) {
+      const tName =
+        t.source.kind === "maven"
+          ? `${t.source.groupId}:${t.source.artifactId}`
+          : t.source.kind === "modrinth"
+            ? t.source.slug
+            : "unknown";
+      collect(tName, t);
+    }
+  }
+  for (const [name, entry] of Object.entries(lock.entries)) collect(name, entry);
+
+  function jarPath(e: FlatEntry): string | undefined {
+    const { source, resolvedVersion } = e.entry;
+    if (source.kind === "modrinth") {
+      return join(
+        getCachePath(),
+        "dependencies",
+        "modrinth",
+        source.slug,
+        `${resolvedVersion}.jar`,
+      );
+    }
+    if (source.kind === "maven") {
+      return join(
+        getCachePath(),
+        "dependencies",
+        "maven",
+        source.groupId,
+        source.artifactId,
+        `${resolvedVersion}.jar`,
+      );
+    }
+    return undefined;
+  }
+
+  const tooNew: string[] = [];
+  let checked = 0;
+
+  await Promise.all(
+    flat.map(async (e) => {
+      const path = jarPath(e);
+      if (!path || !existsSync(path)) return;
+      const classMajor = await readJarClassMajor(path);
+      if (classMajor === undefined) return;
+      checked++;
+      const required = classMajorToJava(classMajor);
+      if (required > userJava!) tooNew.push(`${e.name} requires Java ${required}`);
+    }),
+  );
+
+  if (checked === 0) {
+    return {
+      id: "dep-jars",
+      label: "Dependency compatibility",
+      status: "pass",
+      detail: "no cached jars to inspect",
+    };
+  }
+
+  if (tooNew.length > 0) {
+    return {
+      id: "dep-jars",
+      label: "Dependency compatibility",
+      status: "warn",
+      detail: tooNew.join("; "),
+    };
+  }
+
+  return {
+    id: "dep-jars",
+    label: "Dependency compatibility",
+    status: "pass",
+    detail: `${checked} jar${checked === 1 ? "" : "s"} compatible with Java ${userJava}`,
   };
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,15 +1,16 @@
 import { readdir } from "node:fs/promises";
 import { mkdir, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import process from "node:process";
 
 import { Command, InvalidArgumentError } from "commander";
-import { confirm } from "@inquirer/prompts";
+import { checkbox, confirm, input } from "@inquirer/prompts";
 
 import defaultConfig from "../defaults/config.yml" with { type: "text" };
 import defaultPackage from "../defaults/package.java" with { type: "text" };
 
 import { getPlatform, getRegisteredPlatforms } from "../platform/index.ts";
+import { bold, dim, log } from "../logging.ts";
 import { getCurrentProject, type Project, resolveProjectFile } from "../project.ts";
 import { replace } from "../template.ts";
 
@@ -65,6 +66,13 @@ export async function generateProject(distDir: string, project: Project): Promis
   }
 }
 
+function deriveClassName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((part) => (part ? part.charAt(0).toUpperCase() + part.slice(1) : ""))
+    .join("");
+}
+
 /** Factory for the `pluggy init` commander command. */
 export function initCommand(): Command {
   return new Command("init")
@@ -75,15 +83,24 @@ export function initCommand(): Command {
     .option("--name <name>", "Project name.")
     .option("--version <version>", "Project version.", parseSemver)
     .option("--description <description>", "Project description.")
-    .option("--main <main>", "Main class name.", "com.example.Main")
-    .option("--platform <platform>", "Target platform.", parsePlatform, "paper")
+    .option("--main <main>", "Main class name.")
+    .option(
+      "--platform <platform>",
+      "Target platform, repeatable (default: paper).",
+      (val: string, prev: string[]) => {
+        const id = parsePlatform(val);
+        return prev.includes(id) ? prev : [...prev, id];
+      },
+      [] as string[],
+    )
     .option("-y, --yes", "Skip prompts and use defaults.")
     .addHelpText(
       "after",
-      `\nExamples:\n  $ pluggy init --platform spigot --version 1.21.8\n  $ pluggy init --platform paper --version 1.21.8`,
+      `\nExamples:\n  $ pluggy init --platform paper --platform velocity\n  $ pluggy init --platform spigot --version 1.21.8`,
     )
     .action(async function action(this: Command, path: string | undefined, options) {
       const globalOpts = this.optsWithGlobals();
+      const interactive = !options.yes && !globalOpts.json && process.stdout.isTTY;
 
       let currentProject = getCurrentProject();
       if (globalOpts.project) {
@@ -93,72 +110,97 @@ export function initCommand(): Command {
 
       const TARGET_PATH = resolve(process.cwd(), path || ".");
 
+      // Single guard for non-empty dir or existing project
+      let warned = false;
       try {
         const entries = await readdir(TARGET_PATH);
-        if (entries.length > 0 && !options.yes) {
-          const ok = await confirm({
-            message: `The directory "${TARGET_PATH}" is not empty. Do you want to continue and potentially overwrite its contents?`,
-            default: false,
-          });
-          if (!ok) {
-            console.log("Aborting project initialization.");
-            return;
-          }
-        }
+        if (entries.length > 0) warned = true;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
       }
+      if (!warned && currentProject) warned = true;
 
-      if (currentProject && !options.yes) {
-        const same = dirname(currentProject.projectFile) === TARGET_PATH;
-        const ok = await confirm({
-          message: `You are in an existing project at "${relative(process.cwd(), currentProject.projectFile)}". ${
-            same ? "Do you want to overwrite it?" : "Do you want to create a new project inside?"
-          }`,
-          default: false,
-        });
+      if (warned && globalOpts.json && !options.yes) {
+        const reason = currentProject
+          ? `"${relative(process.cwd(), currentProject.projectFile)}" already exists`
+          : `"${TARGET_PATH}" is not empty`;
+        throw new Error(`${reason}. Use --yes to overwrite.`);
+      }
+
+      if (warned && interactive) {
+        const message = currentProject
+          ? `"${relative(process.cwd(), currentProject.projectFile)}" already exists. Overwrite?`
+          : `"${TARGET_PATH}" is not empty. Continue?`;
+        const ok = await confirm({ message, default: false });
         if (!ok) {
-          console.log("Aborting project initialization.");
+          log.info("Aborted.");
           return;
         }
       }
 
-      const platform = options.platform || "paper";
+      // Name
+      const defaultName = basename(TARGET_PATH);
+      const projectName =
+        options.name ??
+        (path
+          ? basename(TARGET_PATH)
+          : interactive
+            ? await input({ message: "Project name", default: defaultName })
+            : defaultName);
 
-      if (!getRegisteredPlatforms().includes(platform)) {
+      if (!/^[a-zA-Z0-9_-]+$/.test(projectName)) {
         throw new InvalidArgumentError(
-          `Invalid platform: "${platform}". Available platforms: ${getRegisteredPlatforms().join(", ")}`,
+          `Invalid project name: "${projectName}". Only alphanumeric characters, underscores, and hyphens are allowed.`,
         );
       }
 
-      const latestVersion = await getPlatform(platform).getLatestVersion();
+      // Platforms
+      const registeredPlatforms = getRegisteredPlatforms();
+      const platforms: string[] =
+        options.platform.length > 0
+          ? options.platform
+          : interactive
+            ? await checkbox({
+                message: "Target platforms",
+                choices: registeredPlatforms.map((p) => ({
+                  value: p,
+                  name: p,
+                  checked: p === "paper",
+                })),
+                validate: (vals) => vals.length > 0 || "Select at least one platform.",
+              })
+            : ["paper"];
+
+      // Main class
+      const className = deriveClassName(projectName) || "Main";
+      const derivedMain = `com.example.${className}`;
+      const projectMain =
+        options.main ??
+        (interactive ? await input({ message: "Main class", default: derivedMain }) : derivedMain);
+
+      if (!projectMain || !/^[a-zA-Z0-9_.]+$/.test(projectMain) || !projectMain.includes(".")) {
+        throw new InvalidArgumentError(
+          `Invalid main class: "${projectMain}". It must be a valid Java classpath (e.g., com.example.Main).`,
+        );
+      }
+
+      // Fetch latest version for each selected platform in parallel
+      if (!globalOpts.json) log.info(`Fetching latest versions…`);
+      const versionResults = await Promise.all(
+        platforms.map((p) => getPlatform(p).getLatestVersion()),
+      );
+      const versions = [...new Set(versionResults.map((v) => v.version))];
 
       const INITIAL_PROJECT: Project = {
-        name: options.name || basename(TARGET_PATH),
+        name: projectName,
         version: options.version || "1.0.0",
         description: options.description || "A simple Minecraft plugin",
-        main: options.main || "com.example.Main",
+        main: projectMain,
         compatibility: {
-          versions: [latestVersion.version],
-          platforms: [platform],
+          versions,
+          platforms,
         },
       };
-
-      if (!/^[a-zA-Z0-9_]+$/.test(INITIAL_PROJECT.name)) {
-        throw new InvalidArgumentError(
-          `Invalid project name: "${INITIAL_PROJECT.name}". Only alphanumeric characters and underscores are allowed.`,
-        );
-      }
-
-      if (
-        !INITIAL_PROJECT.main ||
-        !/^[a-zA-Z0-9_.]+$/.test(INITIAL_PROJECT.main) ||
-        !INITIAL_PROJECT.main.includes(".")
-      ) {
-        throw new InvalidArgumentError(
-          `Invalid main class: "${INITIAL_PROJECT.main}". It must be a valid Java classpath (e.g., com.example.Main).`,
-        );
-      }
 
       await generateProject(TARGET_PATH, INITIAL_PROJECT);
 
@@ -173,6 +215,12 @@ export function initCommand(): Command {
         return;
       }
 
-      console.log(`Project "${INITIAL_PROJECT.name}" initialized successfully at ${TARGET_PATH}`);
+      log.success(`Project ${bold(`"${INITIAL_PROJECT.name}"`)} initialized`);
+
+      const isCurrentDir = TARGET_PATH === resolve(process.cwd());
+      console.log();
+      console.log(dim("  Next steps:"));
+      if (!isCurrentDir) console.log(dim(`    cd ${relative(process.cwd(), TARGET_PATH)}`));
+      console.log(dim("    pluggy dev"));
     });
 }

--- a/src/jar.test.ts
+++ b/src/jar.test.ts
@@ -1,0 +1,128 @@
+/** Tests for src/jar.ts. Fixture JARs are built with yazl in-process. */
+
+import { createWriteStream } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import yazl from "yazl";
+
+import { afterEach, beforeEach, describe, expect, test } from "vite-plus/test";
+
+import { classMajorToJava, readJarClassMajor, readManifestAttribute } from "./jar.ts";
+
+async function makeJar(path: string, entries: Record<string, Buffer | string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const zip = new yazl.ZipFile();
+    const ws = createWriteStream(path);
+    ws.once("error", reject);
+    ws.once("close", resolve);
+    zip.outputStream.pipe(ws);
+    for (const [name, content] of Object.entries(entries)) {
+      const buf = typeof content === "string" ? Buffer.from(content, "utf8") : content;
+      zip.addBuffer(buf, name);
+    }
+    zip.end();
+  });
+}
+
+/** Build a minimal class-file buffer with the given major version. */
+function classBytes(major: number): Buffer {
+  // magic (4) + minor (2) + major (2) — rest omitted, jar.ts only reads first 8 bytes
+  const buf = Buffer.alloc(8);
+  buf.writeUInt32BE(0xcafebabe, 0);
+  buf.writeUInt16BE(0, 4); // minor
+  buf.writeUInt16BE(major, 6);
+  return buf;
+}
+
+describe("classMajorToJava", () => {
+  test("maps well-known major versions to Java releases", () => {
+    expect(classMajorToJava(52)).toBe(8);
+    expect(classMajorToJava(61)).toBe(17);
+    expect(classMajorToJava(65)).toBe(21);
+    expect(classMajorToJava(69)).toBe(25);
+  });
+});
+
+describe("readManifestAttribute", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pluggy-jar-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("returns the attribute value from MANIFEST.MF", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, {
+      "META-INF/MANIFEST.MF": "Manifest-Version: 1.0\nBuild-Jdk-Spec: 21\nCreated-By: Maven\n",
+    });
+    expect(await readManifestAttribute(jarPath, "Build-Jdk-Spec")).toBe("21");
+  });
+
+  test("returns undefined when attribute is absent", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, {
+      "META-INF/MANIFEST.MF": "Manifest-Version: 1.0\n",
+    });
+    expect(await readManifestAttribute(jarPath, "Build-Jdk-Spec")).toBeUndefined();
+  });
+
+  test("returns undefined when MANIFEST.MF is absent", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, { "com/example/Main.class": classBytes(65) });
+    expect(await readManifestAttribute(jarPath, "Build-Jdk-Spec")).toBeUndefined();
+  });
+
+  test("returns undefined for a missing file", async () => {
+    expect(await readManifestAttribute(join(dir, "missing.jar"), "Build-Jdk-Spec")).toBeUndefined();
+  });
+});
+
+describe("readJarClassMajor", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pluggy-jar-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("reads major version from first .class file", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, { "com/example/Main.class": classBytes(65) });
+    expect(await readJarClassMajor(jarPath)).toBe(65);
+  });
+
+  test("skips module-info.class, reads a regular class", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, {
+      "module-info.class": classBytes(65),
+      "com/example/Main.class": classBytes(61),
+    });
+    expect(await readJarClassMajor(jarPath)).toBe(61);
+  });
+
+  test("returns undefined when JAR has no .class files", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, { "META-INF/MANIFEST.MF": "Manifest-Version: 1.0\n" });
+    expect(await readJarClassMajor(jarPath)).toBeUndefined();
+  });
+
+  test("returns undefined for a missing file", async () => {
+    expect(await readJarClassMajor(join(dir, "missing.jar"))).toBeUndefined();
+  });
+
+  test("round-trips through classMajorToJava correctly", async () => {
+    const jarPath = join(dir, "test.jar");
+    await makeJar(jarPath, { "A.class": classBytes(61) }); // Java 17
+    const major = await readJarClassMajor(jarPath);
+    expect(classMajorToJava(major!)).toBe(17);
+  });
+});

--- a/src/jar.ts
+++ b/src/jar.ts
@@ -1,0 +1,117 @@
+/**
+ * Utilities for reading metadata out of JAR/ZIP files without fully
+ * extracting them. Used by `doctor` to inspect BuildTools and cached
+ * dependency jars.
+ */
+
+import { existsSync } from "node:fs";
+
+import yauzl, { type Entry, type ZipFile } from "yauzl";
+
+function openZip(jarPath: string): Promise<ZipFile | undefined> {
+  return new Promise((resolve) => {
+    yauzl.open(jarPath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+      resolve(err || !zip ? undefined : zip);
+    });
+  });
+}
+
+function readEntry(zip: ZipFile, entry: Entry): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (err, stream) => {
+      if (err || !stream) {
+        reject(err ?? new Error("no stream"));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream.once("end", () => resolve(Buffer.concat(chunks)));
+      stream.once("error", reject);
+    });
+  });
+}
+
+/**
+ * Read a single attribute from a JAR's `META-INF/MANIFEST.MF`.
+ * Returns `undefined` if the JAR is missing, the manifest is absent,
+ * or the attribute is not present.
+ */
+export async function readManifestAttribute(
+  jarPath: string,
+  attribute: string,
+): Promise<string | undefined> {
+  if (!existsSync(jarPath)) return undefined;
+  const zip = await openZip(jarPath);
+  if (!zip) return undefined;
+
+  return new Promise((resolve) => {
+    zip.readEntry();
+    zip.on("entry", async (entry: Entry) => {
+      if (entry.fileName !== "META-INF/MANIFEST.MF") {
+        zip.readEntry();
+        return;
+      }
+      try {
+        const bytes = await readEntry(zip, entry);
+        const text = bytes.toString("utf8");
+        const match = text.match(new RegExp(`^${attribute}:\\s*(.+)`, "m"));
+        resolve(match ? match[1].trim() : undefined);
+      } catch {
+        resolve(undefined);
+      } finally {
+        zip.close();
+      }
+    });
+    zip.on("end", () => {
+      zip.close();
+      resolve(undefined);
+    });
+    zip.on("error", () => {
+      zip.close();
+      resolve(undefined);
+    });
+  });
+}
+
+/**
+ * Read the class-file major version from the first `.class` entry in a JAR.
+ * Returns `undefined` if the JAR can't be read or contains no class files.
+ *
+ * Convert to a Java release with `classMajorToJava` (Java N = major 44+N).
+ */
+export async function readJarClassMajor(jarPath: string): Promise<number | undefined> {
+  if (!existsSync(jarPath)) return undefined;
+  const zip = await openZip(jarPath);
+  if (!zip) return undefined;
+
+  return new Promise((resolve) => {
+    zip.readEntry();
+    zip.on("entry", async (entry: Entry) => {
+      if (!entry.fileName.endsWith(".class") || entry.fileName.includes("module-info")) {
+        zip.readEntry();
+        return;
+      }
+      try {
+        const bytes = await readEntry(zip, entry);
+        resolve(bytes.length >= 8 ? bytes.readUInt16BE(6) : undefined);
+      } catch {
+        resolve(undefined);
+      } finally {
+        zip.close();
+      }
+    });
+    zip.on("end", () => {
+      zip.close();
+      resolve(undefined);
+    });
+    zip.on("error", () => {
+      zip.close();
+      resolve(undefined);
+    });
+  });
+}
+
+/** Convert a class-file major version to its Java release number (Java N = major 44+N). */
+export function classMajorToJava(major: number): number {
+  return major - 44;
+}


### PR DESCRIPTION
## Summary

- **doctor** gains a `checkDependencyJars` step that reads class-file major versions out of every cached dependency JAR and warns when any require a higher Java release than the active toolchain; the Spigot/Bukkit Java floor is now read dynamically from the cached `BuildTools.jar` manifest.
- **build** now javac-tests every non-primary platform declared in `project.json` against its API JAR via a new `checkPlatformCompile`, so cross-platform source incompatibilities surface automatically after each build.
- **init** supports repeatable `--platform`, derives the main class from the project name, fetches platform versions in parallel, and the overwrite guard now throws under `--json` instead of silently proceeding.
- New `src/jar.ts` utility reads JAR manifest attributes and class-file major versions without full extraction.

## Test plan

- [ ] `vp check`
- [ ] `vp test`
- [ ] `bun build --compile --outfile=bin/pluggy ./src/index.ts` still produces a working binary
- [ ] `pluggy init --platform paper --platform velocity` scaffolds a multi-platform project
- [ ] `pluggy build` on a paper+spigot project reports per-platform compile results
- [ ] `pluggy doctor` surfaces the new dependency-compatibility check