### PR TITLE
fix(init): pick a version the user's Java can build, isolate proxy platforms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something in pluggy isn't behaving the way it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Please search [existing issues](https://github.com/ch99q/pluggy/issues?q=is%3Aissue) before submitting.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+      placeholder: "`pluggy build` fails with X when Y."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Exact commands, starting from a clean directory, that reproduce the issue. Include any relevant `project.json` or flags.
+      render: shell
+      placeholder: |
+        pluggy init --yes --platform velocity my-plugin
+        cd my-plugin
+        pluggy build
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the relevant error output. Trim long stack traces to the meaningful frames.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: pluggy-version
+    attributes:
+      label: pluggy version
+      description: Output of `pluggy --version`. If you're on a development build, paste the commit SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: pluggy doctor output
+      description: Run `pluggy doctor` and paste the output. This captures Java version, OS, and toolchain state.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing — workarounds you tried, related issues, links to the failing CI run, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an enhancement to pluggy's CLI, build, dev server, or platform support.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search [existing issues](https://github.com/ch99q/pluggy/issues?q=is%3Aissue) before submitting — feature requests are often already tracked.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the user-facing problem you're hitting? Describe the situation, not the proposed fix.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like pluggy to behave? Include CLI shapes, `project.json` fields, or output examples where useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why they fall short.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Links to upstream issues, related PRs, prior art in other tools, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- 1-5 bullets covering what changed and why. Link related issues with `Closes #123`. -->
+
+## Test plan
+
+<!-- Checklist of what was verified. Include automated checks AND any manual verification (CLI exercised in `playground/`, dev server smoke-tested, etc.). -->
+
+- [ ] `vp test`
+- [ ] `vp lint`
+- [ ] Manual:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,15 @@ Tests live next to the code they cover as `*.test.ts`. Network-dependent tests (
 
 `playground/` at the repo root is gitignored and exists for ad-hoc manual testing of the CLI — building the binary with `bun build --compile --outfile=bin/pluggy ./src/index.ts`, then running `pluggy init`, `pluggy build`, `pluggy dev`, etc. against a scratch project to verify the actual user experience. Use it whenever a change has a UX surface that the test suite can't cover (interactive prompts, error formatting, generated `project.json` shape, BuildTools output, dev server startup). Create subdirectories per scenario (`playground/spigot-1.21/`, `playground/cross-family/`, …) and feel free to leave them around — nothing in `playground/` is committed.
 
+### Filing issues for bugs you stumble across
+
+When you spot a bug that isn't in scope for the current task — typically while exercising the CLI in `playground/` or while reviewing unrelated code — log it as a GitHub issue so it doesn't get forgotten. The workflow:
+
+1. Search first: `gh issue list --search "<keywords>" --state all`. Try a couple of phrasings (the symptom, the affected command, the affected file) before assuming it's new.
+2. If no match, surface it to the human: describe the bug, the reproduction, and a draft body, then ask whether to file. Don't open issues unprompted.
+3. On approval, file with `gh issue create --title "…" --label bug --body "…"`. Match the bug-report template's sections (Summary / Reproduction / Expected / Actual / pluggy version / `pluggy doctor` output / Additional context) — `gh issue create` doesn't auto-apply YAML form templates, so reproduce the structure in the body. Templates live in `.github/ISSUE_TEMPLATE/`.
+4. For a bug found while finishing a PR, link the issue from the PR description so the connection is visible without searching.
+
 ### CLI conventions
 
 - Every command lives in `src/commands/<name>.ts` and exports a factory `xxxCommand()` that returns a `Command` (from `commander`). `src/index.ts` imports the factories and calls `program.addCommand()` — keep `index.ts` thin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ test("spigot platform is registered", () => {
 
 Tests live next to the code they cover as `*.test.ts`. Network-dependent tests (platform `download`, `getVersions`) hit real upstream APIs intentionally — do not mock them.
 
+### Manual testing & the `playground/` folder
+
+`playground/` at the repo root is gitignored and exists for ad-hoc manual testing of the CLI — building the binary with `bun build --compile --outfile=bin/pluggy ./src/index.ts`, then running `pluggy init`, `pluggy build`, `pluggy dev`, etc. against a scratch project to verify the actual user experience. Use it whenever a change has a UX surface that the test suite can't cover (interactive prompts, error formatting, generated `project.json` shape, BuildTools output, dev server startup). Create subdirectories per scenario (`playground/spigot-1.21/`, `playground/cross-family/`, …) and feel free to leave them around — nothing in `playground/` is committed.
+
 ### CLI conventions
 
 - Every command lives in `src/commands/<name>.ts` and exports a factory `xxxCommand()` that returns a `Command` (from `commander`). `src/index.ts` imports the factories and calls `program.addCommand()` — keep `index.ts` thin.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -14,15 +14,15 @@ against `process.cwd()`.
 
 ## Flags
 
-| Flag                    | Default                       | Notes                                                                                                             |
-| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`         | basename of target dir        | Must match `^[a-zA-Z0-9_-]+$`.                                                                                    |
-| `--version <semver>`    | `1.0.0`                       | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                                     |
-| `--description <text>`  | `"A simple Minecraft plugin"` | Free-form.                                                                                                        |
-| `--main <fqcn>`         | `com.example.Main`            | Must be a Java classpath — at least `package.Class`.                                                              |
-| `--platform <id>`       | `paper`                       | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`. Repeatable. |
-| `--mc-version <semver>` | highest common across targets | Minecraft version written to `compatibility.versions[0]`. See below.                                              |
-| `-y, --yes`             | off                           | Skip confirmations. Always on under `--json`.                                                                     |
+| Flag                    | Default                           | Notes                                                                                                                                                                           |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`         | basename of target dir            | Must match `^[a-zA-Z0-9_-]+$`.                                                                                                                                                  |
+| `--version <semver>`    | `1.0.0`                           | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                                                                                                   |
+| `--description <text>`  | `"A simple Minecraft plugin"`     | Free-form.                                                                                                                                                                      |
+| `--main <fqcn>`         | `com.example.Main`                | Must be a Java classpath — at least `package.Class`.                                                                                                                            |
+| `--platform <id>`       | `paper`                           | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`. Repeatable, but must stay within one descriptor family (see error cases). |
+| `--mc-version <semver>` | highest compatible across targets | Minecraft version written to `compatibility.versions[0]`. Accepts both the legacy `1.21.8` shape and Mojang's new calendar scheme (`26.1.2`). See below.                        |
+| `-y, --yes`             | off                               | Skip confirmations. Always on under `--json`.                                                                                                                                   |
 
 The `--version` here refers to the plugin's own `project.version`. The
 Minecraft version lives at `compatibility.versions[0]` and is set by
@@ -31,11 +31,23 @@ Minecraft version lives at `compatibility.versions[0]` and is set by
 When `--mc-version` is omitted, pluggy calls `getVersions()` on every
 selected platform in parallel, intersects the results, and picks the
 highest version that every target publishes. That way a multi-platform
-init (e.g. `paper + spigot`) can never pick a Paper-only release. If the
-intersection is empty, init errors with "No compatible Minecraft version
-found across platforms: …" and suggests either dropping platforms or
-passing `--mc-version` explicitly. Expect a short network wait on first
-run.
+init (e.g. `paper + spigot`) can never pick a Paper-only release.
+
+When `spigot` or `bukkit` is in the target set, init additionally skips
+any candidate whose declared `javaVersions` range excludes the JDK on
+`PATH` — otherwise BuildTools would pick up a Minecraft release it can't
+actually decompile (e.g. `26.1.2` requires Java 25+). The newest version
+your Java can compile wins.
+
+All platforms, including `velocity`, surface Minecraft versions here —
+the `velocity-api` Maven coordinate is resolved internally to the latest
+stable Velocity release, so `compatibility.versions` stays a single
+MC-version vocabulary across the whole project.
+
+If the intersection is empty, init errors with "No compatible Minecraft
+version found across platforms: …" and suggests either dropping
+platforms or passing `--mc-version` explicitly. Expect a short network
+wait on first run.
 
 ## Files produced
 
@@ -104,14 +116,15 @@ Project "example" initialized successfully at /tmp/example
 
 ## Error cases
 
-| Trigger                           | Message                                                                                                                                             |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Invalid `--name`                  | `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`                                               |
-| Invalid `--main`                  | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                                                         |
-| Unknown `--platform`              | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine`                                       |
-| No MC version common to platforms | `No compatible Minecraft version found across platforms: <list>. Try selecting fewer platforms or specifying a version manually with --mc-version.` |
-| Non-empty target dir (no `-y`)    | Interactive confirm; "no" aborts with `Aborted.`                                                                                                    |
-| Existing project dir (no `-y`)    | As above.                                                                                                                                           |
+| Trigger                           | Message                                                                                                                                                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid `--name`                  | `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`                                                                                                                            |
+| Invalid `--main`                  | `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`                                                                                                                                      |
+| Unknown `--platform`              | `Invalid platform: "<p>". Available platforms: paper, folia, spigot, bukkit, velocity, waterfall, travertine`                                                                                                                    |
+| Cross-family platforms            | `Platform "<b>" cannot be combined with "<a>" — they target different plugin families ("<a>" writes "<path-a>", "<b>" writes "<path-b>"). Proxy platforms like velocity, waterfall, and travertine each need their own project.` |
+| No MC version common to platforms | `No compatible Minecraft version found across platforms: <list>. Try selecting fewer platforms or specifying a version manually with --mc-version.`                                                                              |
+| Non-empty target dir (no `-y`)    | Interactive confirm; "no" aborts with `Aborted.`                                                                                                                                                                                 |
+| Existing project dir (no `-y`)    | As above.                                                                                                                                                                                                                        |
 
 Network failures during `getVersions()` propagate from the platform
 provider — see [Troubleshooting](../troubleshooting.md#network-errors-during-init-or-dev).

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -131,9 +131,13 @@ the array by hand to add or remove editors later.
 }
 ```
 
-- `versions` — non-empty array. The first entry is the primary version; it
-  drives the platform API download, `api-version` in the Bukkit descriptor,
-  and the JDK picker for IntelliJ.
+- `versions` — non-empty array of Minecraft versions. Both the legacy
+  `1.21.8` shape and Mojang's 2026 calendar scheme (`26.1.2`) are accepted.
+  The first entry is the primary version; it drives the platform API
+  download, `api-version` in the Bukkit descriptor, and the JDK picker for
+  IntelliJ. For `velocity`, this still reads as an MC version — pluggy
+  resolves the actual `velocity-api` Maven coordinate internally to the
+  latest stable Velocity release.
 - `platforms` — non-empty array. The first entry is the primary platform.
   Every platform in the array must share the same descriptor family (same
   `plugin.yml` vs `bungee.yml` vs `velocity-plugin.json` target) — mixing
@@ -153,9 +157,16 @@ The full platform roster ships with the binary:
 | `travertine` | `bungee.yml`           | (no Maven API — compile against waterfall) |
 
 Paper handles version strings in two formats. For 1.17 – 1.21.x the artifact
-is `<version>-R0.1-SNAPSHOT`; for 26.x and later it's `<version>.build.<N>-alpha`.
-pluggy fetches PaperMC's `maven-metadata.xml` and picks the highest matching
-entry, so you write the plain MC version and pluggy works out the rest.
+is `<version>-R0.1-SNAPSHOT`; for 26.x and later (Mojang's calendar scheme —
+26.1, 26.1.1, 26.1.2) it's `<version>.build.<N>-alpha`. pluggy fetches
+PaperMC's `maven-metadata.xml` and picks the highest matching entry, so you
+write the plain MC version and pluggy works out the rest.
+
+Spigot and Bukkit go through BuildTools, which decompiles the Mojang
+server jar using the JDK on `PATH`. Different Minecraft releases require
+different Java versions (MC 1.21.x allows Java 21 – 26; MC 26.1.x requires
+Java 25 – 26). `pluggy init` reads each candidate's manifest and won't pin
+your project to a version your Java can't actually compile.
 
 ### `registries` (optional)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,11 +28,28 @@ is offline or the upstream is down:
 ### `No compatible Minecraft version found across platforms: <list>.`
 
 pluggy couldn't find a Minecraft version that every selected platform
-publishes. Common causes: mixing a Spigot-only codebase with Paper 26.x
-(Spigot hasn't cut that version yet), or selecting Velocity alongside
-Paper (different release cadences). Either drop the platform that's
-lagging, split the project into per-family workspaces, or pin the
-version yourself with `--mc-version`.
+publishes. Most often this is a short-lived gap where one provider
+publishes a new release before another (e.g. Paper ships `26.1.2` hours
+or days before Spigot's BuildTools catches up). Either drop the platform
+that's lagging, or pin the version yourself with `--mc-version`.
+
+### `Platform "<b>" cannot be combined with "<a>" — they target different plugin families …`
+
+`--platform` was given values from two different descriptor families
+(e.g. `paper` + `velocity`). A single plugin jar can only target one
+family — server plugins (`paper`, `folia`, `spigot`, `bukkit`), BungeeCord
+proxy plugins (`waterfall`, `travertine`), or Velocity plugins. Re-run
+init for the second family in a sibling directory, or split an existing
+monorepo using [workspaces](./workspaces.md#multi-family-monorepos).
+
+### BuildTools fails mid-init / `pluggy dev` on a freshly scaffolded spigot project
+
+`pluggy init` reads each MC version's declared Java range from Spigot's
+manifest and skips releases your JDK can't decompile. If you still see a
+BuildTools decompile error (typically `FileNotFoundException … DataComponentPatch.java`),
+either upgrade your JDK (Mojang's 26.x line needs Java 25+) or pin a
+version that fits your current Java with `--mc-version 1.21.11` (or
+similar).
 
 `pluggy dev` also hits the platform registry for the server jar. The
 first run per `(platform, version)` needs network; subsequent runs

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -235,7 +235,9 @@ my-network/
 
 Each workspace keeps its own descriptor family. The root's inherited
 `compatibility` is overridden by `proxy` with its own
-`{ "versions": ["3.4.0"], "platforms": ["velocity"] }`. `pluggy build`
+`{ "versions": ["1.21.11"], "platforms": ["velocity"] }` — `versions`
+is always a Minecraft version, even for proxy platforms; the
+`velocity-api` Maven coordinate is resolved internally. `pluggy build`
 produces one jar per workspace.
 
 If you'd tried to put paper + velocity in a single workspace's

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,10 +10,12 @@ import defaultConfig from "../defaults/config.yml" with { type: "text" };
 import defaultPackage from "../defaults/package.java" with { type: "text" };
 
 import { getPlatform, getRegisteredPlatforms } from "../platform/index.ts";
+import { getJavaRange } from "../platform/spigot/buildtools.ts";
 import { bold, dim, log } from "../logging.ts";
 import { getCurrentProject, type Project, resolveProjectFile } from "../project.ts";
 import { replace } from "../template.ts";
 
+import { getJavaMajor } from "./doctor.ts";
 import { parseMcVersion, parsePlatform, parseSemver } from "./parsers.ts";
 
 /**
@@ -64,6 +66,30 @@ export async function generateProject(distDir: string, project: Project): Promis
   } catch (e) {
     throw new Error(`Failed to write main class file: ${(e as Error).message}`);
   }
+}
+
+/**
+ * Pick the newest version from `candidates` that the user's installed Java
+ * can compile. Spigot/Bukkit run BuildTools locally, which silently fails
+ * (e.g. decompile output missing) when the Minecraft version's `javaVersions`
+ * window excludes the user's JDK — so we probe the first few candidates and
+ * skip any whose declared range doesn't include `javaMajor`. Falls through
+ * to `candidates[0]` when Java can't be detected or no metadata is usable.
+ */
+async function pickCompatibleVersion(candidates: string[], platforms: string[]): Promise<string> {
+  const fallback = candidates[0];
+  if (!platforms.includes("spigot") && !platforms.includes("bukkit")) return fallback;
+
+  const javaMajor = await getJavaMajor().catch(() => undefined);
+  if (javaMajor === undefined) return fallback;
+
+  for (const candidate of candidates.slice(0, 10)) {
+    const range = await getJavaRange(candidate);
+    if (range === undefined) continue;
+    const [minJava, maxJava] = range;
+    if (javaMajor >= minJava && javaMajor <= maxJava) return candidate;
+  }
+  return fallback;
 }
 
 function deriveClassName(name: string): string {
@@ -172,6 +198,16 @@ export function initCommand(): Command {
               })
             : ["paper"];
 
+      const primaryPath = getPlatform(platforms[0]).descriptor.path;
+      const alien = platforms.find((p) => getPlatform(p).descriptor.path !== primaryPath);
+      if (alien) {
+        throw new InvalidArgumentError(
+          `Platform "${alien}" cannot be combined with "${platforms[0]}" — they target different plugin families ` +
+            `("${platforms[0]}" writes "${primaryPath}", "${alien}" writes "${getPlatform(alien).descriptor.path}"). ` +
+            `Proxy platforms like velocity, waterfall, and travertine each need their own project.`,
+        );
+      }
+
       // Main class
       const className = deriveClassName(projectName) || "Main";
       const derivedMain = `com.example.${className}`;
@@ -222,7 +258,7 @@ export function initCommand(): Command {
               `Try selecting fewer platforms or specifying a version manually with --mc-version.`,
           );
         }
-        versions = [common[0]];
+        versions = [await pickCompatibleVersion(common, platforms)];
       }
 
       const INITIAL_PROJECT: Project = {

--- a/src/platform/papermc/velocity.test.ts
+++ b/src/platform/papermc/velocity.test.ts
@@ -7,15 +7,27 @@ test("velocity platform exists", () => {
   expect(() => getPlatform("@Velocity")).toThrow("Platform with id '@Velocity' not found");
 });
 
-test("velocity platform versions", async () => {
+test("velocity platform versions surface MC versions, not velocity-api versions", async () => {
   const velocity = getPlatform("velocity");
   const versions = await velocity.getVersions();
   expect(Array.isArray(versions)).toBe(true);
-  expect(versions).toEqual(expect.arrayContaining(["3.1.1", "3.1.0", "1.1.9"]));
-  expect(versions.length).toBeGreaterThan(0);
+  expect(versions).toEqual(expect.arrayContaining(["1.21.8", "1.20.6", "1.20.4"]));
+  expect(versions.every((v) => /^\d+\.\d+/.test(v))).toBe(true);
+  expect(versions.some((v) => v.includes("SNAPSHOT"))).toBe(false);
 
   const latest = await velocity.getLatestVersion();
   expect(latest.version).toBe(versions[0]);
+});
+
+test("velocity api coordinate resolves to a velocity-api release, not the MC input", async () => {
+  const velocity = getPlatform("velocity");
+  const api = await velocity.api("1.21.8");
+  expect(api.dependencies).toHaveLength(1);
+  const [dep] = api.dependencies;
+  expect(dep.groupId).toBe("com.velocitypowered");
+  expect(dep.artifactId).toBe("velocity-api");
+  expect(dep.version).not.toBe("1.21.8");
+  expect(dep.version).toMatch(/^\d+\.\d+\.\d+/);
 });
 
 test("velocity platform download latest version", async () => {

--- a/src/platform/papermc/velocity.ts
+++ b/src/platform/papermc/velocity.ts
@@ -56,7 +56,11 @@ export default createPlatform((ctx) => ({
   async download(version: Version, ignoreCache = false) {
     const CACHE_PATH = ctx.getCachePath();
     const release = await latestVelocityRelease();
-    const JAR_PATH = join(CACHE_PATH, "versions", `velocity-${release.id}-${release.build}.jar`);
+    const JAR_PATH = join(
+      CACHE_PATH,
+      "versions",
+      `velocity-${version.version}-${release.build}.jar`,
+    );
 
     if (existsSync(JAR_PATH) && !ignoreCache) {
       return {

--- a/src/platform/papermc/velocity.ts
+++ b/src/platform/papermc/velocity.ts
@@ -6,59 +6,71 @@ import { velocityDescriptor } from "../descriptor/velocity.ts";
 import { createPlatform, type Version } from "../platform.ts";
 import * as papermc from "./papermc.ts";
 
+/**
+ * Velocity is a proxy, not a server — a plugin built against
+ * `velocity-api:3.4.0` works with any Minecraft protocol the running proxy
+ * supports. Pluggy's `compatibility.versions` field represents Minecraft
+ * versions across the whole tool, though, so this provider surfaces MC
+ * versions (borrowed from Paper's list) to the user and resolves the
+ * actual `velocity-api` coordinate internally when downloading or
+ * generating Maven deps.
+ */
+async function latestVelocityRelease(): Promise<{ id: string; build: number }> {
+  const list = await papermc.versions("velocity");
+  if (list.length === 0) throw new Error("No velocity releases found");
+  const stable = list.find((v) => !v.version.id.endsWith("-SNAPSHOT")) ?? list[0];
+  return { id: stable.version.id, build: stable.builds[0] };
+}
+
 export default createPlatform((ctx) => ({
   id: "velocity",
   descriptor: velocityDescriptor,
 
-  async getVersionInfo(version: string): Promise<Version> {
-    const versionsList = await papermc.versions("velocity");
-    const versionInfo = versionsList.find((v) => v.version.id === version);
-    if (!versionInfo) throw new Error(`Failed to fetch version info for ${version}`);
-    return { version, build: versionInfo.builds[0] };
+  async getVersions(): Promise<string[]> {
+    const mc = await papermc.versions("paper");
+    return mc.map((v) => v.version.id);
+  },
+
+  async getVersionInfo(mcVersion: string): Promise<Version> {
+    const release = await latestVelocityRelease();
+    return { version: mcVersion, build: release.build };
   },
 
   async getLatestVersion(): Promise<Version> {
-    const versionsList = await papermc.versions("velocity");
-    if (versionsList.length === 0) throw new Error("No versions found for velocity");
-    const latestVersion = versionsList[0];
-    return { version: latestVersion.version.id, build: latestVersion.builds[0] };
+    const mc = await papermc.versions("paper");
+    if (mc.length === 0) throw new Error("No versions found for velocity");
+    const release = await latestVelocityRelease();
+    return { version: mc[0].version.id, build: release.build };
   },
 
-  async getVersions(): Promise<string[]> {
-    const versionsList = await papermc.versions("velocity");
-    return versionsList.map((v) => v.version.id);
-  },
-
-  api(version) {
-    return Promise.resolve({
+  async api(_mcVersion) {
+    const release = await latestVelocityRelease();
+    return {
       repositories: ["https://repo.papermc.io/repository/maven-public/"],
       dependencies: [
-        { groupId: "com.velocitypowered", artifactId: "velocity-api", version: `${version}` },
+        { groupId: "com.velocitypowered", artifactId: "velocity-api", version: release.id },
       ],
-    });
+    };
   },
 
   async download(version: Version, ignoreCache = false) {
     const CACHE_PATH = ctx.getCachePath();
-    const JAR_PATH = join(
-      CACHE_PATH,
-      "versions",
-      `velocity-${version.version}-${version.build}.jar`,
-    );
+    const release = await latestVelocityRelease();
+    const JAR_PATH = join(CACHE_PATH, "versions", `velocity-${release.id}-${release.build}.jar`);
 
     if (existsSync(JAR_PATH) && !ignoreCache) {
       return {
         version: version.version,
-        build: version.build,
+        build: release.build,
         output: new Uint8Array(readFileSync(JAR_PATH)),
       };
     }
 
-    const result = await papermc.download("velocity", version.version, version.build);
+    const result = await papermc.download("velocity", release.id, release.build);
     const output = new Uint8Array(result.output);
 
     await mkdir(join(CACHE_PATH, "versions"), { recursive: true });
     await writeFile(JAR_PATH, output);
-    return { version: result.version, build: result.build, output };
+    return { version: version.version, build: release.build, output };
   },
 }));

--- a/src/platform/spigot/buildtools.ts
+++ b/src/platform/spigot/buildtools.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { classMajorToJava } from "../../jar.ts";
 import type { PlatformContext } from "../platform.ts";
 
 const BUILDTOOLS_URL =
@@ -134,6 +135,40 @@ export async function compile(
     },
     stream,
   };
+}
+
+/**
+ * Fetch a version's manifest from Spigot's hub and return the Java major
+ * release range it declares (`javaVersions` is a class-file major range,
+ * e.g. `[65, 70]` meaning Java 21 — 26). Returns `undefined` when the
+ * manifest is missing, malformed, omits `javaVersions`, or the request
+ * fails for any reason — `init` treats this as "unknown, fall through"
+ * rather than a hard error, so this function never throws.
+ *
+ * A 5s abort guards against the OS-level TCP timeout (~75s) when Spigot's
+ * hub is unreachable; without it init would hang per probed candidate.
+ */
+export async function getJavaRange(version: string): Promise<[number, number] | undefined> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 5000);
+  let data: unknown;
+  try {
+    const res = await fetch(`${VERSIONS_URL}${version}.json`, { signal: ctrl.signal });
+    if (!res.ok) return undefined;
+    data = await res.json();
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (data === null || typeof data !== "object") return undefined;
+  const range = (data as { javaVersions?: unknown }).javaVersions;
+  if (!Array.isArray(range)) return undefined;
+  const min = range[0];
+  const max = range[range.length - 1];
+  if (typeof min !== "number" || typeof max !== "number") return undefined;
+  return [classMajorToJava(min), classMajorToJava(max)];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Init now picks the newest MC version the local JDK can compile by reading each Spigot version manifest's `javaVersions` range — no more BuildTools `DataComponentPatch.java` crashes on the 26.x rollout.
- Init rejects mixed descriptor families (e.g. `spigot` + `velocity`) up front instead of silently writing an unbuildable `project.json` and failing later at build time.
- Velocity now reports MC versions through `getVersions`/`getLatestVersion`/`getVersionInfo` so `compatibility.versions` stays a single MC-version vocabulary across every platform; the `velocity-api` Maven coordinate is resolved to the latest stable Velocity release internally.
- New `getJavaRange()` helper in `buildtools.ts` is hardened with a 5s abort, full error swallowing, and `classMajorToJava` for the major→release conversion, so a flaky Spigot hub can never hang or throw out of init.
- Docs (`init.md`, `project-json.md`, `troubleshooting.md`, `workspaces.md`) updated to cover Mojang's 2026 calendar scheme (`26.1.x`), the new cross-family init error, and velocity's MC-version semantics.

## Test plan

- [x] `vp test` — 346 passed | 3 skipped
- [x] `vp lint` clean
- [x] Manual: `pluggy init --platform spigot` on Java 21 picks `1.21.11` (skipping `26.1.2`)
- [x] Manual: `pluggy init --platform spigot --platform velocity` fails immediately with the cross-family error
- [x] Manual: `pluggy init --platform velocity` writes an MC version to `compatibility.versions`, and `pluggy build` resolves `velocity-api` to a real Velocity release

## Related

- Spotted during manual verification (out of scope for this PR): #9 — generated boilerplate hardcodes Bukkit `JavaPlugin` even for proxy-only platforms.