### PR TITLE
feat(upgrade): sudo-less install and subtle update-check banner

### DIFF
--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -26,6 +26,7 @@ the exit code.
 | `workspace`           | Workspace graph         | Cycle detected in `workspace:` deps.                               | —                                                                                                                                       |
 | `descriptor (<name>)` | Descriptor family       | `pickDescriptor` throws (unknown platform, mixed families).        | —                                                                                                                                       |
 | `outdated`            | Outdated dependencies   | —                                                                  | Any Modrinth dep has a newer stable version, or any Modrinth query failed.                                                              |
+| `pluggy-version`      | Pluggy version          | —                                                                  | A newer release is available on GitHub, or the latest release couldn't be reached.                                                      |
 
 ### Environment checks
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -43,7 +43,7 @@ install instructions and exits clean.
 $ pluggy upgrade
 Upgrading to: v0.2.0
 downloading https://github.com/ch99q/pluggy/releases/download/v0.2.0/pluggy-darwin-arm64
-✔ pluggy v0.2.0 installed at /usr/local/bin/pluggy (previous binary backed up to /usr/local/bin/pluggy.old)
+✔ pluggy v0.2.0 installed at ~/.pluggy/bin/pluggy (previous binary backed up to ~/.pluggy/bin/pluggy.old)
 ```
 
 With `--print-only`:
@@ -61,14 +61,40 @@ Install manually:
 
 ## Permissions
 
-pluggy uses the path Node reports as `process.execPath`. On macOS and
-Linux the install script drops the binary at `/usr/local/bin/pluggy`,
-which is root-owned — upgrading on those systems requires running `pluggy
-upgrade` with `sudo`, or installing the binary somewhere writable by your
-user.
+pluggy uses the path Node reports as `process.execPath`. The install
+scripts drop the binary somewhere writable by the current user, so no
+`sudo` is needed for upgrades:
 
-On Windows the install script places the binary at
-`%LOCALAPPDATA%\Programs\pluggy\pluggy.exe`, which is user-writable.
+- macOS/Linux: `~/.pluggy/bin/pluggy` (override with `PLUGGY_HOME`).
+- Windows: `%LOCALAPPDATA%\Programs\pluggy\pluggy.exe`.
+
+If pluggy is currently installed in a system-owned path (for example a
+legacy `/usr/local/bin/pluggy` install), `pluggy upgrade` detects this
+and prints recovery instructions: either re-run with `sudo`, or
+reinstall via the install script (which will land in `~/.pluggy/bin`)
+and remove the old system binary so it doesn't shadow the new one.
+
+## Update notification
+
+When pluggy starts, it reads a small cached state file
+(`<cache>/update-check.json`) and, at most once per 24 hours, fetches
+the latest release tag in the background. If the cache shows that you
+are out of date, you'll see a one-line notice on stderr after the
+command finishes:
+
+```text
+✦ pluggy 0.3.0 available → you have 0.2.0. Run pluggy upgrade.
+```
+
+The notice is suppressed when:
+
+- `--json` is set on the current command,
+- `CI` is set to a non-empty truthy value,
+- stderr isn't a TTY (e.g., piped output),
+- `PLUGGY_NO_UPDATE_CHECK=1` is set in the environment, or
+- the running build is the dev sentinel (`0.0.0`).
+
+Run `pluggy doctor` to see the same information inline.
 
 ## Error cases
 

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -25,19 +25,27 @@ printing install instructions.
 
 ## Install paths
 
-| OS      | Path                                        | Writable by user?   |
-| ------- | ------------------------------------------- | ------------------- |
-| macOS   | `/usr/local/bin/pluggy`                     | No (sudo required). |
-| Linux   | `/usr/local/bin/pluggy`                     | No (sudo required). |
-| Windows | `%LOCALAPPDATA%\Programs\pluggy\pluggy.exe` | Yes.                |
+| OS      | Path                                        | Writable by user? |
+| ------- | ------------------------------------------- | ----------------- |
+| macOS   | `~/.pluggy/bin/pluggy`                      | Yes.              |
+| Linux   | `~/.pluggy/bin/pluggy`                      | Yes.              |
+| Windows | `%LOCALAPPDATA%\Programs\pluggy\pluggy.exe` | Yes.              |
 
-The install scripts (`install.sh`, `install.ps1`) use these defaults.
-For systems where `sudo` isn't available (containers, restricted CI
-runners), download the binary directly from the release page and drop
-it anywhere on `PATH`.
+The install scripts (`install.sh`, `install.ps1`) use these defaults
+and never need `sudo`. Override the Unix install root with
+`PLUGGY_HOME` (the binary is always placed at `$PLUGGY_HOME/bin/pluggy`).
 
-On Windows, the install script also prepends the install directory to
-your user `PATH`. Restart your terminal to pick up the change.
+`install.sh` adds `$PLUGGY_HOME/bin` to your `PATH` by appending an
+`export` line to whichever of `~/.zshrc`, `~/.bashrc`, `~/.bash_profile`,
+`~/.profile`, and `~/.config/fish/config.fish` exist. The line is
+idempotent — re-running the installer doesn't duplicate it.
+
+If a previous install left `pluggy` at `/usr/local/bin/pluggy`, the
+new install script warns you so the legacy copy doesn't shadow the
+fresh one on `PATH`. Remove it with `sudo rm /usr/local/bin/pluggy`.
+
+On Windows, the install script appends the install directory to your
+user `PATH`. Restart your terminal to pick up the change.
 
 ## Cache paths
 
@@ -141,6 +149,13 @@ child exits.
 
 Note that SIGKILL on Windows is actually `TerminateProcess` — there's no
 graceful grace period and world data may not flush.
+
+## `$PATH` on macOS/Linux
+
+`install.sh` writes the line `export PATH="$HOME/.pluggy/bin:$PATH"`
+into every shell profile it finds. New shells pick this up
+automatically. To use pluggy in the same shell that ran the installer,
+run that export by hand or `source` the relevant profile.
 
 ## `%PATH%` on Windows
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,13 +23,20 @@ pluggy itself from source.
 curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
 ```
 
-The script downloads the binary for your OS and architecture and installs it
-to `/usr/local/bin/pluggy`. It calls `sudo mv` to place the binary, so expect
-a password prompt on Linux and macOS boxes where `/usr/local/bin` is root-owned.
+The script downloads the binary for your OS and architecture into
+`~/.pluggy/bin/pluggy` and adds that directory to your `PATH` via your
+shell profile (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`,
+`~/.profile`, `~/.config/fish/config.fish` — whichever exist). No
+`sudo` required.
 
-If `sudo` isn't available (containers, CI), fetch the binary directly from
-the [release page](https://github.com/ch99q/pluggy/releases/latest) and drop
-it anywhere on your `PATH`.
+Override the install location with `PLUGGY_HOME`:
+
+```bash
+PLUGGY_HOME=/opt/pluggy curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
+```
+
+Open a new shell or `source` the updated profile to pick up the new
+`PATH` in your current session.
 
 ### Windows
 
@@ -38,8 +45,8 @@ irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
 ```
 
 The script installs `pluggy.exe` to `%LOCALAPPDATA%\Programs\pluggy` and
-prepends that directory to your user `PATH`. Restart your terminal before
-using the command.
+appends that directory to your user `PATH`. No administrator privileges
+required. Restart your terminal before using the command.
 
 ### Verify
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,30 +1,39 @@
 # install.ps1
+#
+# Installs the pluggy CLI into %LOCALAPPDATA%\Programs\pluggy and adds it
+# to the user PATH. No administrator privileges required.
 
 param(
     [string]$Repo = "ch99q/pluggy",
     [string]$Binary = "pluggy"
 )
 
+$ErrorActionPreference = "Stop"
+
 function Get-Arch {
     switch ($env:PROCESSOR_ARCHITECTURE) {
-        "AMD64" { return "x86_64" }
+        "AMD64" { return "amd64" }
         "ARM64" { return "arm64" }
         default { throw "Unsupported architecture: $($env:PROCESSOR_ARCHITECTURE)" }
     }
 }
 
-function Ensure-Path($InstallDir) {
+function Add-UserPath($InstallDir) {
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    if ($userPath -notlike "*$InstallDir*") {
-        [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallDir", "User")
-        Write-Host "Added $InstallDir to your user PATH. You may need to restart your terminal."
+    $entries = if ($userPath) { $userPath -split ";" } else { @() }
+    if ($entries -notcontains $InstallDir) {
+        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Host "Added $InstallDir to your user PATH."
+        Write-Host "Open a new terminal to pick up the change."
     }
 }
 
 $arch = Get-Arch
 $os = "windows"
 $exeName = "$Binary.exe"
-$downloadUrl = "https://github.com/$Repo/releases/latest/download/$Binary-$os-$arch.exe"
+$assetName = "$Binary-$os-$arch.exe"
+$downloadUrl = "https://github.com/$Repo/releases/latest/download/$assetName"
 $installDir = "$env:LOCALAPPDATA\Programs\$Binary"
 
 if (-not (Test-Path $installDir)) {
@@ -33,11 +42,11 @@ if (-not (Test-Path $installDir)) {
 
 $dest = Join-Path $installDir $exeName
 
-Write-Host "Downloading $downloadUrl ..."
+Write-Host "Downloading $downloadUrl"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $dest
 
 Write-Host "Installed $Binary to $dest"
 
-Ensure-Path $installDir
+Add-UserPath $installDir
 
-Write-Host "`nYou can now run '$Binary' from any terminal. If not, restart your terminal or add $installDir to your PATH."
+Write-Host "`nRun 'pluggy -V' from a new terminal to verify the install."

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,97 @@
 #!/usr/bin/env bash
+#
+# Installs the pluggy CLI into $PLUGGY_HOME (defaults to $HOME/.pluggy) and
+# wires the `bin/` directory onto $PATH via the user's shell profile. No
+# sudo required.
+#
+# Override the install location with PLUGGY_HOME=/path/to/dir.
+
 set -e
 
 REPO="ch99q/pluggy"
 BINARY="pluggy"
 
+PLUGGY_HOME="${PLUGGY_HOME:-$HOME/.pluggy}"
+INSTALL_DIR="$PLUGGY_HOME/bin"
+DEST="$INSTALL_DIR/$BINARY"
+
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
 
-# Map arch if needed
-if [ "$ARCH" = "x86_64" ]; then
-  ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ]; then
-  ARCH="arm64"
-fi
+case "$OS" in
+  darwin|linux) ;;
+  *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
 
 URL="https://github.com/$REPO/releases/latest/download/${BINARY}-${OS}-${ARCH}"
 
-curl -fsSL "$URL" -o "$BINARY"
-chmod +x "$BINARY"
-sudo mv "$BINARY" /usr/local/bin/
-echo "$BINARY installed to /usr/local/bin/"
+mkdir -p "$INSTALL_DIR"
+
+TMP="$(mktemp -t pluggy-install.XXXXXX)"
+trap 'rm -f "$TMP"' EXIT
+
+echo "Downloading $URL"
+if ! curl -fsSL "$URL" -o "$TMP"; then
+  echo "Failed to download $URL" >&2
+  exit 1
+fi
+chmod +x "$TMP"
+mv "$TMP" "$DEST"
+trap - EXIT
+
+echo "Installed $BINARY to $DEST"
+
+# Warn about a stale system-wide install that would shadow the new one.
+LEGACY="/usr/local/bin/$BINARY"
+if [ -e "$LEGACY" ] && [ "$LEGACY" != "$DEST" ]; then
+  cat <<EOF >&2
+
+A previous install was found at $LEGACY. It will shadow the new install
+on PATH. Remove it with:
+
+  sudo rm $LEGACY
+
+EOF
+fi
+
+# Add INSTALL_DIR to PATH idempotently in the user's shell profiles.
+add_path_line() {
+  local file="$1"
+  local line="$2"
+  [ -f "$file" ] || return 0
+  if ! grep -Fq "$line" "$file" 2>/dev/null; then
+    printf '\n# pluggy\n%s\n' "$line" >> "$file"
+    echo "Added pluggy to PATH in $file"
+  fi
+}
+
+POSIX_LINE="export PATH=\"$INSTALL_DIR:\$PATH\""
+FISH_LINE="fish_add_path -g $INSTALL_DIR"
+
+add_path_line "$HOME/.bashrc" "$POSIX_LINE"
+add_path_line "$HOME/.bash_profile" "$POSIX_LINE"
+add_path_line "$HOME/.zshrc" "$POSIX_LINE"
+add_path_line "$HOME/.profile" "$POSIX_LINE"
+[ -d "$HOME/.config/fish" ] && add_path_line "$HOME/.config/fish/config.fish" "$FISH_LINE"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    cat <<EOF
+
+To start using pluggy in this shell:
+
+  export PATH="$INSTALL_DIR:\$PATH"
+
+Or open a new terminal session.
+EOF
+    ;;
+esac
+
+echo
+echo "Run 'pluggy -V' to verify the install."

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import { bold, green, log, red, yellow } from "../logging.ts";
 import { getPlatform, getRegisteredPlatforms } from "../platform/index.ts";
 import { getCachePath, type ResolvedProject } from "../project.ts";
 import { getLatestModrinthVersion } from "../resolver/modrinth.ts";
+import { compareVersions, getCachedLatestVersion } from "../update-check.ts";
 import { resolveWorkspaceContext, topologicalOrder, type WorkspaceContext } from "../workspace.ts";
 
 export type CheckStatus = "pass" | "warn" | "fail";
@@ -27,6 +28,10 @@ export interface CheckResult {
 export interface DoctorCommandOptions {
   json?: boolean;
   cwd?: string;
+  /** Current pluggy CLI version (without leading `v`). Used by the `pluggy-version` check. */
+  pluggyVersion?: string;
+  /** GitHub `owner/repo` slug used by the `pluggy-version` check. */
+  repository?: string;
   /** Per-check overrides used by tests to avoid spawning a JVM or hitting the network. */
   checks?: {
     java?: () => Promise<CheckResult>;
@@ -38,6 +43,7 @@ export interface DoctorCommandOptions {
     versions?: (project: ResolvedProject) => Promise<CheckResult[]>;
     outdated?: () => Promise<CheckResult>;
     dependencyJars?: () => Promise<CheckResult>;
+    pluggyVersion?: () => Promise<CheckResult>;
   };
 }
 
@@ -103,6 +109,12 @@ export async function runDoctorCommand(
   all.push(
     await (hooks.dependencyJars ? hooks.dependencyJars() : checkDependencyJars(context, userJava)),
   );
+
+  if (hooks.pluggyVersion) {
+    all.push(await hooks.pluggyVersion());
+  } else if (opts.pluggyVersion !== undefined && opts.repository !== undefined) {
+    all.push(await checkPluggyVersion(opts.pluggyVersion, opts.repository));
+  }
 
   const hardFailures = all.filter((c) => c.status === "fail");
   const ok = hardFailures.length === 0;
@@ -682,6 +694,80 @@ export async function checkDependencyJars(
   };
 }
 
+/**
+ * Compare the running pluggy version against the latest GitHub release.
+ * Uses the cached value when fresh; otherwise fetches with a short
+ * timeout so doctor stays responsive even when offline.
+ */
+export async function checkPluggyVersion(
+  currentVersion: string,
+  repository: string,
+): Promise<CheckResult> {
+  if (currentVersion === "0.0.0" || currentVersion === "") {
+    return {
+      id: "pluggy-version",
+      label: "Pluggy version",
+      status: "pass",
+      detail: "development build",
+    };
+  }
+
+  let latest = await getCachedLatestVersion();
+  if (latest === undefined) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repository}/releases/latest`, {
+          headers: { Accept: "application/vnd.github+json" },
+          signal: controller.signal,
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { tag_name?: string };
+          if (typeof data.tag_name === "string") {
+            latest = data.tag_name.replace(/^v/, "");
+          }
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      // Network failure — surface as a soft warn so the user knows we couldn't check.
+      return {
+        id: "pluggy-version",
+        label: "Pluggy version",
+        status: "warn",
+        detail: `running ${currentVersion}; could not reach GitHub to check for updates`,
+      };
+    }
+  }
+
+  if (latest === undefined) {
+    return {
+      id: "pluggy-version",
+      label: "Pluggy version",
+      status: "warn",
+      detail: `running ${currentVersion}; could not determine latest release`,
+    };
+  }
+
+  if (compareVersions(currentVersion, latest) < 0) {
+    return {
+      id: "pluggy-version",
+      label: "Pluggy version",
+      status: "warn",
+      detail: `running ${currentVersion}; ${latest} is available — run 'pluggy upgrade'`,
+    };
+  }
+
+  return {
+    id: "pluggy-version",
+    label: "Pluggy version",
+    status: "pass",
+    detail: `${currentVersion} (latest)`,
+  };
+}
+
 function projectsForValidation(context: WorkspaceContext): ResolvedProject[] {
   const out: ResolvedProject[] = [context.root];
   for (const ws of context.workspaces) {
@@ -704,12 +790,16 @@ function printCheck(c: CheckResult): void {
 }
 
 /** Factory for the `pluggy doctor` commander command. */
-export function doctorCommand(): Command {
+export function doctorCommand(options: { pluggyVersion: string; repository: string }): Command {
   return new Command("doctor")
     .description("Check your environment and project for common issues.")
     .action(async function action(this: Command) {
       const globalOpts = this.optsWithGlobals();
-      const result = await runDoctorCommand({ json: globalOpts.json === true });
+      const result = await runDoctorCommand({
+        json: globalOpts.json === true,
+        pluggyVersion: options.pluggyVersion,
+        repository: options.repository,
+      });
       if (result.exitCode !== 0) {
         process.exit(result.exitCode);
       }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,6 +1,6 @@
-import { chmod, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { access, chmod, constants, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import process from "node:process";
 
 import { Command } from "commander";
@@ -72,6 +72,32 @@ function printManualInstructions(repository: string, release: GithubRelease): vo
 }
 
 /**
+ * Returns true if the current process can replace the file at `path`
+ * (i.e., it can write to the containing directory). We probe the
+ * directory rather than the file itself because the in-place upgrade
+ * works by renaming around the existing binary.
+ */
+async function canReplaceBinary(path: string): Promise<boolean> {
+  try {
+    await access(dirname(path), constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Heuristic: paths a regular user shouldn't be writing to without sudo. */
+function isSystemPath(path: string): boolean {
+  if (process.platform === "win32") return false;
+  return (
+    path.startsWith("/usr/") ||
+    path.startsWith("/opt/") ||
+    path.startsWith("/bin/") ||
+    path.startsWith("/sbin/")
+  );
+}
+
+/**
  * Download the release asset for the current platform into a temp file,
  * rename the running binary out of the way (Windows tolerates this; Unix
  * is routine), and move the new binary into its place. On failure, the
@@ -118,6 +144,26 @@ async function replaceInPlace(
   return { backupPath };
 }
 
+function printPermissionGuidance(repository: string, currentBinaryPath: string): void {
+  log.error(
+    `cannot write to ${currentBinaryPath} — pluggy was installed to a system path and upgrades from there require root.`,
+  );
+  log.info("");
+  log.info(`${bold("Recommended:")} reinstall pluggy to your home directory (no sudo):`);
+  log.info("");
+  log.info(
+    `  ${dim("$")} curl -fsSL https://github.com/${repository}/releases/latest/download/install.sh | bash`,
+  );
+  log.info("");
+  log.info(`Then remove the old system binary so it doesn't shadow the new one:`);
+  log.info("");
+  log.info(`  ${dim("$")} sudo rm ${currentBinaryPath}`);
+  log.info("");
+  log.info(`${bold("Or:")} re-run the upgrade with elevated privileges:`);
+  log.info("");
+  log.info(`  ${dim("$")} sudo pluggy upgrade`);
+}
+
 /**
  * Factory for the `pluggy upgrade` commander command.
  *
@@ -150,8 +196,24 @@ export function upgradeCommand(options: UpgradeOptions): Command {
         return;
       }
 
-      const downloadUrl = `https://github.com/${options.repository}/releases/download/${release.tag_name}/${assetName}`;
       const currentBinaryPath = process.execPath;
+
+      if (!(await canReplaceBinary(currentBinaryPath))) {
+        if (isSystemPath(currentBinaryPath)) {
+          printPermissionGuidance(options.repository, currentBinaryPath);
+        } else {
+          log.error(
+            `cannot write to ${dirname(currentBinaryPath)}. Check the directory's permissions and retry.`,
+          );
+        }
+        const err = new Error("upgrade aborted: install location is not writable") as Error & {
+          exitCode?: number;
+        };
+        err.exitCode = 1;
+        throw err;
+      }
+
+      const downloadUrl = `https://github.com/${options.repository}/releases/download/${release.tag_name}/${assetName}`;
 
       log.info(`${bold("Upgrading to:")} ${brightBlue(release.tag_name)}`);
       log.info(`${dim(`downloading ${downloadUrl}`)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,13 @@ import { searchCommand } from "./commands/search.ts";
 import { testCommand } from "./commands/test.ts";
 import { upgradeCommand } from "./commands/upgrade.ts";
 import { bold, red } from "./logging.ts";
+import { startUpdateCheck } from "./update-check.ts";
 
 // Side-effect import: platform providers self-register via createPlatform.
 import "./platform/index.ts";
 
 const CLI_VERSION = "0.0.0";
+const REPOSITORY = "ch99q/pluggy";
 
 const program = new Command()
   .name("pluggy")
@@ -40,16 +42,54 @@ program.addCommand(searchCommand());
 program.addCommand(listCommand());
 program.addCommand(buildCommand());
 program.addCommand(testCommand());
-program.addCommand(doctorCommand());
+program.addCommand(doctorCommand({ pluggyVersion: CLI_VERSION, repository: REPOSITORY }));
 program.addCommand(devCommand());
-program.addCommand(upgradeCommand({ repository: "ch99q/pluggy" }));
+program.addCommand(upgradeCommand({ repository: REPOSITORY }));
 program.addCommand(completionsCommand(program));
 
 program.exitOverride();
 
+const wantsJson = process.argv.includes("--json");
+const isUpgradeRun = detectSubcommand(process.argv) === "upgrade";
+
+/**
+ * Find the first positional argument in argv after the executable and
+ * script paths. Skips global flags and consumes the value of flags that
+ * take one (`-p` / `--project`) so we don't mistake the value for a
+ * subcommand. Returns `undefined` if no subcommand is present.
+ */
+function detectSubcommand(argv: string[]): string | undefined {
+  const valueFlags = new Set(["-p", "--project"]);
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") return argv[i + 1];
+    if (valueFlags.has(a)) {
+      i++;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    return a;
+  }
+  return undefined;
+}
+
+// Kick off the cached-state read and (optionally) a background fetch
+// before parsing so the banner is ready by the time the command exits.
+// The upgrade command does its own version handling, so skip it there.
+const updateCheck = isUpgradeRun
+  ? { printBannerIfOutdated: () => {}, dispose: () => {} }
+  : await startUpdateCheck({
+      repository: REPOSITORY,
+      currentVersion: CLI_VERSION,
+      json: wantsJson,
+    });
+
 try {
   await program.parseAsync(process.argv);
+  updateCheck.printBannerIfOutdated();
+  updateCheck.dispose();
 } catch (err) {
+  updateCheck.dispose();
   const error = err as Error & { code?: string; exitCode?: number };
 
   if (

--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+
+import { compareVersions, getCachedLatestVersion, startUpdateCheck } from "./update-check.ts";
+
+describe("compareVersions", () => {
+  test("equal versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("v1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("less / greater", () => {
+    expect(compareVersions("1.2.3", "1.2.4")).toBe(-1);
+    expect(compareVersions("1.3.0", "1.2.9")).toBe(1);
+    expect(compareVersions("0.9.9", "1.0.0")).toBe(-1);
+  });
+
+  test("strips leading v and pre-release suffix", () => {
+    expect(compareVersions("v1.2.3-beta", "1.2.3")).toBe(0);
+    expect(compareVersions("1.2.3", "1.2.4-rc1")).toBe(-1);
+  });
+
+  test("treats missing components as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1", "1.0.1")).toBe(-1);
+  });
+});
+
+describe("startUpdateCheck", () => {
+  let workDir: string;
+  let stateFile: string;
+  let originalNoCheck: string | undefined;
+  let originalCI: string | undefined;
+  let originalTTY: boolean | undefined;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), "pluggy-update-check-"));
+    stateFile = join(workDir, "update-check.json");
+    originalNoCheck = process.env.PLUGGY_NO_UPDATE_CHECK;
+    originalCI = process.env.CI;
+    originalTTY = process.stderr.isTTY;
+    delete process.env.PLUGGY_NO_UPDATE_CHECK;
+    delete process.env.CI;
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+  });
+
+  afterEach(async () => {
+    if (originalNoCheck === undefined) delete process.env.PLUGGY_NO_UPDATE_CHECK;
+    else process.env.PLUGGY_NO_UPDATE_CHECK = originalNoCheck;
+    if (originalCI === undefined) delete process.env.CI;
+    else process.env.CI = originalCI;
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: originalTTY,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  test("prints banner to stderr when cached version is newer", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "0.5.0", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).toHaveBeenCalled();
+    const arg = writeSpy.mock.calls[0]?.[0] as string;
+    expect(arg).toContain("0.5.0");
+    expect(arg).toContain("pluggy upgrade");
+  });
+
+  test("does not print when cached version equals current", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "0.1.0", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("suppressed when --json", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "9.9.9", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      json: true,
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("suppressed when CI=true", async () => {
+    process.env.CI = "true";
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "9.9.9", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("suppressed when PLUGGY_NO_UPDATE_CHECK=1", async () => {
+    process.env.PLUGGY_NO_UPDATE_CHECK = "1";
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "9.9.9", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("suppressed for dev build version 0.0.0", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "9.9.9", lastCheckedAt: new Date().toISOString() }),
+    );
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.0.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing state file is handled silently", async () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ tag_name: "v0.2.0" }), { status: 200 }));
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.printBannerIfOutdated();
+    handle.dispose();
+    expect(writeSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  test("fresh cache (within interval) does not refetch", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "0.1.0", lastCheckedAt: new Date().toISOString() }),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+    const handle = await startUpdateCheck({
+      repository: "ch99q/pluggy",
+      currentVersion: "0.1.0",
+      stateFile,
+    });
+    handle.dispose();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  test("getCachedLatestVersion reads from disk", async () => {
+    await writeFile(
+      stateFile,
+      JSON.stringify({ latestVersion: "0.7.0", lastCheckedAt: new Date().toISOString() }),
+    );
+    expect(await getCachedLatestVersion(stateFile)).toBe("0.7.0");
+  });
+
+  test("getCachedLatestVersion returns undefined when no state", async () => {
+    expect(await getCachedLatestVersion(stateFile)).toBeUndefined();
+  });
+});

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,0 +1,188 @@
+/**
+ * Background check for new pluggy releases.
+ *
+ * Reads/writes a small state file with the most recent known release tag
+ * and the time we last checked. Network fetch is fire-and-forget — the
+ * banner shown to the user is always derived from the *cached* result, so
+ * it never blocks the current command. Suppressed when output is
+ * non-interactive (`--json`, CI, no TTY) or explicitly disabled via
+ * `PLUGGY_NO_UPDATE_CHECK=1`.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+import { bold, brightBlue, dim } from "./logging.ts";
+import { getCachePath } from "./project.ts";
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 2000;
+
+interface UpdateState {
+  latestVersion: string;
+  lastCheckedAt: string;
+}
+
+export interface UpdateCheckOptions {
+  /** GitHub `owner/repo` slug to query. */
+  repository: string;
+  /** Current pluggy version (without leading `v`). */
+  currentVersion: string;
+  /** True when the command is emitting JSON; suppresses the banner. */
+  json?: boolean;
+  /** Override now() for tests. */
+  now?: () => Date;
+  /** Override the state file location for tests. */
+  stateFile?: string;
+}
+
+export interface UpdateCheckHandle {
+  /** Print the banner to stderr if the cached state shows a newer version. */
+  printBannerIfOutdated: () => void;
+  /** Abort any in-flight fetch so the process can exit promptly. */
+  dispose: () => void;
+}
+
+/** Default location of the cached state file. */
+export function getStateFilePath(): string {
+  return join(getCachePath(), "update-check.json");
+}
+
+/**
+ * Compare two semver-ish version strings (e.g. `0.2.0`, `v0.2.1-beta`).
+ * Returns -1 if `a < b`, 0 if equal, 1 if `a > b`. Pre-release suffixes
+ * are ignored for the comparison — close enough for "you are outdated".
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const parse = (v: string): number[] => {
+    const stripped = v.replace(/^v/, "").split(/[-+]/, 1)[0] ?? "0.0.0";
+    return stripped.split(".").map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) ? n : 0;
+    });
+  };
+  const av = parse(a);
+  const bv = parse(b);
+  const len = Math.max(av.length, bv.length);
+  for (let i = 0; i < len; i++) {
+    const x = av[i] ?? 0;
+    const y = bv[i] ?? 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
+/** Whether the update check should be skipped entirely for this run. */
+function isSuppressed(opts: UpdateCheckOptions): boolean {
+  if (opts.json === true) return true;
+  if (process.env.PLUGGY_NO_UPDATE_CHECK === "1") return true;
+  if (process.env.CI !== undefined && process.env.CI !== "" && process.env.CI !== "false") {
+    return true;
+  }
+  if (process.stderr.isTTY !== true) return true;
+  // Dev builds (CLI_VERSION not yet stamped by release.yml) — nothing to compare against.
+  if (opts.currentVersion === "0.0.0" || opts.currentVersion === "") return true;
+  return false;
+}
+
+async function readState(path: string): Promise<UpdateState | undefined> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<UpdateState>;
+    if (typeof parsed.latestVersion !== "string" || typeof parsed.lastCheckedAt !== "string") {
+      return undefined;
+    }
+    return { latestVersion: parsed.latestVersion, lastCheckedAt: parsed.lastCheckedAt };
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeState(path: string, state: UpdateState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2), "utf8");
+}
+
+interface ReleaseResponse {
+  tag_name?: string;
+  message?: string;
+}
+
+/**
+ * Kick off the version check. Reads cached state immediately so the
+ * caller can render a banner without waiting on the network. If the
+ * cache is stale, a background fetch updates it for the next run.
+ *
+ * The returned handle owns an `AbortController` for the in-flight
+ * request — call `dispose()` from a `beforeExit` hook so the process
+ * doesn't linger on a slow socket.
+ */
+export async function startUpdateCheck(opts: UpdateCheckOptions): Promise<UpdateCheckHandle> {
+  if (isSuppressed(opts)) {
+    return { printBannerIfOutdated: () => {}, dispose: () => {} };
+  }
+
+  const now = opts.now ?? (() => new Date());
+  const stateFile = opts.stateFile ?? getStateFilePath();
+  const cached = await readState(stateFile);
+
+  const stale =
+    cached === undefined ||
+    now().getTime() - new Date(cached.lastCheckedAt).getTime() > CHECK_INTERVAL_MS;
+
+  let aborted = false;
+  const controller = new AbortController();
+  let pending: Promise<void> | undefined;
+
+  if (stale) {
+    pending = (async () => {
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(`https://api.github.com/repos/${opts.repository}/releases/latest`, {
+          headers: { Accept: "application/vnd.github+json" },
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as ReleaseResponse;
+        if (typeof data.tag_name !== "string") return;
+        await writeState(stateFile, {
+          latestVersion: data.tag_name.replace(/^v/, ""),
+          lastCheckedAt: now().toISOString(),
+        });
+      } catch {
+        // Network errors, abort, JSON parse — all fine to ignore. We'll retry next run.
+      } finally {
+        clearTimeout(timer);
+      }
+    })();
+    // Swallow rejections so the unhandled-rejection handler never fires.
+    pending.catch(() => {});
+  }
+
+  return {
+    printBannerIfOutdated: () => {
+      if (cached === undefined) return;
+      if (compareVersions(opts.currentVersion, cached.latestVersion) >= 0) return;
+      const arrow = dim("→");
+      const msg = `${dim("✦")} pluggy ${brightBlue(cached.latestVersion)} available ${arrow} you have ${dim(opts.currentVersion)}. Run ${bold("pluggy upgrade")}.`;
+      process.stderr.write(`${msg}\n`);
+    },
+    dispose: () => {
+      if (aborted) return;
+      aborted = true;
+      controller.abort();
+    },
+  };
+}
+
+/**
+ * Returns the most recently cached latest version, if any. Used by
+ * `pluggy doctor` so it can flag an outdated CLI without firing its own
+ * network request.
+ */
+export async function getCachedLatestVersion(stateFile?: string): Promise<string | undefined> {
+  const state = await readState(stateFile ?? getStateFilePath());
+  return state?.latestVersion;
+}


### PR DESCRIPTION
## Summary

- Install scripts now drop pluggy at `~/.pluggy/bin` (Unix) / `%LOCALAPPDATA%\Programs\pluggy` (Windows) and wire it onto `PATH` via shell profiles — no sudo for install or `pluggy upgrade`.
- `pluggy upgrade` probes the install directory for write access and prints clear migration guidance when a legacy `/usr/local/bin` install is detected, instead of silently failing partway through the rename.
- New `src/update-check.ts` caches the latest release tag in `<cache>/update-check.json` and prints a one-line stderr notice (`✦ pluggy 0.3.0 available → you have 0.2.0. Run pluggy upgrade.`) when out of date. Suppressed for `--json`, `CI`, no-TTY, dev builds, and `PLUGGY_NO_UPDATE_CHECK=1`. 24h check cadence with a 2s fetch timeout, aborted on exit so the process doesn't linger.
- New `pluggy-version` check in `pluggy doctor` surfaces the same info as a non-failing warn.

## Test plan

- [x] `vp test` (45 files, 359 tests, +14 new tests in `src/update-check.test.ts`)
- [x] `vp check` (format, lint, types)
- [x] `bun build --compile` produces a working binary; `pluggy -V` and `pluggy --help` smoke-tested
- [ ] Re-run `install.sh` on a clean Linux/macOS box and confirm `~/.pluggy/bin` lands on `PATH`
- [ ] Re-run `install.ps1` on Windows and confirm the binary is reachable from a fresh terminal
- [ ] Trigger the outdated banner by seeding `<cache>/update-check.json` with a higher version