### PR TITLE
fix(init): resolve MC version across platforms and add IDE prompt

### DIFF
--- a/src/build/ide.ts
+++ b/src/build/ide.ts
@@ -26,19 +26,21 @@ export async function writeIdeFiles(
   classpath: string[],
   stagingOutputDir: string,
 ): Promise<void> {
-  const ide = project.ide;
-  if (ide === undefined) return;
+  const ides = project.ide;
+  if (ides === undefined || ides.length === 0) return;
 
-  switch (ide) {
-    case "vscode":
-      await writeVscodeSettings(project, classpath);
-      return;
-    case "eclipse":
-      await writeEclipseFiles(project, classpath, stagingOutputDir);
-      return;
-    case "intellij":
-      await writeIntellijFiles(project, classpath);
-      return;
+  for (const ide of ides) {
+    switch (ide) {
+      case "vscode":
+        await writeVscodeSettings(project, classpath);
+        break;
+      case "eclipse":
+        await writeEclipseFiles(project, classpath, stagingOutputDir);
+        break;
+      case "intellij":
+        await writeIntellijFiles(project, classpath);
+        break;
+    }
   }
 }
 
@@ -242,9 +244,9 @@ function jdkMajorForMcVersion(version: string): number {
   const m = version.match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
   if (m === null) return 21;
   const major = Number(m[1]);
+  if (major >= 2) return 21;
   const minor = Number(m[2]);
   const patch = m[3] !== undefined ? Number(m[3]) : 0;
-  if (major !== 1) return 21; // Future-proof: unknown majors → newest known.
   if (minor >= 21) return 21;
   if (minor === 20 && patch >= 5) return 21;
   if (minor >= 18) return 17;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,7 +10,7 @@ import { pickDescriptor } from "../build/descriptor.ts";
 import { classMajorToJava, readJarClassMajor, readManifestAttribute } from "../jar.ts";
 import { type LockfileEntry, type TransitiveEntry, readLock } from "../lockfile.ts";
 import { bold, green, log, red, yellow } from "../logging.ts";
-import { getRegisteredPlatforms } from "../platform/index.ts";
+import { getPlatform, getRegisteredPlatforms } from "../platform/index.ts";
 import { getCachePath, type ResolvedProject } from "../project.ts";
 import { getLatestModrinthVersion } from "../resolver/modrinth.ts";
 import { resolveWorkspaceContext, topologicalOrder, type WorkspaceContext } from "../workspace.ts";
@@ -35,6 +35,7 @@ export interface DoctorCommandOptions {
     project?: (project: ResolvedProject) => CheckResult;
     workspace?: (ctx: WorkspaceContext) => CheckResult;
     descriptor?: (ctx: WorkspaceContext) => CheckResult[];
+    versions?: (project: ResolvedProject) => Promise<CheckResult[]>;
     outdated?: () => Promise<CheckResult>;
     dependencyJars?: () => Promise<CheckResult>;
   };
@@ -84,6 +85,13 @@ export async function runDoctorCommand(
   const toValidate = projectsForValidation(context);
   for (const project of toValidate) {
     all.push(hooks.project ? hooks.project(project) : checkProjectValid(project));
+  }
+
+  for (const project of toValidate) {
+    const verResults = await (hooks.versions
+      ? hooks.versions(project)
+      : checkVersionCompatibility(project));
+    all.push(...verResults);
   }
 
   all.push(hooks.workspace ? hooks.workspace(context) : checkWorkspaceGraph(context));
@@ -398,6 +406,50 @@ export function checkProjectValid(project: ResolvedProject): CheckResult {
     status: "pass",
     detail: `name=${project.name}, version=${project.version}`,
   };
+}
+
+/**
+ * Verify that every declared version in `compatibility.versions` is actually
+ * available on every declared platform. Catches mismatches like Paper 26.x
+ * being listed for Spigot (which hasn't published that version).
+ */
+export async function checkVersionCompatibility(project: ResolvedProject): Promise<CheckResult[]> {
+  const { versions, platforms } = project.compatibility ?? {};
+  if (!versions?.length || !platforms?.length) return [];
+
+  const out: CheckResult[] = [];
+  for (const platform of platforms) {
+    let available: string[];
+    try {
+      available = await getPlatform(platform).getVersions();
+    } catch {
+      out.push({
+        id: "version-compat",
+        label: `Version compatibility (${platform})`,
+        status: "warn",
+        detail: `could not fetch version list for ${platform}`,
+      });
+      continue;
+    }
+    const set = new Set(available);
+    const missing = versions.filter((v) => !set.has(v));
+    if (missing.length > 0) {
+      out.push({
+        id: "version-compat",
+        label: `Version compatibility (${platform})`,
+        status: "fail",
+        detail: `${platform} does not publish version${missing.length > 1 ? "s" : ""} ${missing.join(", ")}`,
+      });
+    } else {
+      out.push({
+        id: "version-compat",
+        label: `Version compatibility (${platform})`,
+        status: "pass",
+        detail: `${versions.join(", ")}`,
+      });
+    }
+  }
+  return out;
 }
 
 /** Run topological order over workspaces; fails on cycles. */

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,7 +14,7 @@ import { bold, dim, log } from "../logging.ts";
 import { getCurrentProject, type Project, resolveProjectFile } from "../project.ts";
 import { replace } from "../template.ts";
 
-import { parsePlatform, parseSemver } from "./parsers.ts";
+import { parseMcVersion, parsePlatform, parseSemver } from "./parsers.ts";
 
 /**
  * Scaffold a new project at `distDir` from the given `Project` config.
@@ -93,10 +93,11 @@ export function initCommand(): Command {
       },
       [] as string[],
     )
+    .option("--mc-version <version>", "Minecraft version for compatibility.", parseMcVersion)
     .option("-y, --yes", "Skip prompts and use defaults.")
     .addHelpText(
       "after",
-      `\nExamples:\n  $ pluggy init --platform paper --platform velocity\n  $ pluggy init --platform spigot --version 1.21.8`,
+      `\nExamples:\n  $ pluggy init --platform paper --platform velocity\n  $ pluggy init --platform spigot --mc-version 1.21.8`,
     )
     .action(async function action(this: Command, path: string | undefined, options) {
       const globalOpts = this.optsWithGlobals();
@@ -184,18 +185,52 @@ export function initCommand(): Command {
         );
       }
 
-      // Fetch latest version for each selected platform in parallel
-      if (!globalOpts.json) log.info(`Fetching latest versions…`);
-      const versionResults = await Promise.all(
-        platforms.map((p) => getPlatform(p).getLatestVersion()),
-      );
-      const versions = [...new Set(versionResults.map((v) => v.version))];
+      // IDE
+      const IDE_CHOICES: { value: "vscode" | "eclipse" | "intellij"; name: string }[] = [
+        { value: "vscode", name: "VS Code" },
+        { value: "intellij", name: "IntelliJ IDEA" },
+        { value: "eclipse", name: "Eclipse" },
+      ];
+      const ide: ("vscode" | "eclipse" | "intellij")[] | undefined = interactive
+        ? await checkbox({
+            message: "IDE integration",
+            choices: IDE_CHOICES,
+          })
+        : undefined;
+
+      // Resolve the Minecraft version for compatibility
+      let versions: string[];
+      if (options.mcVersion) {
+        versions = [options.mcVersion];
+      } else {
+        if (!globalOpts.json) log.info(`Fetching latest versions…`);
+        const versionLists = await Promise.all(
+          platforms.map(async (p) => ({
+            platform: p,
+            versions: await getPlatform(p).getVersions(),
+          })),
+        );
+        const common =
+          versionLists.reduce<string[] | null>((acc, { versions: vs }) => {
+            if (acc === null) return vs;
+            const set = new Set(vs);
+            return acc.filter((v) => set.has(v));
+          }, null) ?? [];
+        if (common.length === 0) {
+          throw new Error(
+            `No compatible Minecraft version found across platforms: ${platforms.join(", ")}. ` +
+              `Try selecting fewer platforms or specifying a version manually with --mc-version.`,
+          );
+        }
+        versions = [common[0]];
+      }
 
       const INITIAL_PROJECT: Project = {
         name: projectName,
         version: options.version || "1.0.0",
         description: options.description || "A simple Minecraft plugin",
         main: projectMain,
+        ...(ide && ide.length > 0 ? { ide } : {}),
         compatibility: {
           versions,
           platforms,

--- a/src/commands/parsers.ts
+++ b/src/commands/parsers.ts
@@ -41,6 +41,13 @@ export function parsePlatform(value: string): string {
   return id;
 }
 
+export function parseMcVersion(value: string): string {
+  if (/^\d+\.\d+(\.\d+)?$/.test(value)) return value;
+  throw new InvalidArgumentError(
+    `Invalid Minecraft version: ${value} — expected format like 1.21.8 or 26.1.2`,
+  );
+}
+
 export function parseInteger(value: string): number {
   const parsed = Number.parseInt(value, 10);
   if (Number.isNaN(parsed)) throw new InvalidArgumentError(`Invalid integer: ${value}`);

--- a/src/project.ts
+++ b/src/project.ts
@@ -11,7 +11,7 @@ export interface Project {
   authors?: string[];
   /** Fully-qualified main class. Required for plugin workspaces; not on a root that declares `workspaces`. */
   main?: string;
-  ide?: "vscode" | "eclipse" | "intellij";
+  ide?: ("vscode" | "eclipse" | "intellij")[];
   compatibility: {
     versions: string[];
     platforms: string[];


### PR DESCRIPTION
## Summary

- **Version resolution bug**: `pluggy init` was taking each platform's latest version independently, which produced versions like `26.1.2` that Paper publishes but Spigot does not — causing `pluggy dev` to fail with a BuildTools error. Now intersects version lists across all selected platforms to pick the latest common version.
- **IDE prompt**: `pluggy init` now asks which IDEs to set up (VS Code, IntelliJ, Eclipse), and `ide` is an array so teams with mixed editors get all their project files generated on every build.
- **`--mc-version` flag**: New flag on `pluggy init` to explicitly set the Minecraft version for `compatibility.versions`, since the existing `--version` flag controls the plugin's own semver.
- **Doctor check**: `pluggy doctor` now verifies that every version in `compatibility.versions` actually exists on every declared platform, so mismatches are caught before a build or dev run fails.

## Test plan

- [x] `vp check` passes
- [x] All 318 tests pass