### PR TITLE
docs: sync docs with recent CLI and platform changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ For the full walkthrough, read
   ordering, and `workspace:` source kind for sibling deps.
 - **Cross-platform.** macOS, Linux, Windows — identical behaviour, same
   native binary format (arm64 + amd64 where available).
-- **IDE integration.** VS Code, Eclipse, IntelliJ. Set `"ide": "..."` in
-  `project.json` and builds scaffold the right project files.
+- **IDE integration.** VS Code, Eclipse, IntelliJ. Set `"ide": [...]` in
+  `project.json` (or pick them at `init` time) and builds scaffold the
+  right project files for every listed editor.
 - **Reproducible.** Every resolved dep carries a SHA-256 integrity
   hash. `pluggy.lock` is sorted, LF-terminated, atomic-written.
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -65,6 +65,14 @@ For each target workspace:
    dir. `exclude` is subtracted after.
 9. **Zip.** Walk the staging dir, sort entries lexicographically, write
    a zip with forward-slashed entry paths.
+10. **Platform compile-check.** For every non-primary platform declared
+    in `compatibility.platforms` (i.e. `platforms[1..]`), pluggy runs
+    `checkPlatformCompile` — a javac invocation against that platform's
+    API jar with no artifacts emitted. The primary platform was already
+    compiled in step 7, so this exists solely to catch cases where your
+    source is Paper-clean but references a symbol missing on Spigot,
+    Folia, or a Bungee-family platform. A failing check logs a `warn` and
+    flips `exitCode` to `1`, but the primary jar still ships.
 
 The output jar is written to `<output>` after the staging dir is zipped.
 
@@ -104,11 +112,20 @@ On success:
       "ok": true,
       "outputPath": "/repo/bin/my_plugin-1.0.0.jar",
       "sizeBytes": 145840,
-      "durationMs": 3821
+      "durationMs": 3821,
+      "platformChecks": [
+        { "platform": "spigot", "ok": true, "durationMs": 612 }
+      ]
     }
   ]
 }
 ```
+
+`platformChecks` is omitted when `compatibility.platforms` has a single
+entry (nothing to cross-check). Each entry reports `{ platform, ok,
+durationMs }`, plus `error` when `ok` is `false`. A failed entry sets
+`status: "error"` and exits `1` even though the primary jar was still
+produced.
 
 On partial failure (multi-workspace, at least one workspace failed):
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -46,7 +46,9 @@ pluggy dev [options]
      merged with `project.dev.serverProperties`.
 6. Populates `dev/plugins/` with the plugin jar, runtime plugin deps,
    and `project.dev.extraPlugins`. Each entry is hardlinked by basename.
-7. Spawns `java -Xmx<mem> <jvmArgs> -jar server.jar` inside `dev/`.
+7. Spawns `java -Xmx<mem> <jvmArgs> -jar server.jar nogui` inside `dev/`.
+   The trailing `nogui` suppresses Bukkit's AWT console window on desktop
+   JVMs so dev sessions stay headless.
 
 ## The `dev/` layout
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -19,7 +19,7 @@ the exit code.
 
 | id                    | label                   | fail trigger                                                       | warn trigger                                                                                                         |
 | --------------------- | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `java`                | Java toolchain          | `java -version` fails (not on PATH, or non-zero exit).             | Detected JDK outside Java 8 – 21 **and** primary platform is `spigot` or `bukkit` (BuildTools requires that window). |
+| `java`                | Java toolchain          | `java -version` fails (not on PATH, or non-zero exit).             | Primary platform is `spigot` or `bukkit` **and** the detected JDK is older than the Java floor declared by the cached `BuildTools.jar`. |
 | `cache`               | Cache reachability      | Path exists but isn't a directory; probe write fails.              | Directory doesn't exist yet (will be created on first use).                                                          |
 | `registry <url>`      | Registry                | —                                                                  | `HEAD` returns a 5xx or the request errors. 2xx / 3xx / 4xx count as reachable.                                      |
 | `project (<name>)`    | Validate `project.json` | `name`, `version`, or `compatibility` malformed; platform unknown. | —                                                                                                                    |
@@ -32,6 +32,11 @@ the exit code.
 - `java -version` is spawned without a shell. Output is parsed for the
   major version. pluggy accepts both the old `1.8.0_302` and modern
   `21.0.2` formats.
+- For `spigot` / `bukkit` projects, pluggy reads the `Build-Jdk-Spec`
+  manifest attribute from the cached `BuildTools.jar` to determine the
+  minimum Java required. This keeps the check accurate as the SpigotMC
+  team updates BuildTools' JDK floor. If `BuildTools.jar` isn't cached
+  yet or the attribute is missing, the floor defaults to Java 8.
 - The cache directory is stat-checked, then probed with a `writeFile` +
   `unlink` at `.pluggy-doctor-probe-<pid>`. Missing permissions fail the
   check.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -14,23 +14,28 @@ against `process.cwd()`.
 
 ## Flags
 
-| Flag                   | Default                       | Notes                                                                                                 |
-| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `--name <name>`        | basename of target dir        | Must match `^[a-zA-Z0-9_]+$`.                                                                         |
-| `--version <semver>`   | `1.0.0`                       | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                         |
-| `--description <text>` | `"A simple Minecraft plugin"` | Free-form.                                                                                            |
-| `--main <fqcn>`        | `com.example.Main`            | Must be a Java classpath — at least `package.Class`.                                                  |
-| `--platform <id>`      | `paper`                       | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`. |
-| `-y, --yes`            | off                           | Skip confirmations. Always on under `--json`.                                                         |
+| Flag                    | Default                       | Notes                                                                                                 |
+| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--name <name>`         | basename of target dir        | Must match `^[a-zA-Z0-9_-]+$`.                                                                        |
+| `--version <semver>`    | `1.0.0`                       | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                         |
+| `--description <text>`  | `"A simple Minecraft plugin"` | Free-form.                                                                                            |
+| `--main <fqcn>`         | `com.example.Main`            | Must be a Java classpath — at least `package.Class`.                                                  |
+| `--platform <id>`       | `paper`                       | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`. Repeatable. |
+| `--mc-version <semver>` | highest common across targets | Minecraft version written to `compatibility.versions[0]`. See below.                                  |
+| `-y, --yes`             | off                           | Skip confirmations. Always on under `--json`.                                                         |
 
-The `--version` here refers to the plugin's own `project.version`. To pin
-the Minecraft version (`compatibility.versions[0]`), don't pass `--version`;
-edit `project.json` after init, or use `pluggy info` against a specific
-platform version.
+The `--version` here refers to the plugin's own `project.version`. The
+Minecraft version lives at `compatibility.versions[0]` and is set by
+`--mc-version`.
 
-At init time pluggy calls the selected platform's `getLatestVersion()`,
-which hits the upstream API (PaperMC, Spigot, etc.). Expect a short
-network wait on first run.
+When `--mc-version` is omitted, pluggy calls `getVersions()` on every
+selected platform in parallel, intersects the results, and picks the
+highest version that every target publishes. That way a multi-platform
+init (e.g. `paper + spigot`) can never pick a Paper-only release. If the
+intersection is empty, init errors with "No compatible Minecraft version
+found across platforms: …" and suggests either dropping platforms or
+passing `--mc-version` explicitly. Expect a short network wait on first
+run.
 
 ## Files produced
 
@@ -48,15 +53,28 @@ version / class name / package name.
 
 ## Prompts
 
-Without `-y`, pluggy prompts before:
+Without `-y`, pluggy walks through an interactive session:
 
-- Scaffolding into a non-empty directory.
-- Scaffolding inside an existing pluggy project (either overwriting it or
-  nesting a new project).
+- **Non-empty target confirm** — scaffolding into a directory that already
+  has files, or nesting a new project inside an existing pluggy project.
+  Defaults to "no".
+- **Project name** — pre-filled with the target basename. Skipped when
+  `--name` is passed or a positional `path` is given.
+- **Target platforms** — checkbox list of every registered platform, with
+  `paper` pre-selected. Skipped when `--platform` is passed. Requires at
+  least one selection.
+- **Main class** — pre-filled with `com.example.<DerivedClassName>`,
+  where the class name is derived from the project name by splitting on
+  `-`/`_` and PascalCasing. Skipped when `--main` is passed.
+- **IDE integration** — checkbox list of `VS Code`, `IntelliJ IDEA`, and
+  `Eclipse`. Selections are written to `project.ide`, which makes
+  `pluggy build` emit project files for those editors. The prompt always
+  runs in interactive mode; leave it empty to skip IDE scaffolding.
 
-Both prompts default to "no". Under `--json`, these situations throw
-instead of prompting — an interactive prompt in a non-interactive session
-would hang forever.
+Under `--json` or `-y`, the non-empty-dir situation throws instead of
+prompting — an interactive prompt in a non-interactive session would
+hang forever — and every other prompt falls back to its default
+(`paper` for platforms, no IDE integration, derived name/main).
 
 ## Human output
 
@@ -86,15 +104,16 @@ Project "example" initialized successfully at /tmp/example
 
 ## Error cases
 
-| Trigger                        | Message                                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| Invalid `--name`               | `Invalid project name: "<name>". Only alphanumeric characters and underscores are allowed.`                   |
-| Invalid `--main`               | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                   |
-| Unknown `--platform`           | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine` |
-| Non-empty target dir (no `-y`) | Interactive confirm; "no" aborts with `Aborting project initialization.`                                      |
-| Existing project dir (no `-y`) | As above.                                                                                                     |
+| Trigger                           | Message                                                                                                                                      |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid `--name`                  | `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`                                        |
+| Invalid `--main`                  | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                                                  |
+| Unknown `--platform`              | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine`                                |
+| No MC version common to platforms | `No compatible Minecraft version found across platforms: <list>. Try selecting fewer platforms or specifying a version manually with --mc-version.` |
+| Non-empty target dir (no `-y`)    | Interactive confirm; "no" aborts with `Aborted.`                                                                                             |
+| Existing project dir (no `-y`)    | As above.                                                                                                                                    |
 
-Network failures during `getLatestVersion()` propagate from the platform
+Network failures during `getVersions()` propagate from the platform
 provider — see [Troubleshooting](../troubleshooting.md#network-errors-during-init-or-dev).
 
 ## See also

--- a/docs/dev-server.md
+++ b/docs/dev-server.md
@@ -190,12 +190,15 @@ wraps `taskkill` internally, and the SIGINT handler is installed through
 pluggy runs:
 
 ```text
-java -Xmx<memory> <project.dev.jvmArgs or --args> -jar server.jar
+java -Xmx<memory> <project.dev.jvmArgs or --args> -jar server.jar nogui
 ```
 
 Working directory is `dev/`. stdin is piped — pluggy's stdin is forwarded
 so you can type server commands into the terminal. stdout/stderr are
-inherited, so the server's logs are your terminal's output.
+inherited, so the server's logs are your terminal's output. The trailing
+`nogui` suppresses Bukkit's AWT console window on desktop JVMs — pluggy
+always runs the server headless because stdin/stdout is its control
+channel.
 
 No shell is spawned. Windows handles `.exe` lookup internally when the
 command is just `java`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,8 +63,9 @@ pluggy init --yes --name my_plugin --main com.example.myplugin.Main
 - `src/config.yml` — a resources file with `${project.name}` placeholders
   rendered at build time.
 
-The project name must match `[a-zA-Z0-9_]+`. The `--main` value must be a
-dotted Java class path, minimum package + class.
+The project name must match `[a-zA-Z0-9_-]+` (alphanumeric, underscores,
+and hyphens). The `--main` value must be a dotted Java class path,
+minimum package + class.
 
 Without `--yes` pluggy prompts interactively; confirmations are skipped when
 the target directory is empty or when `--json` is set.
@@ -86,9 +87,10 @@ $ cat project.json
 ```
 
 The `compatibility.versions[0]` entry is picked up from the Paper upstream
-at init time — it's whatever Paper's API endpoint reported as the latest
-release. Pin this by passing `--version 1.21.8` to `init` if you need a
-specific version.
+at init time — it's the highest release available on every selected
+platform. Pin this by passing `--mc-version 1.21.8` to `init` if you
+need a specific version. (`--version` sets the plugin's own
+`project.version` — they're separate knobs.)
 
 ## Add a dependency
 

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -1,8 +1,8 @@
 # IDE integration
 
-Set `"ide"` in `project.json` and `pluggy build` writes editor
-scaffolding so your IDE sees pluggy's resolved classpath. Three values are
-supported:
+Set `"ide"` in `project.json` to an array of editor kinds, and `pluggy
+build` writes scaffolding so each IDE sees pluggy's resolved classpath.
+Three values are supported:
 
 | Value        | Produces                  | Consumer                           |
 | ------------ | ------------------------- | ---------------------------------- |
@@ -10,7 +10,14 @@ supported:
 | `"eclipse"`  | `.classpath` + `.project` | Eclipse IDE / Spring Tools / Theia |
 | `"intellij"` | `.idea/` + `<name>.iml`   | IntelliJ IDEA, CLion (Java plugin) |
 
-Unset `ide` means no scaffolding.
+Any subset is valid — list every editor your team uses:
+
+```json
+"ide": ["vscode", "intellij"]
+```
+
+Unset or empty `ide` means no scaffolding. `pluggy init` asks for this
+interactively via a checkbox prompt.
 
 ## When the files are written
 

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -14,7 +14,7 @@ which workspace you're sitting in.
   "description": "A small Paper plugin",
   "authors": ["Alice", "Bob"],
   "main": "com.example.myplugin.Main",
-  "ide": "vscode",
+  "ide": ["vscode"],
   "compatibility": {
     "versions": ["1.21.8"],
     "platforms": ["paper"]
@@ -109,9 +109,18 @@ Required for every buildable workspace. A workspace-less root that declares
 
 ### `ide` (optional)
 
-One of `"vscode"`, `"eclipse"`, `"intellij"`. Controls which editor scaffolding
-`build` writes. Unset means no scaffolding. See [IDE integration](./ide.md)
-for what each value produces.
+Array of `"vscode"`, `"eclipse"`, `"intellij"`. Controls which editor
+scaffolding `build` writes — pluggy walks the array and generates files
+for every listed IDE, so a mixed-editor team can commit one
+`project.json` that covers everyone. Unset or empty means no scaffolding.
+See [IDE integration](./ide.md) for what each value produces.
+
+```json
+"ide": ["vscode", "intellij"]
+```
+
+`pluggy init` writes this field from the interactive IDE checkbox; edit
+the array by hand to add or remove editors later.
 
 ### `compatibility` (required)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,10 +5,10 @@ the code, with placeholders (`<...>`) for interpolated values.
 
 ## `pluggy init`
 
-### `Invalid project name: "<name>". Only alphanumeric characters and underscores are allowed.`
+### `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`
 
-`--name` must match `^[a-zA-Z0-9_]+$`. Hyphens, dots, and Unicode aren't
-allowed. This is enforced by `init` and checked again by `doctor`.
+`--name` must match `^[a-zA-Z0-9_-]+$`. Dots and Unicode aren't allowed.
+This is enforced by `init` and checked again by `doctor`.
 
 ### `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`
 
@@ -18,12 +18,21 @@ a package for production plugin classes.
 
 ### Network errors during init or dev
 
-`pluggy init` hits PaperMC / Spigot / Modrinth to pick the latest
-version for `compatibility.versions[0]`. If your network is offline or
-the upstream is down:
+`pluggy init` calls `getVersions()` on every selected platform in
+parallel and picks the highest version they all publish. If your network
+is offline or the upstream is down:
 
-- Pass `--version <semver>` to skip the network call.
+- Pass `--mc-version <semver>` to skip the network call entirely.
 - Or just put a version in `project.json` after `init` completes.
+
+### `No compatible Minecraft version found across platforms: <list>.`
+
+pluggy couldn't find a Minecraft version that every selected platform
+publishes. Common causes: mixing a Spigot-only codebase with Paper 26.x
+(Spigot hasn't cut that version yet), or selecting Velocity alongside
+Paper (different release cadences). Either drop the platform that's
+lagging, split the project into per-family workspaces, or pin the
+version yourself with `--mc-version`.
 
 `pluggy dev` also hits the platform registry for the server jar. The
 first run per `(platform, version)` needs network; subsequent runs
@@ -171,12 +180,14 @@ with stateful plugins. Full restart is slower but correct.
 
 Install a JDK. See the `javac` entry above.
 
-### `! Java toolchain — Java 22 — spigot/bukkit BuildTools needs Java 8-21`
+### `! Java toolchain — Java <x> — BuildTools requires Java <y>+`
 
-The detected JDK is outside the window Spigot BuildTools supports. This
+The detected JDK is older than the floor declared by the cached
+`BuildTools.jar` (read from its `Build-Jdk-Spec` manifest attribute). This
 is a warning — if you're building against Paper, it doesn't matter. If
-you're building against Spigot or Bukkit, install a JDK in the supported
-range and make it the first one on `PATH`.
+you're building against Spigot or Bukkit, install a JDK at or above the
+reported floor and make it the first one on `PATH`. The floor moves as
+SpigotMC ships new BuildTools releases.
 
 ### `✖ Cache reachability — cache is not writable: <path> (<errno>)`
 


### PR DESCRIPTION
## Summary

Sweeps the docs to catch up with the last few CLI/platform commits that landed without matching doc updates:

- `init` — document the interactive **IDE** and **platform** checkboxes, the new cross-platform MC-version intersection (replaces the old `getLatestVersion()` copy), and the now-hyphen-allowing project name regex. Adds `--mc-version` to the flag table.
- `doctor` / troubleshooting — Java floor for Spigot/Bukkit is now read from `BuildTools.jar`'s `Build-Jdk-Spec` manifest; replaced the stale "Java 8–21" window language.
- `build` — documented the per-platform `checkPlatformCompile` step and the `platformChecks` field in JSON output.
- `dev` / dev-server — show the trailing `nogui` in the spawn command.
- Fixed pre-existing drift: `project.ide` is an array, not a string (`project-json.md`, `ide.md`, `README.md`).

## Test plan

- [ ] Skim each updated doc end-to-end and confirm it matches the current CLI behaviour.
- [ ] Run `pluggy init` interactively to verify the documented IDE and platform prompts match.