### PR TITLE
feat(test): document command, package main as jar, expose mocking-framework hand-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For the full walkthrough, read
 | `pluggy search <query>`      | Query Modrinth.                                    |
 | `pluggy list`                | Show declared deps, resolved versions, registries. |
 | `pluggy build`               | Compile → resources → descriptor → shade → jar.    |
+| `pluggy test`                | Compile and run JUnit tests under `test/`.         |
 | `pluggy dev`                 | Live server with rebuild-on-save.                  |
 | `pluggy doctor`              | Validate environment and every workspace.          |
 | `pluggy upgrade`             | Replace the binary with the latest release.        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Every subcommand, with its flags, JSON envelope, and sample output.
 | [`search`](./commands/search.md)           | Query Modrinth by keyword.                               |
 | [`list`](./commands/list.md)               | Print declared deps, resolved versions, and registries.  |
 | [`build`](./commands/build.md)             | Compile → resources → descriptor → shade → jar.          |
+| [`test`](./commands/test.md)               | Compile and run JUnit Platform tests under `test/`.      |
 | [`dev`](./commands/dev.md)                 | Boot a live server with the plugin and its runtime deps. |
 | [`doctor`](./commands/doctor.md)           | Validate the environment and every workspace.            |
 | [`upgrade`](./commands/upgrade.md)         | Replace the running binary with the latest release.      |
@@ -57,6 +58,7 @@ Every subcommand, with its flags, JSON envelope, and sample output.
 Task-oriented walkthroughs for situations that come up often.
 
 - [Adding a Paper plugin that uses adventure-api](./recipes/paper-with-adventure.md)
+- [Testing a Paper plugin with MockBukkit](./recipes/testing-with-mockbukkit.md)
 - [Setting up a monorepo with a shared API module](./recipes/monorepo-shared-api.md)
 - [Upgrading across Paper major versions](./recipes/upgrade-paper-major.md)
 - [CI builds without pluggy installed globally](./recipes/ci-without-global-pluggy.md)

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -1,0 +1,378 @@
+# `pluggy test`
+
+Compile the project's main + test sources, run them through the JUnit
+Platform Console Launcher, and parse the resulting JUnit XML reports
+into a flat per-test result.
+
+## Usage
+
+```text
+pluggy test [options]
+pluggy t    [options]
+```
+
+## Flags
+
+| Flag                 | Default | Notes                                                                         |
+| -------------------- | ------- | ----------------------------------------------------------------------------- |
+| `--filter <pattern>` | none    | Restrict which tests run. See [Filter syntax](#filter-syntax) below.          |
+| `--fail-fast`        | off     | Stop after the first test failure (passed through to the JUnit launcher).     |
+| `--clean`            | off     | Wipe the test staging dir before running (compiled classes + cached reports). |
+| `--workspace <name>` | none    | Test only this workspace.                                                     |
+| `--workspaces`       | off     | Explicit all-workspaces test from the root.                                   |
+
+## Scope rules
+
+| Location                       | Flags                   | Tests                                   |
+| ------------------------------ | ----------------------- | --------------------------------------- |
+| Standalone project             | none                    | The project.                            |
+| Inside workspace `X`           | none                    | `X`.                                    |
+| Repo root, workspaces declared | none                    | Every workspace, topologically ordered. |
+| Repo root, workspaces declared | `--workspace A`         | Just `A`.                               |
+| Inside workspace `X`           | `--workspaces`          | **Error** — only valid at the root.     |
+| Inside workspace `X`           | `--workspace Y` (Y ≠ X) | **Error** — run from the root.          |
+
+A workspace with no `test/` directory or no `.java` sources under it is
+skipped — not failed. That keeps `--workspaces` runs ergonomic when only
+some workspaces have tests.
+
+## Layout
+
+```text
+<workspace>/
+├── src/                    main sources (compiled and packaged into main.jar)
+├── test/                   JUnit sources — must contain at least one .java file
+└── .pluggy-build/<hash>-test/
+    ├── main-jar-stage/     staged classes + descriptor + resources
+    ├── main.jar            full plugin jar (handed off via system property)
+    ├── main-runtime.jar    same minus the entry-point class (runtime classpath)
+    ├── test-classes/       compiled test sources
+    └── reports/            TEST-*.xml emitted by the JUnit launcher
+```
+
+`<hash>` is the same 12-hex digest used by `pluggy build`
+(`sha256(name \0 version \0 rootDir)`). `--clean` wipes the entire
+`<hash>-test` directory; the per-run `reports/` folder is always wiped
+to keep stale XML from a deleted test class out of the result.
+
+### Why two main jars?
+
+`main.jar` is the production-shaped artifact: classes, generated
+descriptor, every `resources` entry. It's what mocking frameworks
+(MockBukkit, anything that mounts a plugin classloader) load from
+disk via the `pluggy.test.mainJar` system property — see
+[Mocking-framework hand-off](#mocking-framework-hand-off) below.
+
+`main-runtime.jar` is the same jar with the declared entry-point class
+(`project.main`) stripped out. It goes on the system test classpath so
+plain utility classes (services, parsers, listeners) are reachable for
+non-mocking unit tests. The entry-point stays _off_ the system loader
+so the mocking framework's own `ConfiguredPluginClassLoader` can own
+it cleanly — without that, Bukkit's `JavaPlugin requires a valid
+classloader` check fires the moment a mocking framework tries to load
+the plugin.
+
+Normal tests don't see the split. It only matters when something at
+runtime references the entry-point class directly (see the
+[Caveats](#caveats) below).
+
+## Pipeline
+
+For each target workspace:
+
+1. **Detect tests.** No `test/` directory → `no-test-dir`. Directory
+   exists but no `.java` under it → `no-sources`. Either case skips the
+   workspace with status `ok`.
+2. **Resolve main deps.** `project.dependencies`, plus the primary
+   platform's `api()` Maven coordinate, against the project's
+   `registries`.
+3. **Resolve test deps.** `project.testDependencies` against
+   `registries` ∪ Maven Central. JUnit Platform Console Standalone
+   (`org.junit.platform:junit-platform-console-standalone:1.11.4`) is
+   always added to the test classpath — you never declare it.
+4. **Compile main.** `javac` over `src/` into `main-jar-stage/`,
+   classpath = main deps + platform API.
+5. **Package `main.jar` + `main-runtime.jar`.** Stage `resources` and
+   the generated descriptor (same logic `pluggy build` runs), zip into
+   `main.jar`, then zip again into `main-runtime.jar` excluding the
+   entry-point `.class`.
+6. **Compile tests.** `javac` over `test/` against `main.jar` (so test
+   code can import everything) + main deps + test deps + the JUnit
+   standalone jar.
+7. **Run.** `java -Dpluggy.test.mainJar=<…/main.jar> -jar
+junit-platform-console-standalone.jar execute …`. The runtime
+   classpath is `main-runtime.jar` + main deps + test deps + JUnit.
+   `--filter` translates to `--include-tag` / `--select-method` /
+   `--include-classname`; `--fail-fast` translates to `--fail-fast`.
+8. **Parse.** Read every `TEST-*.xml` from `reports/` and flatten into
+   a single `{ total, passed, failed, skipped, cases[] }` shape. The
+   launcher's own stdout/stderr is discarded — pluggy renders its own
+   output from the XML.
+
+`testDependencies` follows the same grammar as `dependencies` — see
+[`project.json` reference](../project-json.md#testdependencies).
+
+## Mocking-framework hand-off
+
+Tests are launched with a small set of system properties that point
+at the resolved jars on disk. The contract is framework-agnostic — any
+test runner, any future mocking library, can read these properties.
+
+| Property                        | Value                                                                                                                                                           |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pluggy.test.mainJar`           | Absolute path to the plugin's own jar (`main.jar`).                                                                                                             |
+| `pluggy.test.dependency.<name>` | One per declared dep, keyed by the name in `project.json` (`dependencies` and `testDependencies`). Value is the absolute path to that dep's resolved jar.       |
+| `pluggy.test.dependencies`      | Every declared dep jar, joined by `File.pathSeparator` (`:` on POSIX, `;` on Windows). Order: `dependencies` first, then `testDependencies`, declaration order. |
+
+Transitive deps don't get their own property — they're already on the
+runtime classpath, and surfacing them would let tests bind to indirect
+dep names that change without notice. Library-style Maven deps (e.g.
+`commons-lang3`) appear in the catalog alongside plugin-shaped deps;
+pluggy doesn't try to detect "is this a plugin?". If a test calls
+`MockBukkit.loadJar` on a library jar, the framework's own error
+("no plugin.yml") tells the user to skip that one.
+
+If a name appears in both `dependencies` and `testDependencies`, the
+`testDependencies` entry wins.
+
+### Pick one dep by name
+
+```java
+@Test
+void warnsWhenWorldEditMissing() {
+    // No extra plugins loaded — your plugin should detect the absence
+    // and fall back gracefully.
+    plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
+    server.getPluginManager().enablePlugin(plugin);
+    // assert your plugin logged "WorldEdit not found, disabling integration"
+}
+
+@Test
+void integratesWithWorldEditWhenPresent() {
+    File worldEdit = new File(System.getProperty("pluggy.test.dependency.worldedit"));
+    MockBukkit.loadJar(worldEdit);
+    plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
+    server.getPluginManager().enablePlugin(plugin);
+    // assert your plugin registered a WorldEdit hook
+}
+```
+
+A small helper makes this readable in test base classes:
+
+```java
+private static File dep(String name) {
+    return new File(System.getProperty("pluggy.test.dependency." + name));
+}
+```
+
+### Boot every declared dep
+
+```java
+@Test
+void cooperatesWithEverything() {
+    String all = System.getProperty("pluggy.test.dependencies");
+    for (String path : all.split(File.pathSeparator)) {
+        if (path.isEmpty()) continue;
+        try {
+            MockBukkit.loadJar(new File(path));
+        } catch (Exception ignored) {
+            // Library jars without a plugin.yml fail here; skip them.
+        }
+    }
+    plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
+    server.getPluginManager().enablePlugin(plugin);
+}
+```
+
+Loading a real third-party plugin (WorldEdit, LuckPerms, …) into
+MockBukkit can fail with `JavaPlugin requires a valid classloader`
+when that plugin's entry class is already on the runtime classpath.
+The catalog only promises the path — whether the jar loads cleanly
+under a given framework is between the plugin and the framework. For
+"is plugin X around?" coverage that doesn't need the third-party
+plugin to actually boot, register a stub via `registerLoadedPlugin`
+with the dep's name.
+
+See the
+[testing-with-mockbukkit](../recipes/testing-with-mockbukkit.md)
+recipe for a worked example.
+
+## Caveats
+
+The entry-point class declared in `project.main` is _not_ on the
+runtime test classpath. Test code can `import com.example.demo.Main`
+freely (compile classpath has the full `main.jar`), but at runtime
+any expression that requires the class to be loadable by the system
+classloader — `Main.class`, `new Main()`, `Class.forName("…Main")`
+through the test classloader — throws `NoClassDefFoundError`. Use
+the `pluggy.test.mainJar` hand-off and the framework's own loader
+(returning `Plugin` or `JavaPlugin`) instead.
+
+Every other plugin class is on the runtime classpath as normal.
+
+## Filter syntax
+
+`--filter` accepts three forms, picked in this order:
+
+| Pattern        | Routed to                      | Matches                             |
+| -------------- | ------------------------------ | ----------------------------------- |
+| `@tag:<name>`  | `--include-tag=<name>`         | JUnit `@Tag("<name>")` annotations. |
+| `Class#method` | `--select-method=Class#method` | One specific test method.           |
+| `<glob>`       | `--include-classname=<regex>`  | Class names matching the glob.      |
+
+Globs use `*` (one segment of any length) and are anchored — `*FooTest`
+matches `com.example.FooTest`, `Foo*` matches `FooBarTest`. Other regex
+metacharacters are escaped before passing to JUnit.
+
+`Class#method` only triggers when the pattern contains `#` and no `*`;
+otherwise it falls through to the classname glob.
+
+## Output
+
+JUnit Jupiter test names are method-name + `()` by default — that's
+what shows up in both human and JSON output. Use `@DisplayName("…")`
+on a method to override.
+
+Human, single workspace, all green:
+
+```text
+test demo
+  com.example.demo.GreeterTest
+    ✓ countsWordsCorrectly()  8ms
+    ✓ rejectsEmptyName()  0ms
+    ✓ greetsNamedUser()  0ms
+
+  3 passed
+```
+
+Human, with a failure:
+
+```text
+test demo
+  com.example.demo.GreeterTest
+    ✓ countsWordsCorrectly()  0ms
+    ✓ rejectsEmptyName()  0ms
+    ✓ greetsNamedUser()  0ms
+  com.example.demo.FailingTest
+    ✗ deliberatelyFails()  10ms
+        expected: <2> but was: <1>
+        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
+
+  3 passed, 1 failed
+```
+
+The "at …" line is the _first_ stack frame in the report, which for a
+JUnit Jupiter `assertEquals` failure is JUnit's internal builder.
+Inspect the full `failures[].stackTrace` in JSON output (or the JUnit
+XML in `.pluggy-build/<hash>-test/reports/`) to see the user-code
+frame.
+
+Human, multi-workspace, summary appended:
+
+```text
+test api
+  …
+test impl
+  …
+
+summary
+  api: 12 passed (480ms)
+  impl: 3 passed, 1 failed (610ms)
+```
+
+`no test/ directory` and `no .java sources in test/` show in the summary
+in place of counts.
+
+## JSON output
+
+Top-level shape:
+
+```json
+{
+  "status": "success",
+  "results": [
+    {
+      "workspace": "demo",
+      "rootDir": "/Users/you/demo",
+      "ok": true,
+      "durationMs": 6210,
+      "tests": { "total": 3, "passed": 3, "failed": 0, "skipped": 0 }
+    }
+  ]
+}
+```
+
+Per-result fields:
+
+| Field      | When present                        | Meaning                                                        |
+| ---------- | ----------------------------------- | -------------------------------------------------------------- |
+| `tests`    | Tests actually ran.                 | `{ total, passed, failed, skipped }`.                          |
+| `failures` | At least one failure.               | Array of `{ class, test, durationMs, message?, stackTrace? }`. |
+| `skipped`  | Workspace produced no tests.        | `"no-test-dir"` or `"no-sources"`.                             |
+| `error`    | Workspace errored before tests ran. | The error message (e.g. compile failure).                      |
+
+On a failed run:
+
+```json
+{
+  "status": "error",
+  "results": [
+    {
+      "workspace": "demo",
+      "rootDir": "/Users/you/demo",
+      "ok": false,
+      "durationMs": 7175,
+      "tests": { "total": 4, "passed": 3, "failed": 1, "skipped": 0 },
+      "failures": [
+        {
+          "class": "com.example.demo.FailingTest",
+          "test": "deliberatelyFails()",
+          "durationMs": 9,
+          "message": "expected: <2> but was: <1>",
+          "stackTrace": "org.opentest4j.AssertionFailedError: expected: <2> but was: <1>\n\tat org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)\n\t…"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The `stackTrace` field is the raw JUnit XML failure body; current
+builds wrap it in a `<![CDATA[…]]>` envelope which is not yet stripped.
+The `message` field is always clean.
+
+Success JSON goes to stdout; failure JSON goes to stderr. Exit code is
+`0` when every workspace passed (or skipped), `1` if any test failed or
+any workspace errored.
+
+## Single-workspace vs multi-workspace failure
+
+Single-workspace runs rethrow compile / launcher exceptions — the CLI's
+top-level handler prints them. Multi-workspace runs capture the error
+into the per-workspace result, keep going, and exit `1` at the end if
+anything errored.
+
+Test _assertions_ never throw in either mode; they surface via
+`ok: false` and `failures[]` so you can see every failing test in one
+pass.
+
+## Error cases
+
+| Stage    | Message pattern                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------- |
+| Compile  | `compile: javac exited with code <n> for project "<name>" (last 40 lines):\n...`                           |
+| Compile  | `compile: no .java sources found under "<dir>" for project "<name>"` (only thrown for `src/`, not `test/`) |
+| Launcher | `test: JUnit launcher exited with code <n> and produced no reports.\n<last 40 stderr lines>`               |
+| Spawn    | `test: failed to spawn java: <reason>` — usually no `java` on `PATH`; install a JDK.                       |
+
+A non-zero JUnit exit _with_ reports is treated as a normal failed run —
+the launcher exits `1` whenever any test fails. The "produced no
+reports" path only fires on real launcher problems (classpath, JVM
+crash, missing main class).
+
+## See also
+
+- [`project.json` reference](../project-json.md#testdependencies) — declaring test-only deps.
+- [`pluggy build`](./build.md) — the same compile pipeline minus tests.
+- [Testing with MockBukkit](../recipes/testing-with-mockbukkit.md) — a worked recipe.
+- [Troubleshooting](../troubleshooting.md) — `javac` / `java` not found, etc.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,6 +180,7 @@ Each step lives in a dedicated module under `src/build/` — see
 ## Where to go next
 
 - Make the dev loop faster: [`pluggy dev`](./commands/dev.md).
+- Add JUnit tests: [`pluggy test`](./commands/test.md).
 - Split into a monorepo: [Workspaces](./workspaces.md).
 - Ship a jar that bundles a third-party library: [Shading](./project-json.md#shading).
 - Set up IDE integration: [IDE integration](./ide.md).

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -213,6 +213,27 @@ The `version` field shape depends on the scheme:
 | `file`      | Arbitrary label. The content-addressed integrity hash is what actually identifies the file.                  |
 | `workspace` | Ignored. The sibling's own `project.json:version` wins.                                                      |
 
+### `testDependencies` (optional)
+
+Same shape and grammar as `dependencies` — short or long form, every
+source kind. These are added to the test classpath only and never end
+up in the built jar.
+
+```json
+"testDependencies": {
+  "assertj": {
+    "source": "maven:org.assertj:assertj-core",
+    "version": "3.26.3"
+  }
+}
+```
+
+Resolved against `registries` plus an implicit Maven Central, so JUnit
+itself can always be fetched. JUnit Platform Console Standalone is
+auto-injected by `pluggy test` — you never declare it.
+
+`testDependencies` is read by `pluggy test`. Other commands ignore it.
+
 ### `shading` (optional)
 
 Object keyed by dependency name — same key you used in `dependencies`. Each

--- a/docs/recipes/testing-with-mockbukkit.md
+++ b/docs/recipes/testing-with-mockbukkit.md
@@ -1,0 +1,271 @@
+# Testing a Paper plugin with MockBukkit
+
+[MockBukkit](https://mockbukkit.org/) is the standard mocking framework
+for Bukkit / Paper plugins. It boots a fake `Server` in-process so you
+can test command handlers, event listeners, services, and the plugin's
+own lifecycle without spinning up a real Paper server.
+
+`pluggy test` packages your plugin into a jar before running tests
+and hands the path off via a `pluggy.test.mainJar` system property —
+see [Mocking-framework hand-off](../commands/test.md#mocking-framework-hand-off)
+in the command reference. `MockBukkit.loadJar(...)` reads that
+property; the integration is not MockBukkit-specific.
+
+## 1. Pick a MockBukkit version that matches your Paper API
+
+MockBukkit publishes one artifact per Paper minor version. The artifact
+ID embeds the Minecraft version (`mockbukkit-v1.21`), and each release
+of that artifact targets a specific Paper API revision — readable from
+the `Paper-Version` line in the jar's `META-INF/MANIFEST.MF`.
+
+Mismatched versions print:
+
+```
+################### MockBukkit Version Mismatch ###################
+🔍 MockBukkit X.Y.Z (…) was built against Paper API version 1.21.N-R0.1-SNAPSHOT
+```
+
+For Paper 1.21.8, MockBukkit `4.90.0` is the last release that targets
+that exact API; 4.95.0+ moved to 1.21.10 / 1.21.11. Check Maven Central
+metadata when picking a version:
+
+```bash
+curl -fsSL https://repo1.maven.org/maven2/org/mockbukkit/mockbukkit/mockbukkit-v1.21/maven-metadata.xml
+```
+
+## 2. Declare it as a `testDependency`
+
+```json
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "main": "com.example.demo.Main",
+  "compatibility": {
+    "versions": ["1.21.8"],
+    "platforms": ["paper"]
+  },
+  "testDependencies": {
+    "mockbukkit": {
+      "source": "maven:org.mockbukkit.mockbukkit:mockbukkit-v1.21",
+      "version": "4.90.0"
+    }
+  }
+}
+```
+
+`testDependencies` is resolved against your `registries` plus an
+implicit Maven Central, so MockBukkit is fetched without any extra
+config. JUnit Platform Console Standalone is auto-injected — you never
+declare it.
+
+## 3. Test the full plugin lifecycle
+
+Load the plugin via the `pluggy.test.mainJar` system property,
+explicitly enable it (MockBukkit's `loadJar` does not auto-enable), and
+go.
+
+```java
+package com.example.demo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+class MainPluginTest {
+
+    private ServerMock server;
+    private Plugin plugin;
+
+    @BeforeEach
+    void bootMockServer() {
+        server = MockBukkit.mock();
+        File jar = new File(System.getProperty("pluggy.test.mainJar"));
+        plugin = MockBukkit.loadJar(jar);
+        server.getPluginManager().enablePlugin(plugin);
+    }
+
+    @AfterEach
+    void shutdown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void pluginEnables() {
+        assertNotNull(plugin);
+        assertTrue(plugin.isEnabled());
+    }
+
+    @Test
+    void pluginNameMatches() {
+        assertEquals("demo", plugin.getName());
+    }
+
+    @Test
+    void canSpawnPlayers() {
+        server.addPlayer("Alice");
+        server.addPlayer("Bob");
+        assertEquals(2, server.getOnlinePlayers().size());
+    }
+}
+```
+
+Run it:
+
+```text
+$ pluggy test
+test demo
+  com.example.demo.MainPluginTest
+    ✓ canSpawnPlayers()  699ms
+    ✓ pluginEnables()  5ms
+    ✓ pluginNameMatches()  6ms
+
+  3 passed
+```
+
+The first MockBukkit-using test in a class pays a one-time warm-up
+cost (~700 ms); subsequent tests in the same class are fast.
+
+## 4. Loading other declared plugins
+
+Every dep declared in `project.json` (`dependencies` or
+`testDependencies`) is exposed to tests as a system property —
+see [Mocking-framework hand-off](../commands/test.md#mocking-framework-hand-off)
+for the full property list. The two patterns you'll use most:
+
+**Pick one by name** when a test cares about a specific dep:
+
+```java
+@Test
+void integratesWithWorldEditWhenPresent() {
+    File worldEdit = new File(System.getProperty("pluggy.test.dependency.worldedit"));
+    MockBukkit.loadJar(worldEdit);
+    plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
+    server.getPluginManager().enablePlugin(plugin);
+    // …assert your integration hook ran
+}
+```
+
+**Boot everything** when you want a maximal "production-like" mock
+server:
+
+```java
+@Test
+void worksUnderFullStack() {
+    for (String path : System.getProperty("pluggy.test.dependencies").split(File.pathSeparator)) {
+        if (path.isEmpty()) continue;
+        try { MockBukkit.loadJar(new File(path)); } catch (Exception ignored) {}
+    }
+    plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
+    server.getPluginManager().enablePlugin(plugin);
+}
+```
+
+The catch is required because library jars (Maven deps that aren't
+plugins) appear in the catalog too, and `loadJar` errors with
+"no plugin.yml" on those.
+
+Loading a real third-party plugin under MockBukkit can fail with
+`JavaPlugin requires a valid classloader` when that plugin's entry
+class is already on the runtime classpath. For coverage that only
+needs to detect "is plugin X loaded?", register a stub with the
+dep's name via `registerLoadedPlugin` instead of booting the real
+plugin.
+
+## 5. Test handlers without booting the plugin
+
+For tests that exercise listeners, commands, or services without
+needing the full plugin lifecycle, drive `ServerMock` directly. The
+plugin reference can be a fake (`MockBukkit.createMockPlugin()`) or
+the real one if you've already loaded it:
+
+```java
+class JoinListenerTest {
+
+    private ServerMock server;
+    private JoinListener listener;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        listener = new JoinListener();
+        server.getPluginManager().registerEvents(listener, MockBukkit.createMockPlugin());
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void greetsJoiningPlayers() {
+        var player = server.addPlayer("Alice");
+        assertTrue(player.nextMessage().contains("Welcome"));
+    }
+}
+```
+
+`server.addPlayer()` synchronously fires `PlayerJoinEvent`, so the
+listener runs and the assertion against `nextMessage()` reads the
+greeting your code sent.
+
+## Why `loadJar` and not `load(Main.class)`?
+
+`pluggy test` does not put the plugin's entry-point class
+(`project.main`) on the runtime classpath. The compile classpath
+includes it (so test code can `import com.example.demo.Main`), but
+the runtime classpath has it stripped out. That keeps the system
+classloader from resolving the entry-point first, which would trip
+Bukkit's `JavaPlugin requires a valid classloader` check the moment
+MockBukkit tried to reload it through its own classloader.
+
+Practical implications:
+
+- `MockBukkit.loadJar(System.getProperty("pluggy.test.mainJar"))`
+  works — load the plugin from the jar.
+- `MockBukkit.load(Main.class)` does _not_ work in this layout —
+  it requires `Main.class` on the runtime classpath, which pluggy
+  holds back.
+- Treat the loaded plugin as `Plugin` (or `JavaPlugin`) in your test
+  variable types. Direct runtime references to `Main.class` /
+  `new Main()` throw `NoClassDefFoundError` because the .class isn't
+  on the runtime classpath.
+
+Every other plugin class (utility classes, listeners, services) is
+on the runtime classpath as normal — only the declared entry-point
+class is held back.
+
+See [test command — Caveats](../commands/test.md#caveats) for the
+mechanism.
+
+## Cleaning up between runs
+
+When you delete or rename a test file, the old `.class` is still in
+the test staging directory and JUnit will keep finding it. Run with
+`--clean` to wipe the staging dir:
+
+```bash
+pluggy test --clean
+```
+
+You don't need `--clean` for normal edit-and-rerun cycles — `javac`
+overwrites changed classes in place, and the main jars are
+regenerated every run.
+
+## See also
+
+- [`pluggy test`](../commands/test.md) — full command reference,
+  including the [mocking-framework hand-off](../commands/test.md#mocking-framework-hand-off)
+  contract.
+- [`project.json` reference](../project-json.md#testdependencies) —
+  declaring `testDependencies`.
+- [MockBukkit documentation](https://mockbukkit.org/) — upstream docs
+  and API reference.

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -5,11 +5,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { createReadStream, createWriteStream } from "node:fs";
-import { mkdir, readdir, rm, stat } from "node:fs/promises";
-import { dirname, join, posix, relative } from "node:path";
-
-import yazl from "yazl";
+import { mkdir, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import { log } from "../logging.ts";
 import { getPlatform } from "../platform/index.ts";
@@ -22,6 +19,7 @@ import { resolveMaven } from "../resolver/maven.ts";
 import { compileJava } from "./compile.ts";
 import { pickDescriptor } from "./descriptor.ts";
 import { writeIdeFiles } from "./ide.ts";
+import { zipDirectory } from "./jar.ts";
 import { stageResources } from "./resources.ts";
 import { applyShading } from "./shade.ts";
 
@@ -263,53 +261,4 @@ function uniqueInOrder(values: string[]): string[] {
     out.push(v);
   }
   return out;
-}
-
-async function zipDirectory(sourceDir: string, destPath: string): Promise<void> {
-  const files = await collectFiles(sourceDir);
-  files.sort((a, b) => a.localeCompare(b));
-
-  return await new Promise<void>((resolvePromise, rejectPromise) => {
-    const zip = new yazl.ZipFile();
-
-    // yazl is a streaming writer — pipe before queuing entries.
-    const ws = createWriteStream(destPath);
-    ws.once("error", rejectPromise);
-    ws.once("close", () => resolvePromise());
-    zip.outputStream.pipe(ws);
-
-    for (const abs of files) {
-      const rel = toPosix(relative(sourceDir, abs));
-      zip.addReadStreamLazy(rel, (cb) => {
-        try {
-          cb(null, createReadStream(abs));
-        } catch (e) {
-          cb(e as Error, null as unknown as NodeJS.ReadableStream);
-        }
-      });
-    }
-
-    zip.end();
-  });
-}
-
-async function collectFiles(dir: string): Promise<string[]> {
-  const out: string[] = [];
-  async function walk(current: string): Promise<void> {
-    const entries = await readdir(current, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = join(current, entry.name);
-      if (entry.isDirectory()) {
-        await walk(full);
-      } else if (entry.isFile()) {
-        out.push(full);
-      }
-    }
-  }
-  await walk(dir);
-  return out;
-}
-
-function toPosix(p: string): string {
-  return p.split(/[/\\]/).filter(Boolean).join(posix.sep);
 }

--- a/src/build/jar.ts
+++ b/src/build/jar.ts
@@ -1,0 +1,73 @@
+/**
+ * Streaming zip helper used by the build and test pipelines to package a
+ * staging directory into a deterministic jar (sorted entries, forward-slashed
+ * paths). Lives here so both pipelines share one implementation.
+ */
+
+import { createReadStream, createWriteStream } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, posix, relative } from "node:path";
+
+import yazl from "yazl";
+
+export interface ZipOptions {
+  /**
+   * If provided, only entries whose forward-slashed relative path returns
+   * `true` are included. Lets callers carve a subset out of a staged tree
+   * without rebuilding it.
+   */
+  include?: (relPath: string) => boolean;
+}
+
+export async function zipDirectory(
+  sourceDir: string,
+  destPath: string,
+  opts: ZipOptions = {},
+): Promise<void> {
+  const files = await collectFiles(sourceDir);
+  files.sort((a, b) => a.localeCompare(b));
+
+  return await new Promise<void>((resolvePromise, rejectPromise) => {
+    const zip = new yazl.ZipFile();
+
+    const ws = createWriteStream(destPath);
+    ws.once("error", rejectPromise);
+    ws.once("close", () => resolvePromise());
+    zip.outputStream.pipe(ws);
+
+    for (const abs of files) {
+      const rel = toPosix(relative(sourceDir, abs));
+      if (opts.include !== undefined && !opts.include(rel)) continue;
+      zip.addReadStreamLazy(rel, (cb) => {
+        try {
+          cb(null, createReadStream(abs));
+        } catch (e) {
+          cb(e as Error, null as unknown as NodeJS.ReadableStream);
+        }
+      });
+    }
+
+    zip.end();
+  });
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(current: string): Promise<void> {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        out.push(full);
+      }
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+function toPosix(p: string): string {
+  return p.split(/[/\\]/).filter(Boolean).join(posix.sep);
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,7 +1,14 @@
 /**
- * Test pipeline — resolve deps → compile src → compile test → run JUnit
- * Platform Console Launcher → parse JUnit XML reports. Orchestration only;
- * pure arg-building and report-parsing live in `./runner.ts`.
+ * Test pipeline — resolve deps → compile src → package main.jar → compile
+ * test → run JUnit Platform Console Launcher → parse JUnit XML reports.
+ * Orchestration only; pure arg-building and report-parsing live in
+ * `./runner.ts`.
+ *
+ * Main classes are zipped into a `main.jar` (with the generated descriptor
+ * and any declared `resources`) and that jar — not the raw classes directory
+ * — is what the test classpath sees. This mirrors how the plugin is loaded
+ * in production and lets any framework that inspects the runtime classloader
+ * (MockBukkit, agent-style harnesses, …) work without per-framework hooks.
  *
  * JUnit Platform Console Standalone is auto-injected from Maven Central; the
  * user never declares it. User-provided test deps go in `project.json`'s
@@ -11,11 +18,15 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 
 import { compileJava } from "../build/compile.ts";
+import { pickDescriptor } from "../build/descriptor.ts";
+import { zipDirectory } from "../build/jar.ts";
+import { stageResources } from "../build/resources.ts";
 import { log } from "../logging.ts";
 import { getPlatform } from "../platform/index.ts";
+import { writeFileLF } from "../portable.ts";
 import type { ResolvedProject } from "../project.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { resolveMaven } from "../resolver/maven.ts";
@@ -91,13 +102,28 @@ export async function runTests(
     await rm(stagingDir, { recursive: true, force: true });
   }
 
-  const mainClassesDir = join(stagingDir, "main-classes");
+  // Main classes are compiled directly into a stage dir we then zip into a
+  // jar. Putting the *jar* (rather than the raw classes directory) on the test
+  // classpath matches how the plugin is loaded in production: any framework
+  // that does runtime classloader inspection — MockBukkit, agent-based test
+  // tooling, anything that calls `Class.getProtectionDomain().getCodeSource()`
+  // — sees a real jar URL and can find the descriptor on the classpath.
+  const mainStageDir = join(stagingDir, "main-jar-stage");
+  const mainJarPath = join(stagingDir, "main.jar");
+  const mainRuntimeJarPath = join(stagingDir, "main-runtime.jar");
   const testClassesDir = join(stagingDir, "test-classes");
   const reportsDir = join(stagingDir, "reports");
 
-  await mkdir(mainClassesDir, { recursive: true });
+  await mkdir(mainStageDir, { recursive: true });
   await mkdir(testClassesDir, { recursive: true });
-  // Wipe reports per-run so a stale TEST-*.xml from a deleted class can't leak in.
+  // The jars are regenerated from `mainStageDir` every run; the staleness
+  // story matches `mainStageDir` (incremental between runs, full reset
+  // under `--clean`). Drop the previous jars so a rebuild can't append
+  // onto a half-written file.
+  await rm(mainJarPath, { force: true });
+  await rm(mainRuntimeJarPath, { force: true });
+  // Reports are wiped per-run unconditionally so a stale TEST-*.xml from a
+  // deleted class can't leak into this run's results.
   await rm(reportsDir, { recursive: true, force: true });
   await mkdir(reportsDir, { recursive: true });
 
@@ -111,7 +137,7 @@ export async function runTests(
 
   const mainDeps = await resolveDeclared(project, "dependencies", projectRegistries);
   const platformApiJars = await resolvePlatformApiJars(project, projectRegistries);
-  const mainClasspath = dedupe([...flattenJars(mainDeps), ...platformApiJars]);
+  const mainClasspath = dedupe([...flattenJars(mainDeps.map((d) => d.dep)), ...platformApiJars]);
 
   const testDeps = await resolveDeclared(project, "testDependencies", testRegistries);
   const junit = await resolveMaven(
@@ -126,18 +152,44 @@ export async function runTests(
     },
   );
 
+  // We build two jars from the same staged directory:
+  //
+  //   * `main.jar` — the full jar, handed to the test JVM via the
+  //     `pluggy.test.mainJar` system property. Mocking frameworks
+  //     (MockBukkit, anything else that mounts a plugin classloader) load
+  //     the plugin from this path so the entry-point class ends up under
+  //     their own `ConfiguredPluginClassLoader`.
+  //   * `main-runtime.jar` — same content minus the declared entry-point
+  //     class. This jar goes on the system test classpath so plain
+  //     utility classes are reachable for non-mocking unit tests, but the
+  //     entry-point class is *not* — keeping it off the system loader is
+  //     what lets the mocking framework own it cleanly. Without this
+  //     split, Bukkit's `JavaPlugin requires a valid classloader` check
+  //     fires when the framework tries to reload the plugin.
+  //
+  // Test compile classpath uses the full `main.jar` so test code can
+  // import the entry-point class for `Main.class` references and similar.
+  const testDepJars = flattenJars(testDeps.map((d) => d.dep));
   const testCompileClasspath = dedupe([
-    mainClassesDir,
+    mainJarPath,
     ...mainClasspath,
-    ...flattenJars(testDeps),
+    ...testDepJars,
+    junit.jarPath,
+  ]);
+  const testRuntimeClasspath = dedupe([
+    mainRuntimeJarPath,
+    ...mainClasspath,
+    ...testDepJars,
     junit.jarPath,
   ]);
 
   await compileJava(project, {
     sourceDir: join(project.rootDir, "src"),
-    outputDir: mainClassesDir,
+    outputDir: mainStageDir,
     classpath: mainClasspath,
   });
+
+  await packageMainJar(project, mainStageDir, mainJarPath, mainRuntimeJarPath);
 
   await compileJava(project, {
     sourceDir: testSourceDir,
@@ -147,9 +199,10 @@ export async function runTests(
 
   const launcherArgs = buildLauncherArgs({
     consoleJar: junit.jarPath,
-    classpath: [testClassesDir, ...testCompileClasspath],
+    classpath: [testClassesDir, ...testRuntimeClasspath],
     testClassesDir,
     reportsDir,
+    systemProperties: buildTestSystemProperties(mainJarPath, mainDeps, testDeps),
     filter: opts.filter,
     failFast: opts.failFast,
   });
@@ -174,6 +227,98 @@ export async function runTests(
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
+
+/**
+ * Stage the generated descriptor + declared resources alongside the compiled
+ * classes in `mainStageDir`, then zip the directory into two jars:
+ *
+ *   * `mainJarPath` — full content, used by mocking frameworks via the
+ *     `pluggy.test.mainJar` system property.
+ *   * `mainRuntimeJarPath` — same content minus the declared entry-point
+ *     class. Goes on the system test classpath so utility classes are
+ *     reachable; the entry-point stays unreachable so the mocking
+ *     framework's classloader can own it (see Bukkit's `JavaPlugin`
+ *     classloader check).
+ *
+ * Shading is intentionally not applied: the test classpath already has
+ * every dep jar on it explicitly, so re-shading their classes into the
+ * jar would just produce duplicate-class warnings at test time.
+ */
+async function packageMainJar(
+  project: ResolvedProject,
+  mainStageDir: string,
+  mainJarPath: string,
+  mainRuntimeJarPath: string,
+): Promise<void> {
+  await stageResources(project, mainStageDir);
+
+  const descriptor = pickDescriptor(project);
+  const resources = project.resources;
+  const userOwnsDescriptor =
+    resources !== undefined &&
+    resources !== null &&
+    Object.prototype.hasOwnProperty.call(resources, descriptor.path);
+
+  if (!userOwnsDescriptor) {
+    const rendered = descriptor.generate(project);
+    const dest = join(mainStageDir, descriptor.path);
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFileLF(dest, rendered);
+  }
+
+  await zipDirectory(mainStageDir, mainJarPath);
+
+  // `project.main` is required for any workspace that runs tests (it has a
+  // `src/` to compile). If it's missing here, descriptor generation above
+  // already threw with a clearer message — but be defensive.
+  const mainEntry =
+    project.main !== undefined && project.main.length > 0
+      ? `${project.main.replace(/\./g, "/")}.class`
+      : undefined;
+  await zipDirectory(mainStageDir, mainRuntimeJarPath, {
+    include: (rel) => mainEntry === undefined || rel !== mainEntry,
+  });
+}
+
+/**
+ * Build the system-property catalog handed to the test JVM.
+ *
+ * Three properties are exposed:
+ *
+ *   * `pluggy.test.mainJar` — absolute path to the plugin's own jar.
+ *   * `pluggy.test.dependency.<name>` — one entry per declared dep
+ *     (`project.dependencies` and `project.testDependencies`), keyed by
+ *     the name from project.json. Picks of "load worldedit but not
+ *     luckperms" use this.
+ *   * `pluggy.test.dependencies` — `path.delimiter`-joined list of every
+ *     declared dep jar in declaration order (`dependencies` first, then
+ *     `testDependencies`). For "boot the server with everything declared".
+ *
+ * Transitive deps are intentionally not exposed: they're already on the
+ * test classpath, and surfacing them would let callers depend on
+ * indirect dep names that change without notice. Library-style Maven
+ * deps may end up in the catalog — pluggy doesn't try to detect "is
+ * this a plugin?", that's the test's call.
+ *
+ * On a name collision between `dependencies` and `testDependencies`,
+ * the testDependency wins (last-write). Pluggy's resolver already
+ * complains about ambiguous shapes upstream of this; if the same key
+ * survives to here we just pick the test-time entry.
+ */
+function buildTestSystemProperties(
+  mainJarPath: string,
+  mainDeps: NamedDependency[],
+  testDeps: NamedDependency[],
+): Record<string, string> {
+  const props: Record<string, string> = { "pluggy.test.mainJar": mainJarPath };
+  const ordered: string[] = [];
+  for (const { name, dep } of [...mainDeps, ...testDeps]) {
+    props[`pluggy.test.dependency.${name}`] = dep.jarPath;
+    ordered.push(dep.jarPath);
+  }
+  props["pluggy.test.dependencies"] = ordered.join(delimiter);
+  return props;
+}
 
 async function runJavaLauncher(args: string[]): Promise<{ exitCode: number; stderrTail: string }> {
   log.debug(`java ${args.length} args (JUnit Console Launcher)`);
@@ -227,15 +372,21 @@ async function readReports(reportsDir: string): Promise<string[]> {
   return out;
 }
 
+interface NamedDependency {
+  /** The key under `dependencies` / `testDependencies` in project.json. */
+  name: string;
+  dep: ResolvedDependency;
+}
+
 async function resolveDeclared(
   project: ResolvedProject,
   field: "dependencies" | "testDependencies",
   registries: string[],
-): Promise<ResolvedDependency[]> {
+): Promise<NamedDependency[]> {
   const declared = project[field];
   if (declared === undefined || declared === null) return [];
 
-  const out: ResolvedDependency[] = [];
+  const out: NamedDependency[] = [];
   for (const [name, raw] of Object.entries(declared)) {
     const { source, version } =
       typeof raw === "string"
@@ -248,7 +399,7 @@ async function resolveDeclared(
       force: false,
       registries,
     });
-    out.push(resolved);
+    out.push({ name, dep: resolved });
   }
   return out;
 }

--- a/src/test/runner.test.ts
+++ b/src/test/runner.test.ts
@@ -70,6 +70,20 @@ describe("buildLauncherArgs", () => {
     expect(args).toContain("--scan-class-path=/t");
   });
 
+  test("system properties are emitted as -D flags before -jar", () => {
+    const args = buildLauncherArgs({
+      consoleJar: "/j",
+      classpath: [],
+      testClassesDir: "/t",
+      reportsDir: "/r",
+      systemProperties: { "pluggy.test.mainJar": "/stage/main.jar", debug: "true" },
+    });
+    expect(args[0]).toBe("-Dpluggy.test.mainJar=/stage/main.jar");
+    expect(args[1]).toBe("-Ddebug=true");
+    expect(args[2]).toBe("-jar");
+    expect(args[3]).toBe("/j");
+  });
+
   test("method selector drops --scan-class-path (JUnit rejects scan + select)", () => {
     const args = buildLauncherArgs({
       consoleJar: "/j",

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -19,6 +19,11 @@ export interface LauncherArgs {
   filter?: string;
   /** Stop on first failure. */
   failFast?: boolean;
+  /**
+   * JVM system properties to pass before `-jar` (rendered as `-Dkey=value`).
+   * Ordered iteration; values are not escaped — callers must pre-validate.
+   */
+  systemProperties?: Record<string, string>;
 }
 
 export interface TestCase {
@@ -52,7 +57,13 @@ export function buildLauncherArgs(args: LauncherArgs): string[] {
   // the selector does its own discovery against `--class-path`.
   const hasSelector = filterArgs.some((a) => a.startsWith("--select-"));
 
-  const out: string[] = [
+  const out: string[] = [];
+  if (args.systemProperties !== undefined) {
+    for (const [key, value] of Object.entries(args.systemProperties)) {
+      out.push(`-D${key}=${value}`);
+    }
+  }
+  out.push(
     "-jar",
     args.consoleJar,
     // `execute` is the explicit subcommand; newer standalone jars warn without it.
@@ -60,7 +71,7 @@ export function buildLauncherArgs(args: LauncherArgs): string[] {
     "--disable-banner",
     "--details=none",
     `--class-path=${args.classpath.join(delimiter)}`,
-  ];
+  );
   if (!hasSelector) {
     out.push(`--scan-class-path=${args.testClassesDir}`);
   }


### PR DESCRIPTION
## Summary

- Adds the missing `docs/commands/test.md` reference (the test command shipped in #6 was undocumented) and a worked MockBukkit recipe at `docs/recipes/testing-with-mockbukkit.md`, cross-linked from the docs index, README, getting-started, and `project.json` reference (new `testDependencies` field).
- Reworks the test pipeline so it compiles `src/` into a real production-shaped `main.jar` (classes + descriptor + resources) and puts that jar on the test classpath instead of a raw classes directory, mirroring how plugins load in production.
- Builds a second `main-runtime.jar` with the `project.main` entry-point class stripped, putting only that on the runtime classpath so a mocking framework's own `ConfiguredPluginClassLoader` can own the entry-point class without tripping Bukkit's `JavaPlugin requires a valid classloader` check.
- Exposes a framework-agnostic system-property catalog (`pluggy.test.mainJar`, `pluggy.test.dependency.<name>`, `pluggy.test.dependencies`) so any test or mocking framework can find the plugin jar and any declared dep by name or as a path-separator list.
- Refactors `zipDirectory` out to `src/build/jar.ts` (with an optional `include` filter) so build and test share one zipper.

## Test plan

- [x] `vp check` (format + lint + typecheck) clean
- [x] `vp test` — 346 passed, 3 skipped, 0 failed
- [x] Verified end-to-end against a playground demo: 3 utility tests, 4 MockBukkit lifecycle tests against the real `Main extends JavaPlugin` (load via `MockBukkit.loadJar(System.getProperty("pluggy.test.mainJar"))`), 3 catalog tests asserting every declared dep's property exists and points at a real file