### PR TITLE
ci: add cross-platform check and binary build pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.jar binary
+*.zip binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check & Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Format, lint, and type check
+        run: vp check
+
+      - name: Run tests
+        run: vp test
+
+  build:
+    name: Build binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Compile CLI binary
+        run: |
+          mkdir -p bin
+          bun build --compile --outfile=bin/pluggy ./src/index.ts
+
+      - name: Smoke test binary
+        run: ./bin/pluggy --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
         with:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `vp check` and `vp test` across ubuntu, macos, and windows on PRs to main, pushes to main, and manual dispatch.
- Adds a linux `build` job that compiles the Bun single-file binary via `bun build --compile` and smoke-tests `./bin/pluggy --version`.
- Minimal `contents: read` permissions and a per-workflow concurrency group that cancels in-flight PR runs on new pushes.

## Test plan
- [ ] First run on this PR passes the three-OS matrix and the build job.