### PR TITLE
feat(cli): add test command for running JUnit suites

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -113,9 +113,7 @@ On success:
       "outputPath": "/repo/bin/my_plugin-1.0.0.jar",
       "sizeBytes": 145840,
       "durationMs": 3821,
-      "platformChecks": [
-        { "platform": "spigot", "ok": true, "durationMs": 612 }
-      ]
+      "platformChecks": [{ "platform": "spigot", "ok": true, "durationMs": 612 }]
     }
   ]
 }

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -17,15 +17,15 @@ No flags beyond the global `--json`.
 Every check returns one of `pass`, `warn`, `fail`. Only `fail` affects
 the exit code.
 
-| id                    | label                   | fail trigger                                                       | warn trigger                                                                                                         |
-| --------------------- | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| id                    | label                   | fail trigger                                                       | warn trigger                                                                                                                            |
+| --------------------- | ----------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `java`                | Java toolchain          | `java -version` fails (not on PATH, or non-zero exit).             | Primary platform is `spigot` or `bukkit` **and** the detected JDK is older than the Java floor declared by the cached `BuildTools.jar`. |
-| `cache`               | Cache reachability      | Path exists but isn't a directory; probe write fails.              | Directory doesn't exist yet (will be created on first use).                                                          |
-| `registry <url>`      | Registry                | —                                                                  | `HEAD` returns a 5xx or the request errors. 2xx / 3xx / 4xx count as reachable.                                      |
-| `project (<name>)`    | Validate `project.json` | `name`, `version`, or `compatibility` malformed; platform unknown. | —                                                                                                                    |
-| `workspace`           | Workspace graph         | Cycle detected in `workspace:` deps.                               | —                                                                                                                    |
-| `descriptor (<name>)` | Descriptor family       | `pickDescriptor` throws (unknown platform, mixed families).        | —                                                                                                                    |
-| `outdated`            | Outdated dependencies   | —                                                                  | Any Modrinth dep has a newer stable version, or any Modrinth query failed.                                           |
+| `cache`               | Cache reachability      | Path exists but isn't a directory; probe write fails.              | Directory doesn't exist yet (will be created on first use).                                                                             |
+| `registry <url>`      | Registry                | —                                                                  | `HEAD` returns a 5xx or the request errors. 2xx / 3xx / 4xx count as reachable.                                                         |
+| `project (<name>)`    | Validate `project.json` | `name`, `version`, or `compatibility` malformed; platform unknown. | —                                                                                                                                       |
+| `workspace`           | Workspace graph         | Cycle detected in `workspace:` deps.                               | —                                                                                                                                       |
+| `descriptor (<name>)` | Descriptor family       | `pickDescriptor` throws (unknown platform, mixed families).        | —                                                                                                                                       |
+| `outdated`            | Outdated dependencies   | —                                                                  | Any Modrinth dep has a newer stable version, or any Modrinth query failed.                                                              |
 
 ### Environment checks
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -14,15 +14,15 @@ against `process.cwd()`.
 
 ## Flags
 
-| Flag                    | Default                       | Notes                                                                                                 |
-| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `--name <name>`         | basename of target dir        | Must match `^[a-zA-Z0-9_-]+$`.                                                                        |
-| `--version <semver>`    | `1.0.0`                       | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                         |
-| `--description <text>`  | `"A simple Minecraft plugin"` | Free-form.                                                                                            |
-| `--main <fqcn>`         | `com.example.Main`            | Must be a Java classpath — at least `package.Class`.                                                  |
+| Flag                    | Default                       | Notes                                                                                                             |
+| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`         | basename of target dir        | Must match `^[a-zA-Z0-9_-]+$`.                                                                                    |
+| `--version <semver>`    | `1.0.0`                       | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                                     |
+| `--description <text>`  | `"A simple Minecraft plugin"` | Free-form.                                                                                                        |
+| `--main <fqcn>`         | `com.example.Main`            | Must be a Java classpath — at least `package.Class`.                                                              |
 | `--platform <id>`       | `paper`                       | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`. Repeatable. |
-| `--mc-version <semver>` | highest common across targets | Minecraft version written to `compatibility.versions[0]`. See below.                                  |
-| `-y, --yes`             | off                           | Skip confirmations. Always on under `--json`.                                                         |
+| `--mc-version <semver>` | highest common across targets | Minecraft version written to `compatibility.versions[0]`. See below.                                              |
+| `-y, --yes`             | off                           | Skip confirmations. Always on under `--json`.                                                                     |
 
 The `--version` here refers to the plugin's own `project.version`. The
 Minecraft version lives at `compatibility.versions[0]` and is set by
@@ -104,14 +104,14 @@ Project "example" initialized successfully at /tmp/example
 
 ## Error cases
 
-| Trigger                           | Message                                                                                                                                      |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Invalid `--name`                  | `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`                                        |
-| Invalid `--main`                  | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                                                  |
-| Unknown `--platform`              | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine`                                |
+| Trigger                           | Message                                                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid `--name`                  | `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`                                               |
+| Invalid `--main`                  | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                                                         |
+| Unknown `--platform`              | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine`                                       |
 | No MC version common to platforms | `No compatible Minecraft version found across platforms: <list>. Try selecting fewer platforms or specifying a version manually with --mc-version.` |
-| Non-empty target dir (no `-y`)    | Interactive confirm; "no" aborts with `Aborted.`                                                                                             |
-| Existing project dir (no `-y`)    | As above.                                                                                                                                    |
+| Non-empty target dir (no `-y`)    | Interactive confirm; "no" aborts with `Aborted.`                                                                                                    |
+| Existing project dir (no `-y`)    | As above.                                                                                                                                           |
 
 Network failures during `getVersions()` propagate from the platform
 provider — see [Troubleshooting](../troubleshooting.md#network-errors-during-init-or-dev).

--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for src/commands/test.ts. Real workspace resolver + on-disk
+ * `project.json`; `runTests` is mocked so no JVM is spawned.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+
+vi.mock("../test/index.ts", () => ({
+  runTests: vi.fn(),
+}));
+
+import { runTests } from "../test/index.ts";
+
+import { runTestCommand, selectTestTargets } from "./test.ts";
+import { resolveWorkspaceContext } from "../workspace.ts";
+
+describe("runTestCommand", () => {
+  let rootDir: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pluggy-test-cmd-"));
+    stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(runTests).mockReset();
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  async function writeStandalone(): Promise<void> {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "standalone",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+      }),
+    );
+  }
+
+  async function writeMultiWorkspace(): Promise<void> {
+    await mkdir(join(rootDir, "modules", "api"), { recursive: true });
+    await mkdir(join(rootDir, "modules", "impl"), { recursive: true });
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "suite",
+        version: "1.0.0",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+        workspaces: ["./modules/api", "./modules/impl"],
+      }),
+    );
+    await writeFile(
+      join(rootDir, "modules", "api", "project.json"),
+      JSON.stringify({
+        name: "suite_api",
+        version: "0.1.0",
+        main: "com.example.api.Plugin",
+      }),
+    );
+    await writeFile(
+      join(rootDir, "modules", "impl", "project.json"),
+      JSON.stringify({
+        name: "suite_impl",
+        version: "0.1.0",
+        main: "com.example.impl.Plugin",
+        dependencies: {
+          suite_api: { source: "workspace:suite_api", version: "*" },
+        },
+      }),
+    );
+  }
+
+  test("all tests pass → exitCode 0, status success", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 100,
+      result: {
+        total: 3,
+        passed: 3,
+        failed: 0,
+        skipped: 0,
+        cases: [
+          { suite: "com.example.FooTest", name: "a", durationMs: 1, status: "passed" },
+          { suite: "com.example.FooTest", name: "b", durationMs: 2, status: "passed" },
+          { suite: "com.example.FooTest", name: "c", durationMs: 3, status: "passed" },
+        ],
+      },
+    });
+
+    const res = await runTestCommand({ cwd: rootDir });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.status).toBe("success");
+    expect(res.results[0]).toMatchObject({
+      ok: true,
+      tests: { total: 3, passed: 3, failed: 0, skipped: 0 },
+    });
+  });
+
+  test("test failure → exitCode 1, failures array populated", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 50,
+      result: {
+        total: 2,
+        passed: 1,
+        failed: 1,
+        skipped: 0,
+        cases: [
+          { suite: "A", name: "p", durationMs: 1, status: "passed" },
+          {
+            suite: "A",
+            name: "f",
+            durationMs: 2,
+            status: "failed",
+            message: "expected true",
+            stackTrace: "at A.f(A.java:1)",
+          },
+        ],
+      },
+    });
+
+    const res = await runTestCommand({ cwd: rootDir });
+
+    expect(res.exitCode).toBe(1);
+    expect(res.status).toBe("partial");
+    expect(res.results[0].failures).toEqual([
+      {
+        class: "A",
+        test: "f",
+        durationMs: 2,
+        message: "expected true",
+        stackTrace: "at A.f(A.java:1)",
+      },
+    ]);
+  });
+
+  test("no-test-dir → ok=true, skipped field set, exitCode 0", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "no-tests",
+      durationMs: 5,
+      reason: "no-test-dir",
+    });
+
+    const res = await runTestCommand({ cwd: rootDir });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.results[0].ok).toBe(true);
+    expect(res.results[0].skipped).toBe("no-test-dir");
+    expect(res.results[0].tests).toBeUndefined();
+  });
+
+  test("multi-workspace: runs in topo order, continues on failure", async () => {
+    await writeMultiWorkspace();
+    vi.mocked(runTests)
+      .mockResolvedValueOnce({
+        status: "ok",
+        durationMs: 10,
+        result: { total: 1, passed: 1, failed: 0, skipped: 0, cases: [] },
+      })
+      .mockRejectedValueOnce(new Error("compile boom"));
+
+    const res = await runTestCommand({ cwd: rootDir });
+
+    expect(res.exitCode).toBe(1);
+    expect(res.status).toBe("partial");
+    expect(res.results).toHaveLength(2);
+    expect(res.results[0]).toMatchObject({ workspace: "suite_api", ok: true });
+    expect(res.results[1]).toMatchObject({ workspace: "suite_impl", ok: false });
+    expect(res.results[1].error).toContain("compile boom");
+    expect(runTests).toHaveBeenCalledTimes(2);
+  });
+
+  test("single-target compile failure rethrows (no second target to continue with)", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockRejectedValueOnce(new Error("javac exited with code 1"));
+
+    await expect(runTestCommand({ cwd: rootDir })).rejects.toThrow(/javac exited/);
+  });
+
+  test("--json success → single JSON object on stdout", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 100,
+      result: {
+        total: 1,
+        passed: 1,
+        failed: 0,
+        skipped: 0,
+        cases: [{ suite: "A", name: "x", durationMs: 1, status: "passed" }],
+      },
+    });
+
+    await runTestCommand({ cwd: rootDir, json: true });
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed.status).toBe("success");
+    expect(parsed.results[0].tests).toEqual({ total: 1, passed: 1, failed: 0, skipped: 0 });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  test("--json with failures → JSON on stderr, exit 1", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 1,
+      result: {
+        total: 1,
+        passed: 0,
+        failed: 1,
+        skipped: 0,
+        cases: [{ suite: "A", name: "f", durationMs: 1, status: "failed", message: "nope" }],
+      },
+    });
+
+    const res = await runTestCommand({ cwd: rootDir, json: true });
+
+    expect(res.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(stderrSpy.mock.calls[0][0] as string);
+    expect(parsed.status).toBe("error");
+    expect(parsed.results[0].failures[0].message).toBe("nope");
+  });
+
+  test("--workspace narrows at root", async () => {
+    await writeMultiWorkspace();
+    vi.mocked(runTests).mockResolvedValue({
+      status: "ok",
+      durationMs: 1,
+      result: { total: 0, passed: 0, failed: 0, skipped: 0, cases: [] },
+    });
+
+    const res = await runTestCommand({ cwd: rootDir, workspace: "suite_impl" });
+
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0].workspace).toBe("suite_impl");
+    expect(runTests).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes filter and failFast through to runTests", async () => {
+    await writeStandalone();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 1,
+      result: { total: 0, passed: 0, failed: 0, skipped: 0, cases: [] },
+    });
+
+    await runTestCommand({ cwd: rootDir, filter: "@tag:slow", failFast: true });
+
+    const call = vi.mocked(runTests).mock.calls[0];
+    expect(call[1]).toMatchObject({ filter: "@tag:slow", failFast: true });
+  });
+});
+
+describe("selectTestTargets", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pluggy-test-sel-"));
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("standalone: one target, the root project", async () => {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "solo",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+      }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir);
+    const targets = selectTestTargets(ctx!, {});
+    expect(targets).toHaveLength(1);
+    expect(targets[0].name).toBe("solo");
+  });
+
+  test("unknown --workspace throws", async () => {
+    await mkdir(join(rootDir, "modules", "a"), { recursive: true });
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "r",
+        version: "1.0.0",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+        workspaces: ["./modules/a"],
+      }),
+    );
+    await writeFile(
+      join(rootDir, "modules", "a", "project.json"),
+      JSON.stringify({ name: "a", version: "0.1.0", main: "a.M" }),
+    );
+    const ctx = resolveWorkspaceContext(rootDir)!;
+    expect(() => selectTestTargets(ctx, { workspace: "does-not-exist" })).toThrow(
+      /workspace not found/,
+    );
+  });
+});

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,0 +1,307 @@
+import process from "node:process";
+
+import { Command, InvalidArgumentError } from "commander";
+
+import { runTests, type TestRunOutcome } from "../test/index.ts";
+import { bold, dim, green, log, red, yellow } from "../logging.ts";
+import type { ResolvedProject } from "../project.ts";
+import type { TestCase } from "../test/runner.ts";
+import {
+  findWorkspace,
+  resolveWorkspaceContext,
+  topologicalOrder,
+  type WorkspaceContext,
+} from "../workspace.ts";
+
+export interface TestCommandOptions {
+  filter?: string;
+  failFast?: boolean;
+  clean?: boolean;
+  workspace?: string;
+  workspaces?: boolean;
+  json?: boolean;
+  cwd?: string;
+}
+
+export interface TestCommandResult {
+  status: "success" | "partial";
+  exitCode: 0 | 1;
+  results: Array<{
+    workspace: string;
+    rootDir: string;
+    ok: boolean;
+    durationMs: number;
+    tests?: { total: number; passed: number; failed: number; skipped: number };
+    failures?: Array<{
+      class: string;
+      test: string;
+      durationMs: number;
+      message?: string;
+      stackTrace?: string;
+    }>;
+    /** "no-test-dir" | "no-sources" when the workspace ran no tests. */
+    skipped?: "no-test-dir" | "no-sources";
+    /** Set when the workspace errored before tests could run (e.g. compile). */
+    error?: string;
+  }>;
+}
+
+/**
+ * Run `pluggy test` across the resolved target set.
+ *
+ * Compile errors and launcher failures rethrow for single-target calls so the
+ * top-level handler formats them; in multi-workspace runs the error is
+ * captured into the per-workspace result and we keep going. Test *failures*
+ * (asserts) never throw — they surface via `ok: false` + `failures[]`.
+ */
+export async function runTestCommand(opts: TestCommandOptions): Promise<TestCommandResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const context = resolveWorkspaceContext(cwd);
+  if (context === undefined) {
+    throw new Error("No pluggy project found — run this from inside a project directory.");
+  }
+
+  const targets = selectTestTargets(context, opts);
+
+  const results: TestCommandResult["results"] = [];
+  let anyFailed = false;
+
+  for (const target of targets) {
+    const label = target.name;
+    const rootDir = target.rootDir;
+    const started = Date.now();
+
+    try {
+      if (opts.json !== true) {
+        log.info(`${bold("test")} ${label}`);
+      }
+
+      const outcome: TestRunOutcome = await runTests(target, {
+        filter: opts.filter,
+        failFast: opts.failFast,
+        clean: opts.clean,
+      });
+
+      if (outcome.status === "no-tests") {
+        const reason = outcome.reason;
+        results.push({
+          workspace: label,
+          rootDir,
+          ok: true,
+          durationMs: outcome.durationMs,
+          skipped: reason,
+        });
+        if (opts.json !== true) {
+          const msg =
+            reason === "no-test-dir"
+              ? `${label}: no test/ directory — nothing to run`
+              : `${label}: test/ contains no .java sources`;
+          log.warn(msg);
+        }
+        continue;
+      }
+
+      const { result, durationMs } = outcome;
+      const ok = result.failed === 0;
+      if (!ok) anyFailed = true;
+
+      const failures = result.cases
+        .filter((c) => c.status === "failed")
+        .map((c) => ({
+          class: c.suite,
+          test: c.name,
+          durationMs: c.durationMs,
+          message: c.message,
+          stackTrace: c.stackTrace,
+        }));
+
+      results.push({
+        workspace: label,
+        rootDir,
+        ok,
+        durationMs,
+        tests: {
+          total: result.total,
+          passed: result.passed,
+          failed: result.failed,
+          skipped: result.skipped,
+        },
+        failures: failures.length > 0 ? failures : undefined,
+      });
+
+      if (opts.json !== true) {
+        renderHumanResult(label, result.cases, result);
+      }
+    } catch (err) {
+      anyFailed = true;
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({
+        workspace: label,
+        rootDir,
+        ok: false,
+        durationMs: Date.now() - started,
+        error: message,
+      });
+      if (opts.json !== true) {
+        log.error(`${label}: ${message}`);
+      }
+      if (targets.length === 1) {
+        throw err;
+      }
+    }
+  }
+
+  const exitCode: 0 | 1 = anyFailed ? 1 : 0;
+  const status: TestCommandResult["status"] = anyFailed ? "partial" : "success";
+
+  if (opts.json === true) {
+    const payload = {
+      status: anyFailed ? "error" : "success",
+      results: results.map((r) => ({
+        workspace: r.workspace,
+        rootDir: r.rootDir,
+        ok: r.ok,
+        durationMs: r.durationMs,
+        tests: r.tests,
+        failures: r.failures,
+        skipped: r.skipped,
+        error: r.error,
+      })),
+    };
+    if (anyFailed) {
+      console.error(JSON.stringify(payload, null, 2));
+    } else {
+      console.log(JSON.stringify(payload, null, 2));
+    }
+  } else if (targets.length > 1) {
+    log.info("");
+    log.info(bold("summary"));
+    for (const r of results) {
+      const line = summaryLine(r);
+      log.info(`  ${r.workspace}: ${line}`);
+    }
+  }
+
+  return { status, exitCode, results };
+}
+
+/**
+ * Pick the workspaces `pluggy test` should cover. Mirrors `selectBuildTargets`
+ * exactly — root with workspaces → all in topo order, `--workspace` narrows,
+ * inside a workspace → just that one.
+ */
+export function selectTestTargets(
+  context: WorkspaceContext,
+  opts: Pick<TestCommandOptions, "workspace" | "workspaces">,
+): ResolvedProject[] {
+  if (context.atRoot && context.workspaces.length > 0) {
+    if (opts.workspace !== undefined) {
+      const node = findWorkspace(context, opts.workspace);
+      return [node.project];
+    }
+    return topologicalOrder(context.workspaces).map((n) => n.project);
+  }
+
+  if (context.current !== undefined) {
+    if (opts.workspace !== undefined && opts.workspace !== context.current.name) {
+      throw new InvalidArgumentError(
+        `--workspace "${opts.workspace}" does not match the current workspace "${context.current.name}". Run from the root to test a different workspace.`,
+      );
+    }
+    if (opts.workspaces === true) {
+      throw new InvalidArgumentError(
+        "--workspaces is only valid at the repo root; you're inside workspace " +
+          `"${context.current.name}".`,
+      );
+    }
+    return [context.current.project];
+  }
+
+  if (opts.workspace !== undefined) {
+    throw new InvalidArgumentError(
+      `--workspace "${opts.workspace}" given but this project declares no workspaces.`,
+    );
+  }
+  return [context.root];
+}
+
+function summaryLine(r: TestCommandResult["results"][number]): string {
+  if (r.error !== undefined) return `FAILED — ${r.error}`;
+  if (r.skipped === "no-test-dir") return "no test/ directory";
+  if (r.skipped === "no-sources") return "no .java sources in test/";
+  const t = r.tests;
+  if (t === undefined) return "ok";
+  const parts = [`${t.passed} passed`];
+  if (t.failed > 0) parts.push(`${t.failed} failed`);
+  if (t.skipped > 0) parts.push(`${t.skipped} skipped`);
+  return parts.join(", ") + ` (${r.durationMs}ms)`;
+}
+
+function renderHumanResult(
+  label: string,
+  cases: TestCase[],
+  totals: { total: number; passed: number; failed: number; skipped: number },
+): void {
+  // Group cases by suite classname, preserving discovery order.
+  const bySuite = new Map<string, TestCase[]>();
+  for (const c of cases) {
+    const bucket = bySuite.get(c.suite);
+    if (bucket === undefined) bySuite.set(c.suite, [c]);
+    else bucket.push(c);
+  }
+
+  for (const [suite, entries] of bySuite) {
+    log.info(`  ${suite}`);
+    for (const c of entries) {
+      const glyph =
+        c.status === "passed" ? green("✓") : c.status === "failed" ? red("✗") : yellow("○");
+      const line = `    ${glyph} ${c.name}`;
+      const time = dim(`${c.durationMs}ms`);
+      log.info(`${line}  ${time}`);
+      if (c.status === "failed") {
+        if (c.message !== undefined && c.message.length > 0) {
+          log.info(`        ${c.message}`);
+        }
+        if (c.stackTrace !== undefined) {
+          const first = c.stackTrace.split("\n").find((l) => l.trim().startsWith("at "));
+          if (first !== undefined) log.info(`        ${first.trim()}`);
+        }
+      }
+    }
+  }
+
+  const parts = [`${totals.passed} passed`];
+  if (totals.failed > 0) parts.push(`${totals.failed} failed`);
+  if (totals.skipped > 0) parts.push(`${totals.skipped} skipped`);
+  log.info("");
+  log.info(`  ${parts.join(", ")}`);
+}
+
+/** Factory for the `pluggy test` commander command. */
+export function testCommand(): Command {
+  return new Command("test")
+    .alias("t")
+    .description("Compile and run JUnit tests under test/.")
+    .option(
+      "--filter <pattern>",
+      "Include tests matching classname glob, Class#method, or @tag:<name>.",
+    )
+    .option("--fail-fast", "Stop after the first test failure.")
+    .option("--clean", "Wipe the test build cache before running.")
+    .option("--workspace <name>", "Test a single workspace.")
+    .option("--workspaces", "Explicit all-workspaces test.")
+    .action(async function action(this: Command, options) {
+      const globalOpts = this.optsWithGlobals();
+      const result = await runTestCommand({
+        filter: options.filter,
+        failFast: options.failFast === true,
+        clean: options.clean === true,
+        workspace: options.workspace,
+        workspaces: options.workspaces === true,
+        json: globalOpts.json === true,
+      });
+      if (result.exitCode !== 0) {
+        process.exit(result.exitCode);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { installCommand } from "./commands/install.ts";
 import { listCommand } from "./commands/list.ts";
 import { removeCommand } from "./commands/remove.ts";
 import { searchCommand } from "./commands/search.ts";
+import { testCommand } from "./commands/test.ts";
 import { upgradeCommand } from "./commands/upgrade.ts";
 import { bold, red } from "./logging.ts";
 
@@ -38,6 +39,7 @@ program.addCommand(infoCommand());
 program.addCommand(searchCommand());
 program.addCommand(listCommand());
 program.addCommand(buildCommand());
+program.addCommand(testCommand());
 program.addCommand(doctorCommand());
 program.addCommand(devCommand());
 program.addCommand(upgradeCommand({ repository: "ch99q/pluggy" }));

--- a/src/platform/papermc/papermc.ts
+++ b/src/platform/papermc/papermc.ts
@@ -27,11 +27,16 @@ interface Version {
   builds: number[];
 }
 
-/** List every version of a PaperMC project, newest-first. */
+/**
+ * List every version of a PaperMC project that has at least one
+ * published build, newest-first. Upstream sometimes publishes a
+ * version entry before any build artifacts exist (e.g. Folia 26.1.2);
+ * such entries are filtered out because they aren't downloadable.
+ */
 export function versions(project: Project): Promise<Version[]> {
   return fetch(`${PAPER_ENDPOINT}/${project}/versions`)
     .then((res) => res.json() as Promise<{ versions: Version[] }>)
-    .then((data) => data.versions);
+    .then((data) => data.versions.filter((v) => v.builds.length > 0));
 }
 
 /**

--- a/src/project.ts
+++ b/src/project.ts
@@ -17,6 +17,7 @@ export interface Project {
     platforms: string[];
   };
   dependencies?: Record<string, string | Dependency>;
+  testDependencies?: Record<string, string | Dependency>;
   registries?: (string | Registry)[];
   shading?: Record<string, Shading>;
   resources?: Record<string, string>;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,336 @@
+/**
+ * Test pipeline — resolve deps → compile src → compile test → run JUnit
+ * Platform Console Launcher → parse JUnit XML reports. Orchestration only;
+ * pure arg-building and report-parsing live in `./runner.ts`.
+ *
+ * JUnit Platform Console Standalone is auto-injected from Maven Central; the
+ * user never declares it. User-provided test deps go in `project.json`'s
+ * `testDependencies`, resolved through the same pipeline as `dependencies`.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { compileJava } from "../build/compile.ts";
+import { log } from "../logging.ts";
+import { getPlatform } from "../platform/index.ts";
+import type { ResolvedProject } from "../project.ts";
+import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
+import { resolveMaven } from "../resolver/maven.ts";
+import { parseSource } from "../source.ts";
+
+import {
+  buildLauncherArgs,
+  parseJUnitReports,
+  type TestRunResult as ParsedRunResult,
+} from "./runner.ts";
+
+/** Maven Central — always appended to the test-time registry list. */
+const MAVEN_CENTRAL = "https://repo1.maven.org/maven2";
+
+/** Pinned JUnit Platform Console Standalone — single jar, includes Jupiter + Vintage. */
+const JUNIT_CONSOLE = {
+  groupId: "org.junit.platform",
+  artifactId: "junit-platform-console-standalone",
+  version: "1.11.4",
+} as const;
+
+const STAGING_ROOT = ".pluggy-build";
+const MAX_STDERR_LINES = 40;
+
+export interface TestRunOptions {
+  /** Wipe the test staging dir (compiled classes, XML reports) before running. */
+  clean?: boolean;
+  /** User filter — see `filterToLauncherArgs`. */
+  filter?: string;
+  /** Stop on first test failure. */
+  failFast?: boolean;
+}
+
+export type TestRunOutcome =
+  | {
+      status: "ok";
+      durationMs: number;
+      result: ParsedRunResult;
+    }
+  | {
+      status: "no-tests";
+      durationMs: number;
+      /** Why no tests ran — surfaced to the user. */
+      reason: "no-test-dir" | "no-sources";
+    };
+
+/**
+ * Compile and run the test suite for one project. Throws on compile errors
+ * or unexpected JVM failures; test *failures* (asserts/exceptions) return
+ * normally inside `result.failed > 0` so the caller can aggregate.
+ */
+export async function runTests(
+  project: ResolvedProject,
+  opts: TestRunOptions = {},
+): Promise<TestRunOutcome> {
+  const started = Date.now();
+
+  const testSourceDir = join(project.rootDir, "test");
+  if (!(await isDirectory(testSourceDir))) {
+    return { status: "no-tests", durationMs: Date.now() - started, reason: "no-test-dir" };
+  }
+  if (!(await hasJavaSources(testSourceDir))) {
+    return { status: "no-tests", durationMs: Date.now() - started, reason: "no-sources" };
+  }
+
+  const stagingId = createHash("sha256")
+    .update(`${project.name}\0${project.version}\0${project.rootDir}`)
+    .digest("hex")
+    .slice(0, 12);
+  const stagingDir = join(project.rootDir, STAGING_ROOT, `${stagingId}-test`);
+
+  if (opts.clean === true) {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+
+  const mainClassesDir = join(stagingDir, "main-classes");
+  const testClassesDir = join(stagingDir, "test-classes");
+  const reportsDir = join(stagingDir, "reports");
+
+  await mkdir(mainClassesDir, { recursive: true });
+  await mkdir(testClassesDir, { recursive: true });
+  // Wipe reports per-run so a stale TEST-*.xml from a deleted class can't leak in.
+  await rm(reportsDir, { recursive: true, force: true });
+  await mkdir(reportsDir, { recursive: true });
+
+  // Project-declared registries (strings or {url, ...}).
+  const projectRegistries: string[] = [];
+  for (const entry of project.registries ?? []) {
+    projectRegistries.push(typeof entry === "string" ? entry : entry.url);
+  }
+  // Test-time registries always include Maven Central so JUnit can be fetched.
+  const testRegistries = dedupe([...projectRegistries, MAVEN_CENTRAL]);
+
+  const mainDeps = await resolveDeclared(project, "dependencies", projectRegistries);
+  const platformApiJars = await resolvePlatformApiJars(project, projectRegistries);
+  const mainClasspath = dedupe([...flattenJars(mainDeps), ...platformApiJars]);
+
+  const testDeps = await resolveDeclared(project, "testDependencies", testRegistries);
+  const junit = await resolveMaven(
+    JUNIT_CONSOLE.groupId,
+    JUNIT_CONSOLE.artifactId,
+    JUNIT_CONSOLE.version,
+    {
+      rootDir: project.rootDir,
+      includePrerelease: false,
+      force: false,
+      registries: testRegistries,
+    },
+  );
+
+  const testCompileClasspath = dedupe([
+    mainClassesDir,
+    ...mainClasspath,
+    ...flattenJars(testDeps),
+    junit.jarPath,
+  ]);
+
+  await compileJava(project, {
+    sourceDir: join(project.rootDir, "src"),
+    outputDir: mainClassesDir,
+    classpath: mainClasspath,
+  });
+
+  await compileJava(project, {
+    sourceDir: testSourceDir,
+    outputDir: testClassesDir,
+    classpath: testCompileClasspath,
+  });
+
+  const launcherArgs = buildLauncherArgs({
+    consoleJar: junit.jarPath,
+    classpath: [testClassesDir, ...testCompileClasspath],
+    testClassesDir,
+    reportsDir,
+    filter: opts.filter,
+    failFast: opts.failFast,
+  });
+
+  const { exitCode, stderrTail } = await runJavaLauncher(launcherArgs);
+
+  const xmlDocs = await readReports(reportsDir);
+  const result = parseJUnitReports(xmlDocs);
+
+  // Non-zero exit plus zero reports → real launcher failure (classpath, JVM crash, …).
+  if (exitCode !== 0 && result.total === 0) {
+    throw new Error(
+      `test: JUnit launcher exited with code ${exitCode} and produced no reports.${
+        stderrTail.length > 0 ? `\n${stderrTail}` : ""
+      }`,
+    );
+  }
+
+  return { status: "ok", durationMs: Date.now() - started, result };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function runJavaLauncher(args: string[]): Promise<{ exitCode: number; stderrTail: string }> {
+  log.debug(`java ${args.length} args (JUnit Console Launcher)`);
+  // We render our own output from the XML reports afterwards, so the launcher's
+  // own stdout/stderr are suppressed. stderr is still buffered so we can attach
+  // the tail to an error message on an unexpected launcher failure.
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("java", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stderrBuf: string[] = [];
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+
+    // Drain stdout so the pipe doesn't fill up; discard its contents.
+    child.stdout?.on("data", () => {});
+
+    child.stderr?.on("data", (chunk: string) => {
+      for (const line of chunk.split(/\r?\n/)) {
+        if (line.length === 0) continue;
+        stderrBuf.push(line);
+      }
+    });
+
+    child.once("error", (err) => {
+      rejectPromise(new Error(`test: failed to spawn java: ${(err as Error).message}`));
+    });
+
+    child.once("close", (code) => {
+      const tail = stderrBuf.slice(-MAX_STDERR_LINES).join("\n");
+      resolvePromise({ exitCode: code ?? 0, stderrTail: tail });
+    });
+  });
+}
+
+async function readReports(reportsDir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(reportsDir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const name of entries) {
+    if (!name.startsWith("TEST-") || !name.endsWith(".xml")) continue;
+    try {
+      out.push(await readFile(join(reportsDir, name), "utf8"));
+    } catch {
+      // File vanished or couldn't be read — skip, don't fail the whole run.
+    }
+  }
+  return out;
+}
+
+async function resolveDeclared(
+  project: ResolvedProject,
+  field: "dependencies" | "testDependencies",
+  registries: string[],
+): Promise<ResolvedDependency[]> {
+  const declared = project[field];
+  if (declared === undefined || declared === null) return [];
+
+  const out: ResolvedDependency[] = [];
+  for (const [name, raw] of Object.entries(declared)) {
+    const { source, version } =
+      typeof raw === "string"
+        ? { source: `modrinth:${name}`, version: raw }
+        : { source: raw.source, version: raw.version };
+    const parsed = parseSource(source, version);
+    const resolved = await resolveDependency(parsed, {
+      rootDir: project.rootDir,
+      includePrerelease: false,
+      force: false,
+      registries,
+    });
+    out.push(resolved);
+  }
+  return out;
+}
+
+async function resolvePlatformApiJars(
+  project: ResolvedProject,
+  projectRegistries: string[],
+): Promise<string[]> {
+  const platforms = project.compatibility?.platforms ?? [];
+  const versions = project.compatibility?.versions ?? [];
+  if (platforms.length === 0 || versions.length === 0) return [];
+
+  let primary;
+  try {
+    primary = getPlatform(platforms[0]);
+  } catch {
+    return [];
+  }
+
+  const apiSpec = await primary.api(versions[0]);
+  if (apiSpec.dependencies.length === 0) return [];
+
+  const registries = dedupe([...apiSpec.repositories, ...projectRegistries]);
+
+  const jars: string[] = [];
+  for (const coord of apiSpec.dependencies) {
+    const resolved = await resolveMaven(coord.groupId, coord.artifactId, coord.version, {
+      rootDir: project.rootDir,
+      includePrerelease: false,
+      force: false,
+      registries,
+    });
+    jars.push(...flattenJars([resolved]));
+  }
+  return dedupe(jars);
+}
+
+function flattenJars(deps: ResolvedDependency[]): string[] {
+  const out: string[] = [];
+  const visit = (d: ResolvedDependency): void => {
+    out.push(d.jarPath);
+    for (const t of d.transitiveDeps) visit(t);
+  };
+  for (const d of deps) visit(d);
+  return out;
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function hasJavaSources(dir: string): Promise<boolean> {
+  async function walk(current: string): Promise<boolean> {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (await walk(full)) return true;
+      } else if (entry.isFile() && entry.name.endsWith(".java")) {
+        return true;
+      }
+    }
+    return false;
+  }
+  try {
+    return await walk(dir);
+  } catch {
+    return false;
+  }
+}

--- a/src/test/runner.test.ts
+++ b/src/test/runner.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for pure helpers in `src/test/runner.ts`. No I/O — every
+ * behavior here is input-output only.
+ */
+
+import { delimiter } from "node:path";
+
+import { describe, expect, test } from "vite-plus/test";
+
+import { buildLauncherArgs, filterToLauncherArgs, parseJUnitReports } from "./runner.ts";
+
+describe("buildLauncherArgs", () => {
+  test("emits jar, classpath, scan-class-path, reports-dir", () => {
+    const args = buildLauncherArgs({
+      consoleJar: "/cache/junit.jar",
+      classpath: ["/stage/test", "/stage/main", "/cache/dep.jar"],
+      testClassesDir: "/stage/test",
+      reportsDir: "/stage/reports",
+    });
+    expect(args[0]).toBe("-jar");
+    expect(args[1]).toBe("/cache/junit.jar");
+    expect(args[2]).toBe("execute");
+    expect(args).toContain("--disable-banner");
+    expect(args).toContain("--details=none");
+    expect(args).toContain(
+      `--class-path=/stage/test${delimiter}/stage/main${delimiter}/cache/dep.jar`,
+    );
+    expect(args).toContain("--scan-class-path=/stage/test");
+    expect(args).toContain("--reports-dir=/stage/reports");
+  });
+
+  test("--fail-fast only when requested", () => {
+    const without = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+    });
+    expect(without).not.toContain("--fail-fast");
+
+    const withFF = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+      failFast: true,
+    });
+    expect(withFF).toContain("--fail-fast");
+  });
+
+  test("propagates filter → launcher args", () => {
+    const args = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+      filter: "@tag:slow",
+    });
+    expect(args).toContain("--include-tag=slow");
+  });
+
+  test("tag filter keeps --scan-class-path (it's a filter, not a selector)", () => {
+    const args = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+      filter: "@tag:slow",
+    });
+    expect(args).toContain("--scan-class-path=/t");
+  });
+
+  test("method selector drops --scan-class-path (JUnit rejects scan + select)", () => {
+    const args = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+      filter: "com.example.FooTest#works",
+    });
+    expect(args).toContain("--select-method=com.example.FooTest#works");
+    expect(args.some((a) => a.startsWith("--scan-class-path"))).toBe(false);
+  });
+});
+
+describe("filterToLauncherArgs", () => {
+  test("@tag:<name> → --include-tag", () => {
+    expect(filterToLauncherArgs("@tag:slow")).toEqual(["--include-tag=slow"]);
+  });
+
+  test("Class#method → --select-method", () => {
+    expect(filterToLauncherArgs("com.example.FooTest#addsPlayer")).toEqual([
+      "--select-method=com.example.FooTest#addsPlayer",
+    ]);
+  });
+
+  test("Class#method containing * falls back to classname regex", () => {
+    // # + * is ambiguous; we treat it as a classname glob and let the user
+    // split if they really want a per-method regex.
+    const [arg] = filterToLauncherArgs("Foo#bar*");
+    expect(arg.startsWith("--include-classname=")).toBe(true);
+  });
+
+  test("plain classname glob → regex with * → .*", () => {
+    expect(filterToLauncherArgs("com.example.*Test")).toEqual([
+      "--include-classname=^com\\.example\\..*Test$",
+    ]);
+  });
+
+  test("classname with only literal chars is anchored and escaped", () => {
+    expect(filterToLauncherArgs("com.example.FooTest")).toEqual([
+      "--include-classname=^com\\.example\\.FooTest$",
+    ]);
+  });
+});
+
+describe("parseJUnitReports", () => {
+  test("empty input → zero totals", () => {
+    const r = parseJUnitReports([]);
+    expect(r).toEqual({ total: 0, passed: 0, failed: 0, skipped: 0, cases: [] });
+  });
+
+  test("single passing case", () => {
+    const xml = `<?xml version="1.0"?>
+<testsuite name="FooTest" tests="1" failures="0">
+  <testcase name="works" classname="com.example.FooTest" time="0.012" />
+</testsuite>`;
+    const r = parseJUnitReports([xml]);
+    expect(r.total).toBe(1);
+    expect(r.passed).toBe(1);
+    expect(r.failed).toBe(0);
+    expect(r.cases[0]).toEqual({
+      suite: "com.example.FooTest",
+      name: "works",
+      durationMs: 12,
+      status: "passed",
+      message: undefined,
+      stackTrace: undefined,
+    });
+  });
+
+  test("failure case captures message and stack trace", () => {
+    const xml = `<?xml version="1.0"?>
+<testsuite name="BarTest">
+  <testcase name="breaks" classname="com.example.BarTest" time="0.003">
+    <failure message="expected: &quot;a&quot; but was: &quot;b&quot;" type="AssertionError">at com.example.BarTest.breaks(BarTest.java:42)</failure>
+  </testcase>
+</testsuite>`;
+    const r = parseJUnitReports([xml]);
+    expect(r.failed).toBe(1);
+    expect(r.cases[0].status).toBe("failed");
+    expect(r.cases[0].message).toBe('expected: "a" but was: "b"');
+    expect(r.cases[0].stackTrace).toContain("at com.example.BarTest.breaks");
+  });
+
+  test("<error> counts as failure", () => {
+    const xml = `<?xml version="1.0"?>
+<testsuite>
+  <testcase name="crashes" classname="com.example.CrashTest" time="0">
+    <error message="boom" type="NullPointerException" />
+  </testcase>
+</testsuite>`;
+    const r = parseJUnitReports([xml]);
+    expect(r.failed).toBe(1);
+    expect(r.cases[0].message).toBe("boom");
+  });
+
+  test("<skipped /> → skipped", () => {
+    const xml = `<?xml version="1.0"?>
+<testsuite>
+  <testcase name="later" classname="com.example.X" time="0">
+    <skipped />
+  </testcase>
+</testsuite>`;
+    const r = parseJUnitReports([xml]);
+    expect(r.skipped).toBe(1);
+    expect(r.cases[0].status).toBe("skipped");
+  });
+
+  test("aggregates multiple docs + mixed statuses", () => {
+    const a = `<testsuite>
+  <testcase name="p" classname="A" time="0.001" />
+  <testcase name="f" classname="A" time="0.002"><failure message="x">trace</failure></testcase>
+</testsuite>`;
+    const b = `<testsuite>
+  <testcase name="s" classname="B" time="0"><skipped /></testcase>
+</testsuite>`;
+    const r = parseJUnitReports([a, b]);
+    expect(r).toMatchObject({ total: 3, passed: 1, failed: 1, skipped: 1 });
+    expect(r.cases.map((c) => c.suite)).toEqual(["A", "A", "B"]);
+  });
+});

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -1,0 +1,207 @@
+/**
+ * Pure helpers for the test runner: JUnit Console Launcher argument
+ * assembly, `--filter` translation, and JUnit-XML report parsing. No I/O —
+ * callers in `./index.ts` spawn the JVM and read the reports directory.
+ */
+
+import { delimiter } from "node:path";
+
+export interface LauncherArgs {
+  /** Absolute path to junit-platform-console-standalone jar. */
+  consoleJar: string;
+  /** Every entry that should be on the JVM classpath. */
+  classpath: string[];
+  /** Directory whose compiled classes are scanned for tests. */
+  testClassesDir: string;
+  /** Where JUnit should write XML reports. */
+  reportsDir: string;
+  /** User filter (see `parseFilter`). */
+  filter?: string;
+  /** Stop on first failure. */
+  failFast?: boolean;
+}
+
+export interface TestCase {
+  /** Fully-qualified class name (e.g. `com.example.FooTest`). */
+  suite: string;
+  /** Method name (e.g. `addsPlayer`). */
+  name: string;
+  durationMs: number;
+  status: "passed" | "failed" | "skipped";
+  message?: string;
+  stackTrace?: string;
+}
+
+export interface TestRunResult {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  cases: TestCase[];
+}
+
+/**
+ * Assemble the argv for `java -jar junit-platform-console-standalone …`.
+ * Caller prepends `java` and spawns.
+ */
+export function buildLauncherArgs(args: LauncherArgs): string[] {
+  const filterArgs = args.filter === undefined ? [] : filterToLauncherArgs(args.filter);
+  // ConsoleLauncher refuses `--scan-class-path` combined with any `--select-*`
+  // argument ("Scanning the classpath and using explicit selectors at the same
+  // time is not supported"). Drop the scan directive when a selector is present —
+  // the selector does its own discovery against `--class-path`.
+  const hasSelector = filterArgs.some((a) => a.startsWith("--select-"));
+
+  const out: string[] = [
+    "-jar",
+    args.consoleJar,
+    // `execute` is the explicit subcommand; newer standalone jars warn without it.
+    "execute",
+    "--disable-banner",
+    "--details=none",
+    `--class-path=${args.classpath.join(delimiter)}`,
+  ];
+  if (!hasSelector) {
+    out.push(`--scan-class-path=${args.testClassesDir}`);
+  }
+  out.push(`--reports-dir=${args.reportsDir}`);
+  if (args.failFast === true) {
+    out.push("--fail-fast");
+  }
+  out.push(...filterArgs);
+  return out;
+}
+
+/**
+ * Translate pluggy's user-facing `--filter <pattern>` into JUnit Console
+ * Launcher arguments.
+ *
+ *   @tag:<name>     → --include-tag=<name>
+ *   Class#method    → --select-method=Class#method
+ *   <classname>     → --include-classname=<regex>  (glob * → .*, other chars escaped)
+ */
+export function filterToLauncherArgs(filter: string): string[] {
+  if (filter.startsWith("@tag:")) {
+    const tag = filter.slice("@tag:".length);
+    return [`--include-tag=${tag}`];
+  }
+  if (filter.includes("#") && !filter.includes("*")) {
+    return [`--select-method=${filter}`];
+  }
+  return [`--include-classname=${globToRegex(filter)}`];
+}
+
+/**
+ * Parse every `TEST-*.xml` file's content into a flat `TestRunResult`.
+ * Input is the array of XML document strings — the caller reads the
+ * directory. Empty input produces a zero-total result.
+ */
+export function parseJUnitReports(xmlDocs: string[]): TestRunResult {
+  const cases: TestCase[] = [];
+  for (const xml of xmlDocs) {
+    for (const entry of parseSuite(xml)) {
+      cases.push(entry);
+    }
+  }
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const c of cases) {
+    if (c.status === "passed") passed += 1;
+    else if (c.status === "failed") failed += 1;
+    else skipped += 1;
+  }
+  return { total: cases.length, passed, failed, skipped, cases };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function parseSuite(xml: string): TestCase[] {
+  const cases: TestCase[] = [];
+  const caseBlocks = xml.match(/<testcase\b[\s\S]*?(?:\/>|<\/testcase>)/g);
+  if (caseBlocks === null) return cases;
+
+  for (const block of caseBlocks) {
+    const suite = readAttr(block, "classname") ?? "";
+    const name = readAttr(block, "name") ?? "";
+    const timeRaw = readAttr(block, "time");
+    const durationMs = timeRaw !== undefined ? Math.round(Number.parseFloat(timeRaw) * 1000) : 0;
+
+    let status: TestCase["status"] = "passed";
+    let message: string | undefined;
+    let stackTrace: string | undefined;
+
+    const failure = extractChild(block, "failure") ?? extractChild(block, "error");
+    if (failure !== undefined) {
+      status = "failed";
+      message = decodeEntities(failure.attrs.message ?? "");
+      stackTrace = failure.body.trim().length > 0 ? decodeEntities(failure.body).trim() : undefined;
+    } else if (extractChild(block, "skipped") !== undefined) {
+      status = "skipped";
+    }
+
+    cases.push({ suite, name, durationMs, status, message, stackTrace });
+  }
+  return cases;
+}
+
+function readAttr(tag: string, attr: string): string | undefined {
+  const m = tag.match(new RegExp(`\\b${attr}="([^"]*)"`));
+  return m === null ? undefined : m[1];
+}
+
+function extractChild(
+  block: string,
+  tagName: string,
+): { attrs: Record<string, string>; body: string } | undefined {
+  // Matches either <tag ... /> or <tag ...>body</tag>.
+  const selfClose = new RegExp(`<${tagName}\\b([^>]*)\\/>`);
+  const paired = new RegExp(`<${tagName}\\b([^>]*)>([\\s\\S]*?)<\\/${tagName}>`);
+  const paired_m = block.match(paired);
+  if (paired_m !== null) {
+    return { attrs: parseAttrs(paired_m[1]), body: paired_m[2] };
+  }
+  const self_m = block.match(selfClose);
+  if (self_m !== null) {
+    return { attrs: parseAttrs(self_m[1]), body: "" };
+  }
+  return undefined;
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const rx = /(\w+)="([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(raw)) !== null) {
+    out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#10;/g, "\n")
+    .replace(/&#13;/g, "\r")
+    .replace(/&#9;/g, "\t")
+    .replace(/&amp;/g, "&");
+}
+
+function globToRegex(pattern: string): string {
+  let out = "";
+  for (const ch of pattern) {
+    if (ch === "*") {
+      out += ".*";
+    } else if (/[.+?^${}()|[\]\\]/.test(ch)) {
+      out += `\\${ch}`;
+    } else {
+      out += ch;
+    }
+  }
+  return `^${out}$`;
+}


### PR DESCRIPTION
## Summary

- Adds a new `pluggy test` command that compiles project sources and runs JUnit tests via the platform launcher (`src/commands/test.ts`, `src/test/index.ts`, `src/test/runner.ts`).
- Introduces a `testDependencies` field on `Project` and wires the command into `src/index.ts`. Includes contract tests for both the command and the runner.
- Reflows table formatting in `docs/commands/build.md`, `doctor.md`, and `init.md`.

## Test plan

- [ ] `vp check` passes
- [ ] `vp test` passes (including new `src/commands/test.test.ts` and `src/test/runner.test.ts`)
- [ ] `pluggy test` runs against a sample project end-to-end and emits valid `--json` output