### PR TITLE
docs: add documentation convention and rewrite README to apply it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ See `conventions/` for the full conventions with examples in both TypeScript and
 
 - **`conventions/QUALITY.md`** -API design: verb+noun entry points, category objects, single call backbone, no global state, fail-early errors.
 - **`conventions/PERFORMANCE.md`** -Performance: data structure selection, bounded collections, early exits, signal over polling, hot-path allocations, batching, coordination.
+- **`conventions/DOCUMENTATION.md`** -Writing docs: lead with the answer, active voice, "must" vs "we recommend", show the artifact (code, tree, config) instead of describing it, rarely use em-dashes, sentence-case headings with intro paragraphs, descriptive links, no duplicated facts.
 
 ## Runtime & tooling
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ch99q
+Copyright (c) 2024-2026 Christian W. Hansen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,124 +9,144 @@
 
 # pluggy
 
-A CLI for Minecraft plugin development. Scaffold a project, pull
-dependencies from Modrinth / Maven / local jars / sibling workspaces,
-build a real plugin jar with the full Maven transitive closure on the
-classpath, and boot a live Paper / Spigot / Velocity server with a
-file-watcher that rebuilds on save.
-
-Ships as a single native binary — no Gradle wrapper, no `pom.xml`, no
-JVM-based toolchain to install. One JSON file per project, one lockfile
-per repo.
+pluggy is a Minecraft plugin toolchain that fits in one binary. Scaffold a project, install plugins from Modrinth, pull Maven artifacts with their full transitive closure, and run a live Paper, Spigot, or Velocity server that rebuilds on save.
 
 ## Install
 
-macOS / Linux:
+Install pluggy with the script for your platform. Both scripts drop the binary on your `PATH` without root or administrator rights.
+
+On macOS and Linux:
 
 ```bash
 curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
 ```
 
-Windows (PowerShell):
+On Windows (PowerShell):
 
 ```powershell
 irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
 ```
 
-Both scripts drop the binary somewhere on your `PATH`. Verify:
+Open a new terminal and verify:
 
 ```bash
 pluggy -V
 ```
 
-Upgrade in place any time with `pluggy upgrade`.
+To upgrade in place later, run `pluggy upgrade`.
 
-## Quick tour
+## Quick start
 
-```bash
-# Scaffold
-mkdir my-plugin && cd my-plugin
-pluggy init --yes --name my_plugin --main com.example.myplugin.Main
+Go from an empty directory to a running server in three commands:
 
-# Add deps
-pluggy install worldedit                            # Modrinth
-pluggy install maven:net.kyori:adventure-api@4.17.0 # Maven
-pluggy install ./libs/proprietary.jar               # Local jar
+```text
+$ pluggy init --yes --name shop --main com.example.shop.Main
 
-# Build
-pluggy build
-# → bin/my_plugin-1.0.0.jar
+$ pluggy install worldedit
+Installed worldedit into shop (1 resolved).
 
-# Run a live Paper server with rebuild-on-save
-pluggy dev
+$ pluggy dev
+dev: starting shop
 ```
 
-For the full walkthrough, read
-[docs/getting-started.md](./docs/getting-started.md).
+That gives you this layout:
 
-## What it supports
+```text
+shop/
+├── project.json
+├── pluggy.lock
+└── src/
+    ├── com/example/shop/Main.java
+    └── config.yml
+```
 
-- **Platforms.** paper, folia, spigot, bukkit, velocity, waterfall,
-  travertine. Each is a first-class provider with its own descriptor
-  family and Maven API coordinate.
-- **Dependency sources.** Modrinth slugs, Maven coordinates, local jars
-  (content-addressed by SHA-256), and sibling workspaces.
-- **Transitive resolution.** The Maven resolver parses POMs, folds in
-  `<dependencyManagement>` BOM imports, and handles `-SNAPSHOT` versions
-  by fetching per-version metadata. Full closure on the classpath.
-- **Workspaces.** Monorepo layouts with inheritance, topological build
-  ordering, and `workspace:` source kind for sibling deps.
-- **Cross-platform.** macOS, Linux, Windows — identical behaviour, same
-  native binary format (arm64 + amd64 where available).
-- **IDE integration.** VS Code, Eclipse, IntelliJ. Set `"ide": [...]` in
-  `project.json` (or pick them at `init` time) and builds scaffold the
-  right project files for every listed editor.
-- **Reproducible.** Every resolved dep carries a SHA-256 integrity
-  hash. `pluggy.lock` is sorted, LF-terminated, atomic-written.
+And this `project.json`:
 
-## Commands at a glance
+```json
+{
+  "name": "shop",
+  "version": "1.0.0",
+  "main": "com.example.shop.Main",
+  "compatibility": {
+    "versions": ["1.21.8"],
+    "platforms": ["paper"]
+  },
+  "dependencies": {
+    "worldedit": {
+      "source": "modrinth:worldedit",
+      "version": "7.3.15"
+    }
+  }
+}
+```
+
+Save a `.java` file and pluggy rebuilds the jar, restarts the server, and lands you back at the Paper console, typically inside a second. Ship a release jar with one more command:
+
+```text
+$ pluggy build
+✔ shop: bin/shop-1.0.0.jar (142.4 KB, 3821ms)
+```
+
+## Why pluggy
+
+pluggy collapses every step of plugin development into one binary: scaffold, dependency resolution, build, dev loop, and IDE setup. The list below covers what that buys you, with the command that demonstrates each.
+
+- **Modrinth in one line.** `pluggy install worldedit` resolves the latest stable, downloads it, and locks the SHA-256. No registry config, no version pinning required up front.
+- **Maven without XML.** `pluggy install maven:net.kyori:adventure-api@4.17.0` parses the POM, folds in `<dependencyManagement>` BOM imports, and lands the full transitive closure on the classpath. SNAPSHOT versions resolve through per-version metadata.
+- **Live server in one command.** `pluggy dev` downloads the matching Paper, Spigot, or Velocity jar, accepts the EULA, hardlinks your plugin and runtime deps into `plugins/`, and boots the server. File saves trigger a debounced rebuild and restart.
+- **Seven server platforms.** paper, folia, spigot, bukkit, velocity, waterfall, and travertine, each with its own descriptor format and Maven API coordinate. Switch by editing `compatibility.platforms` in `project.json`.
+- **Cross-platform, identically.** The same binary runs on macOS, Linux, and Windows. Paths normalize to forward slashes, generated files use LF line endings, and shutdown handling works the same on every OS.
+- **Reproducible by default.** Every resolved dep is recorded in `pluggy.lock` with a SHA-256 hash. The lockfile is sorted, LF-terminated, and written atomically. Diffs stay small and merges stay sane.
+- **IDE-aware.** List editors in `"ide": ["vscode", "eclipse", "intellij"]` and `pluggy build` scaffolds the right project files for every entry.
+- **Workspaces.** Monorepo layouts with inheritance, topological build order, and a `workspace:` source kind for sibling dependencies.
+
+## Commands
+
+pluggy exposes a small set of commands. Every command supports `--json` for structured output and `--help` for inline help.
 
 | Command                      | Summary                                            |
 | ---------------------------- | -------------------------------------------------- |
 | `pluggy init`                | Scaffold a new project.                            |
-| `pluggy install [plugin]`    | Add a dep or reconcile the lockfile.               |
-| `pluggy remove <plugin>`     | Drop a dep (and its cached jar).                   |
+| `pluggy install [plugin]`    | Add a dependency or reconcile the lockfile.        |
+| `pluggy remove <plugin>`     | Drop a dependency and its cached jar.              |
 | `pluggy info <plugin>`       | Inspect a source.                                  |
 | `pluggy search <query>`      | Query Modrinth.                                    |
 | `pluggy list`                | Show declared deps, resolved versions, registries. |
-| `pluggy build`               | Compile → resources → descriptor → shade → jar.    |
+| `pluggy build`               | Compile, package resources, and produce a jar.     |
 | `pluggy test`                | Compile and run JUnit tests under `test/`.         |
-| `pluggy dev`                 | Live server with rebuild-on-save.                  |
-| `pluggy doctor`              | Validate environment and every workspace.          |
+| `pluggy dev`                 | Run a live server that rebuilds on save.           |
+| `pluggy doctor`              | Validate the environment and every workspace.      |
 | `pluggy upgrade`             | Replace the binary with the latest release.        |
 | `pluggy completions <shell>` | Print a shell completion script.                   |
 
-Every command is documented in [docs/commands/](./docs/commands/).
+For per-command flags, JSON envelopes, and sample output, see the [command reference](./docs/commands/).
 
 ## Documentation
 
-- **Start here:** [docs/getting-started.md](./docs/getting-started.md)
-- **Config reference:** [docs/project-json.md](./docs/project-json.md)
-- **Dependencies:** [docs/dependencies.md](./docs/dependencies.md)
-- **Workspaces:** [docs/workspaces.md](./docs/workspaces.md)
-- **Build pipeline:** [docs/build-pipeline.md](./docs/build-pipeline.md)
-- **Dev server:** [docs/dev-server.md](./docs/dev-server.md)
-- **IDE integration:** [docs/ide.md](./docs/ide.md)
-- **Cross-platform notes:** [docs/cross-platform.md](./docs/cross-platform.md)
-- **Troubleshooting:** [docs/troubleshooting.md](./docs/troubleshooting.md)
-- **All docs:** [docs/README.md](./docs/README.md)
+The full documentation lives under [`docs/`](./docs/). Start with the getting-started guide; the rest is reference.
+
+- [Getting started](./docs/getting-started.md): install, scaffold, build, run a dev server.
+- [project.json reference](./docs/project-json.md): every field and validation rule.
+- [Dependency sources](./docs/dependencies.md): the Modrinth, Maven, file, and workspace grammar.
+- [Build pipeline](./docs/build-pipeline.md): what happens between `pluggy build` and the jar.
+- [Dev server](./docs/dev-server.md): staging directory, EULA, reload semantics, shutdown.
+- [Workspaces](./docs/workspaces.md): monorepo layout, inheritance, topological order.
+- [IDE integration](./docs/ide.md): what pluggy writes for VS Code, Eclipse, and IntelliJ.
+- [Cross-platform notes](./docs/cross-platform.md): paths, line endings, signal handling.
+- [Troubleshooting](./docs/troubleshooting.md): common failures and how to fix them.
 
 ## Contributing
 
-Source is TypeScript, organized around a commander command tree and a
-pluggable platform registry. `vp check` (format + lint + typecheck) and
-`vp test` (Vitest) validate changes. The shipped CLI binary is produced
-by `bun build --compile`.
+pluggy is written in TypeScript. The development loop runs through Vite+ (`vp check`, `vp test`) and the shipped CLI binary is produced by `bun build --compile`.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development loop and
-[CLAUDE.md](./CLAUDE.md) for repo conventions (cross-platform rules,
-command conventions, stub-module workflow).
+For the development loop, see [CONTRIBUTING.md](./CONTRIBUTING.md). For repo conventions (cross-platform rules, command shape, and the stub-module workflow), see [CLAUDE.md](./CLAUDE.md).
 
 ## License
 
-MIT. See [LICENSE](./LICENSE).
+pluggy is released under the MIT License. See [LICENSE](./LICENSE).
+
+## Next steps
+
+- New to pluggy: read the [getting started guide](./docs/getting-started.md).
+- Migrating from Maven or Gradle: see the [migration recipe](./docs/recipes/migrating-from-maven-gradle.md).
+- Setting up CI: see the [CI without global pluggy recipe](./docs/recipes/ci-without-global-pluggy.md).

--- a/conventions/DOCUMENTATION.md
+++ b/conventions/DOCUMENTATION.md
@@ -47,7 +47,7 @@ Bad: "Click `Save` on the Settings page."
 Good: "On the Settings page, click `Save`."
 
 Format identifiers consistently. Use code font for filenames, commands, code, environment variables, and API names. Use bold for UI elements such as button labels and menu names. Use plain text for prose.
-Bad: "Run **vp check** in the *src/* directory."
+Bad: "Run **vp check** in the _src/_ directory."
 Good: "Run `vp check` in the `src/` directory."
 
 Write descriptive link text that makes sense out of context. Screen readers and link lists strip the surrounding prose; "click here" tells the user nothing.

--- a/conventions/DOCUMENTATION.md
+++ b/conventions/DOCUMENTATION.md
@@ -1,0 +1,69 @@
+# Documentation
+
+This convention defines how to write documentation that stays accurate, scannable, and consistent. It applies to every prose surface in the project: READMEs, guides, reference pages, command help text, and PR descriptions. Examples are shown as Bad and Good pairs.
+
+Lead with the answer. The first sentence of every section tells the reader what they will learn or what the section does. Do not bury the point under context, history, or hedging.
+Bad: "There are several ways to configure pluggy, depending on what you are doing."
+Good: "Configure pluggy by editing `project.json`. Every key is documented below."
+
+Address the reader as "you" and write in active voice and present tense. Active voice names the actor and stays short. Present tense describes how the system behaves, not how it once behaved.
+Bad: "The server will be queried by the client when a request has been made."
+Good: "The client queries the server on each request."
+
+Use "must" for requirements and "we recommend" for recommendations. Avoid "should" because it hides whether the rule is mandatory.
+Bad: "You should run `vp check` before committing."
+Good: "Run `vp check` before committing." or "We recommend running `vp check` before committing."
+
+Prefer simple words and precise verbs. Cut hedges, jargon, anthropomorphism, and marketing language. "Lets you" beats "allows you to." "The server returns" beats "the server thinks."
+Bad: "This powerful feature allows users to leverage advanced caching capabilities."
+Good: "Caching speeds up repeated builds. Enable it with `cache: true`."
+
+Show the artifact when introducing a tool or feature. Developers engage with code, file trees, configuration, and CLI sessions, not with adjective-led benefit lists. A real terminal session, a directory layout, or the actual config file sells better than prose that describes how the tool feels, and stays accurate as the code evolves.
+Bad: "pluggy gives you a clean, intuitive workflow with a beautifully simple project file."
+Good: a `project.json` snippet, the resulting directory tree, and three terminal commands that produce them.
+
+Use meaningful names in examples. Placeholders like `foo` and `bar` strip the example of the context that helps a reader map it to their own problem.
+Bad: `function foo(bar) { return bar.baz; }`
+Good: `function balance(account) { return account.deposits; }`
+
+Spell out Latin abbreviations. "For example" and "that is" read more naturally than "e.g." and "i.e." and translate cleanly for non-native speakers.
+Bad: "Pass any flag (e.g., `--json`) to the command."
+Good: "Pass any flag, for example `--json`, to the command."
+
+Rarely use em-dashes. They fragment sentences and read as a tic when overused. Reach first for a period when the thought is complete, a comma when the aside is short, parentheses when it is genuinely parenthetical, or a colon when the second clause explains the first. Reserve em-dashes for the rare interruption that none of those carry.
+Bad: "Run `vp check` — it formats, lints, and type-checks — before committing."
+Good: "Run `vp check` before committing. It formats, lints, and type-checks."
+
+Use sentence case for headings, and place one introductory paragraph between every heading and its first list. A heading followed immediately by bullets leaves the reader without context for what the list represents.
+Bad: `## Configuration\n- cache: enable build cache\n- ...`
+Good: `## Configuration\n\nConfigure pluggy through \`project.json\`. Every key below is optional.\n\n- cache: enable build cache`
+
+Use numbered lists for sequential steps and bulleted lists for everything else. Keep items parallel: every item begins with the same part of speech, such as an imperative verb for steps or a noun for inventory.
+Bad: bullet list mixing "Install dependencies" and "Caching is enabled by default"
+Good: bullet list with "Install dependencies" and "Enable caching"
+
+State conditions before actions. The reader needs to know where they are before being told what to do, otherwise they act in the wrong place and back out.
+Bad: "Click `Save` on the Settings page."
+Good: "On the Settings page, click `Save`."
+
+Format identifiers consistently. Use code font for filenames, commands, code, environment variables, and API names. Use bold for UI elements such as button labels and menu names. Use plain text for prose.
+Bad: "Run **vp check** in the *src/* directory."
+Good: "Run `vp check` in the `src/` directory."
+
+Write descriptive link text that makes sense out of context. Screen readers and link lists strip the surrounding prose; "click here" tells the user nothing.
+Bad: "For install instructions, [click here](README.md)."
+Good: "See the [install instructions](README.md)."
+
+Keep docs accurate to the implementation. Documentation that contradicts the code is worse than no documentation. Update docs in the same change as the behaviour they describe, and when you rename a heading, update every link that targets it.
+Bad: a `--cache` flag described in the README that was removed two releases ago.
+Good: removing the flag and its README entry in the same commit.
+
+Do not duplicate facts. Each fact lives in one place; other pages link to it. Duplicated facts drift, and readers chasing the second copy will read the stale one.
+Bad: install steps copy-pasted into both `README.md` and `docs/getting-started.md`.
+Good: `README.md` links to `docs/getting-started.md` for install steps.
+
+Close with what's next when applicable. End how-to and tutorial pages with a short "Next steps" section linking to the natural follow-up. Reference pages need no closer.
+Bad: a tutorial that ends with "That's it!"
+Good: a tutorial that ends with "Next steps" linking to the deployment guide.
+
+These rules together produce documentation that stays useful as the project evolves. When a doc feels hard to read, the answer is almost always one of: buried point, passive voice, hidden requirement, vague verb, abstract instead of demonstrated, placeholder-shaped example, Latin abbreviation, em-dash clutter, missing context paragraph, mismatched list, conditions after actions, inconsistent formatting, undescriptive link, stale fact, duplicated fact, or missing follow-up. Check in that order.


### PR DESCRIPTION
## Summary

- Adds `conventions/DOCUMENTATION.md`, a sibling to `QUALITY.md` and `PERFORMANCE.md`, with the rules for writing docs in the same paragraph-then-example shape: lead with the answer, active voice, "must" vs "we recommend", show the artifact instead of describing it, rarely use em-dashes, sentence-case headings with intro paragraphs, descriptive links, no duplicated facts.
- Rewrites `README.md` to apply the convention: trimmed lead, Install above the fold, and a Quick start that shows the CLI session, the resulting directory tree, and a real `project.json` rather than prose.
- Reframes the capabilities list as benefit-led entries grounded in the literal command that demonstrates each item.
- Adds an index entry for the new convention to `CLAUDE.md`.

## Test plan

- [ ] `vp test`
- [ ] `vp lint`
- [x] Manual: rendered README locally; verified link targets resolve and the new convention reads consistently against `QUALITY.md` / `PERFORMANCE.md`.