### PR TITLE
feat(test): run a (version × platform) matrix with per-cell JDKs

### DIFF
--- a/src/commands/test.test.ts
+++ b/src/commands/test.test.ts
@@ -108,6 +108,12 @@ describe("runTestCommand", () => {
       ok: true,
       tests: { total: 3, passed: 3, failed: 0, skipped: 0 },
     });
+    expect(res.results[0].cells).toHaveLength(1);
+    expect(res.results[0].cells[0]).toMatchObject({
+      mcVersion: "1.21.8",
+      platformId: "paper",
+      ok: true,
+    });
   });
 
   test("test failure → exitCode 1, failures array populated", async () => {
@@ -145,6 +151,8 @@ describe("runTestCommand", () => {
         durationMs: 2,
         message: "expected true",
         stackTrace: "at A.f(A.java:1)",
+        mcVersion: "1.21.8",
+        platformId: "paper",
       },
     ]);
   });
@@ -266,6 +274,122 @@ describe("runTestCommand", () => {
 
     const call = vi.mocked(runTests).mock.calls[0];
     expect(call[1]).toMatchObject({ filter: "@tag:slow", failFast: true });
+  });
+
+  async function writeMatrixProject(): Promise<void> {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "matrix",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: {
+          versions: ["1.21.4", "1.20.4"],
+          platforms: ["paper", "spigot"],
+        },
+      }),
+    );
+  }
+
+  function okOutcome(
+    mcVersion?: string,
+    platformId?: string,
+  ): {
+    status: "ok";
+    durationMs: number;
+    result: { total: number; passed: number; failed: number; skipped: number; cases: [] };
+    mcVersion?: string;
+    platformId?: string;
+    jdkMajor?: number;
+  } {
+    return {
+      status: "ok",
+      durationMs: 1,
+      result: { total: 1, passed: 1, failed: 0, skipped: 0, cases: [] },
+      mcVersion,
+      platformId,
+      jdkMajor: 21,
+    };
+  }
+
+  test("expands a 2x2 matrix into four runTests calls", async () => {
+    await writeMatrixProject();
+    vi.mocked(runTests).mockImplementation(async (_p, opts) =>
+      okOutcome(opts?.mcVersion, opts?.platformId),
+    );
+
+    const res = await runTestCommand({ cwd: rootDir });
+
+    expect(res.exitCode).toBe(0);
+    expect(runTests).toHaveBeenCalledTimes(4);
+    const cellCoords = res.results[0].cells.map((c) => `${c.mcVersion}:${c.platformId}`);
+    expect(cellCoords).toEqual(["1.21.4:paper", "1.21.4:spigot", "1.20.4:paper", "1.20.4:spigot"]);
+    expect(res.results[0].tests).toEqual({ total: 4, passed: 4, failed: 0, skipped: 0 });
+  });
+
+  test("--mc-version and --platform narrow the matrix", async () => {
+    await writeMatrixProject();
+    vi.mocked(runTests).mockImplementation(async (_p, opts) =>
+      okOutcome(opts?.mcVersion, opts?.platformId),
+    );
+
+    const res = await runTestCommand({
+      cwd: rootDir,
+      mcVersions: ["1.21.4"],
+      platforms: ["paper"],
+    });
+
+    expect(runTests).toHaveBeenCalledTimes(1);
+    expect(res.results[0].cells).toHaveLength(1);
+    expect(res.results[0].cells[0]).toMatchObject({ mcVersion: "1.21.4", platformId: "paper" });
+  });
+
+  test("--mc-version with an undeclared value rejects with a clear error", async () => {
+    await writeMatrixProject();
+
+    await expect(runTestCommand({ cwd: rootDir, mcVersions: ["1.99.0"] })).rejects.toThrow(
+      /--mc-version "1.99.0"/,
+    );
+    expect(runTests).not.toHaveBeenCalled();
+  });
+
+  test("mixed-family platforms fail matrix expansion before running cells", async () => {
+    await writeFile(
+      join(rootDir, "project.json"),
+      JSON.stringify({
+        name: "mixed",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.4"], platforms: ["paper", "velocity"] },
+      }),
+    );
+
+    await expect(runTestCommand({ cwd: rootDir })).rejects.toThrow(/must share one family/);
+    expect(runTests).not.toHaveBeenCalled();
+  });
+
+  test("--fail-fast stops the matrix at the first failed cell", async () => {
+    await writeMatrixProject();
+    vi.mocked(runTests).mockResolvedValueOnce({
+      status: "ok",
+      durationMs: 1,
+      result: {
+        total: 1,
+        passed: 0,
+        failed: 1,
+        skipped: 0,
+        cases: [{ suite: "A", name: "f", durationMs: 1, status: "failed", message: "x" }],
+      },
+      mcVersion: "1.21.4",
+      platformId: "paper",
+      jdkMajor: 21,
+    });
+
+    const res = await runTestCommand({ cwd: rootDir, failFast: true });
+
+    expect(res.exitCode).toBe(1);
+    expect(runTests).toHaveBeenCalledTimes(1);
+    expect(res.results[0].cells).toHaveLength(1);
   });
 });
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -4,6 +4,7 @@ import { Command, InvalidArgumentError } from "commander";
 
 import { runTests, type TestRunOutcome } from "../test/index.ts";
 import { bold, dim, green, log, red, yellow } from "../logging.ts";
+import { assertSamePlatformFamily } from "../platform/index.ts";
 import type { ResolvedProject } from "../project.ts";
 import type { TestCase } from "../test/runner.ts";
 import {
@@ -21,6 +22,30 @@ export interface TestCommandOptions {
   workspaces?: boolean;
   json?: boolean;
   cwd?: string;
+  /** Narrow the matrix to one or more MC versions. Empty = no filter. */
+  mcVersions?: string[];
+  /** Narrow the matrix to one or more platform ids. Empty = no filter. */
+  platforms?: string[];
+}
+
+export interface TestCellResult {
+  mcVersion?: string;
+  platformId?: string;
+  jdkMajor?: number;
+  ok: boolean;
+  durationMs: number;
+  tests?: { total: number; passed: number; failed: number; skipped: number };
+  failures?: Array<{
+    class: string;
+    test: string;
+    durationMs: number;
+    message?: string;
+    stackTrace?: string;
+  }>;
+  /** "no-test-dir" | "no-sources" when the cell ran no tests. */
+  skipped?: "no-test-dir" | "no-sources";
+  /** Set when the cell errored before tests could run (e.g. compile). */
+  error?: string;
 }
 
 export interface TestCommandResult {
@@ -31,28 +56,42 @@ export interface TestCommandResult {
     rootDir: string;
     ok: boolean;
     durationMs: number;
+    /** Sum of `tests` totals across all cells in this workspace. */
     tests?: { total: number; passed: number; failed: number; skipped: number };
+    /** Failures across all cells, each tagged with the cell's coordinates. */
     failures?: Array<{
       class: string;
       test: string;
       durationMs: number;
       message?: string;
       stackTrace?: string;
+      mcVersion?: string;
+      platformId?: string;
     }>;
-    /** "no-test-dir" | "no-sources" when the workspace ran no tests. */
+    /** Set when every cell hit the same `no-tests` reason (workspace-wide fact). */
     skipped?: "no-test-dir" | "no-sources";
-    /** Set when the workspace errored before tests could run (e.g. compile). */
+    /** Set when the workspace errored before any cell could run. */
     error?: string;
+    /** One entry per (mcVersion × platformId) cell run for this workspace. */
+    cells: TestCellResult[];
   }>;
 }
 
 /**
  * Run `pluggy test` across the resolved target set.
  *
- * Compile errors and launcher failures rethrow for single-target calls so the
- * top-level handler formats them; in multi-workspace runs the error is
- * captured into the per-workspace result and we keep going. Test *failures*
- * (asserts) never throw — they surface via `ok: false` + `failures[]`.
+ * Each project expands into a matrix of `(mcVersion × platformId)` cells —
+ * every entry of `compatibility.versions` paired with every entry of
+ * `compatibility.platforms`. All platforms must share one family (bukkit,
+ * velocity, bungee); mixing families fails matrix expansion before any
+ * cell runs. `--mc-version` and `--platform` narrow the matrix down for
+ * fast iteration.
+ *
+ * Compile errors and launcher failures rethrow only when there is exactly
+ * one cell across the entire run so the top-level handler formats them;
+ * otherwise the error is captured into the per-cell result and the next
+ * cell continues. Test *failures* (asserts) never throw — they surface
+ * via `ok: false` + `failures[]` on the cell.
  */
 export async function runTestCommand(opts: TestCommandOptions): Promise<TestCommandResult> {
   const cwd = opts.cwd ?? process.cwd();
@@ -65,91 +104,197 @@ export async function runTestCommand(opts: TestCommandOptions): Promise<TestComm
 
   const results: TestCommandResult["results"] = [];
   let anyFailed = false;
-
+  // Track the total cell count across all targets so we know whether to
+  // rethrow on a single-cell run (matches the prior single-target rethrow).
+  // Keep the raw error around so InvalidArgumentError keeps its type when
+  // a single-target rethrow surfaces it to the top-level handler.
+  const matrices: {
+    project: ResolvedProject;
+    cells: MatrixCell[];
+    error?: { message: string; original: unknown };
+  }[] = [];
   for (const target of targets) {
-    const label = target.name;
-    const rootDir = target.rootDir;
-    const started = Date.now();
-
     try {
-      if (opts.json !== true) {
-        log.info(`${bold("test")} ${label}`);
-      }
-
-      const outcome: TestRunOutcome = await runTests(target, {
-        filter: opts.filter,
-        failFast: opts.failFast,
-        clean: opts.clean,
-      });
-
-      if (outcome.status === "no-tests") {
-        const reason = outcome.reason;
-        results.push({
-          workspace: label,
-          rootDir,
-          ok: true,
-          durationMs: outcome.durationMs,
-          skipped: reason,
-        });
-        if (opts.json !== true) {
-          const msg =
-            reason === "no-test-dir"
-              ? `${label}: no test/ directory — nothing to run`
-              : `${label}: test/ contains no .java sources`;
-          log.warn(msg);
-        }
-        continue;
-      }
-
-      const { result, durationMs } = outcome;
-      const ok = result.failed === 0;
-      if (!ok) anyFailed = true;
-
-      const failures = result.cases
-        .filter((c) => c.status === "failed")
-        .map((c) => ({
-          class: c.suite,
-          test: c.name,
-          durationMs: c.durationMs,
-          message: c.message,
-          stackTrace: c.stackTrace,
-        }));
-
-      results.push({
-        workspace: label,
-        rootDir,
-        ok,
-        durationMs,
-        tests: {
-          total: result.total,
-          passed: result.passed,
-          failed: result.failed,
-          skipped: result.skipped,
-        },
-        failures: failures.length > 0 ? failures : undefined,
-      });
-
-      if (opts.json !== true) {
-        renderHumanResult(label, result.cases, result);
-      }
+      matrices.push({ project: target, cells: buildMatrix(target, opts) });
     } catch (err) {
-      anyFailed = true;
       const message = err instanceof Error ? err.message : String(err);
+      matrices.push({ project: target, cells: [], error: { message, original: err } });
+    }
+  }
+  const totalCellCount = matrices.reduce((n, m) => n + m.cells.length, 0);
+  let anyCellFailed = false;
+
+  let stopAfterWorkspace = false;
+  for (const { project, cells, error } of matrices) {
+    if (stopAfterWorkspace) break;
+    const label = project.name;
+    const rootDir = project.rootDir;
+    const workspaceStarted = Date.now();
+
+    if (error !== undefined) {
+      anyFailed = true;
       results.push({
         workspace: label,
         rootDir,
         ok: false,
-        durationMs: Date.now() - started,
-        error: message,
+        durationMs: 0,
+        cells: [],
+        error: error.message,
       });
       if (opts.json !== true) {
-        log.error(`${label}: ${message}`);
+        log.error(`${label}: ${error.message}`);
       }
       if (targets.length === 1) {
-        throw err;
+        throw error.original;
+      }
+      continue;
+    }
+
+    if (cells.length === 0) {
+      // Matrix filters excluded everything — surface a clear error rather
+      // than silently passing.
+      anyFailed = true;
+      const message =
+        "no matrix cells matched — check --mc-version / --platform against compatibility.";
+      results.push({
+        workspace: label,
+        rootDir,
+        ok: false,
+        durationMs: 0,
+        cells: [],
+        error: message,
+      });
+      if (opts.json !== true) log.error(`${label}: ${message}`);
+      continue;
+    }
+
+    if (opts.json !== true) {
+      log.info(
+        `${bold("test")} ${label} ${dim(`(${cells.length} cell${cells.length === 1 ? "" : "s"})`)}`,
+      );
+    }
+
+    const cellResults: TestCellResult[] = [];
+    let workspaceOk = true;
+
+    for (const cell of cells) {
+      const cellLabel = formatCellLabel(cell);
+      const cellStarted = Date.now();
+
+      if (opts.json !== true) {
+        log.info(`  ${dim("→")} ${cellLabel}`);
+      }
+
+      try {
+        const outcome: TestRunOutcome = await runTests(project, {
+          filter: opts.filter,
+          failFast: opts.failFast,
+          clean: opts.clean,
+          mcVersion: cell.mcVersion,
+          platformId: cell.platformId,
+        });
+
+        if (outcome.status === "no-tests") {
+          cellResults.push({
+            mcVersion: cell.mcVersion,
+            platformId: cell.platformId,
+            ok: true,
+            durationMs: outcome.durationMs,
+            skipped: outcome.reason,
+          });
+          if (opts.json !== true) {
+            const msg =
+              outcome.reason === "no-test-dir"
+                ? `no test/ directory — nothing to run`
+                : `test/ contains no .java sources`;
+            log.warn(`    ${msg}`);
+          }
+          // No-tests is the same across every cell (it's a workspace fact),
+          // so once we see it we can break out — re-running the matrix would
+          // produce identical output.
+          break;
+        }
+
+        const { result, durationMs, jdkMajor } = outcome;
+        const ok = result.failed === 0;
+        if (!ok) {
+          workspaceOk = false;
+          anyCellFailed = true;
+        }
+
+        const failures = result.cases
+          .filter((c) => c.status === "failed")
+          .map((c) => ({
+            class: c.suite,
+            test: c.name,
+            durationMs: c.durationMs,
+            message: c.message,
+            stackTrace: c.stackTrace,
+          }));
+
+        cellResults.push({
+          mcVersion: cell.mcVersion,
+          platformId: cell.platformId,
+          jdkMajor,
+          ok,
+          durationMs,
+          tests: {
+            total: result.total,
+            passed: result.passed,
+            failed: result.failed,
+            skipped: result.skipped,
+          },
+          failures: failures.length > 0 ? failures : undefined,
+        });
+
+        if (opts.json !== true) {
+          renderHumanResult(result.cases, result);
+        }
+
+        if (!ok && opts.failFast === true) {
+          // Stop the whole run — the user asked to bail on first failure.
+          anyFailed = true;
+          stopAfterWorkspace = true;
+          break;
+        }
+      } catch (err) {
+        workspaceOk = false;
+        anyCellFailed = true;
+        const message = err instanceof Error ? err.message : String(err);
+        cellResults.push({
+          mcVersion: cell.mcVersion,
+          platformId: cell.platformId,
+          ok: false,
+          durationMs: Date.now() - cellStarted,
+          error: message,
+        });
+        if (opts.json !== true) {
+          log.error(`    ${message}`);
+        }
+        if (totalCellCount === 1) {
+          throw err;
+        }
+        if (opts.failFast === true) {
+          anyFailed = true;
+          stopAfterWorkspace = true;
+          break;
+        }
       }
     }
+
+    if (!workspaceOk) anyFailed = true;
+
+    results.push({
+      workspace: label,
+      rootDir,
+      ok: workspaceOk,
+      durationMs: Date.now() - workspaceStarted,
+      ...rollupCells(cellResults),
+      cells: cellResults,
+    });
   }
+
+  if (anyCellFailed) anyFailed = true;
 
   const exitCode: 0 | 1 = anyFailed ? 1 : 0;
   const status: TestCommandResult["status"] = anyFailed ? "partial" : "success";
@@ -157,32 +302,97 @@ export async function runTestCommand(opts: TestCommandOptions): Promise<TestComm
   if (opts.json === true) {
     const payload = {
       status: anyFailed ? "error" : "success",
-      results: results.map((r) => ({
-        workspace: r.workspace,
-        rootDir: r.rootDir,
-        ok: r.ok,
-        durationMs: r.durationMs,
-        tests: r.tests,
-        failures: r.failures,
-        skipped: r.skipped,
-        error: r.error,
-      })),
+      results,
     };
     if (anyFailed) {
       console.error(JSON.stringify(payload, null, 2));
     } else {
       console.log(JSON.stringify(payload, null, 2));
     }
-  } else if (targets.length > 1) {
+  } else if (results.length > 1 || (results[0]?.cells.length ?? 0) > 1) {
     log.info("");
     log.info(bold("summary"));
     for (const r of results) {
-      const line = summaryLine(r);
-      log.info(`  ${r.workspace}: ${line}`);
+      if (r.error !== undefined) {
+        log.info(`  ${r.workspace}: FAILED — ${r.error}`);
+        continue;
+      }
+      for (const cell of r.cells) {
+        const cellLabel = formatCellLabel(cell);
+        log.info(`  ${r.workspace} ${dim(cellLabel)}: ${summaryLine(cell)}`);
+      }
     }
   }
 
   return { status, exitCode, results };
+}
+
+interface MatrixCell {
+  mcVersion?: string;
+  platformId?: string;
+}
+
+/**
+ * Expand a project's compatibility matrix into the cells `pluggy test` will
+ * run. Validates that every platform belongs to one family, then takes the
+ * cross product of `versions × platforms`. `--mc-version` / `--platform`
+ * filter the inputs before expansion; an empty filter array means "no
+ * filter" while a non-empty one rejects values that don't match.
+ */
+export function buildMatrix(project: ResolvedProject, opts: TestCommandOptions): MatrixCell[] {
+  const versions = project.compatibility?.versions ?? [];
+  const platforms = project.compatibility?.platforms ?? [];
+
+  if (platforms.length > 0) {
+    // Throws if platforms come from more than one family — caller catches.
+    assertSamePlatformFamily(platforms);
+  }
+
+  const versionFilter = opts.mcVersions ?? [];
+  const platformFilter = opts.platforms ?? [];
+
+  if (versionFilter.length > 0) {
+    for (const v of versionFilter) {
+      if (!versions.includes(v)) {
+        throw new InvalidArgumentError(
+          `--mc-version "${v}" is not declared in compatibility.versions (${versions.join(", ") || "empty"}).`,
+        );
+      }
+    }
+  }
+  if (platformFilter.length > 0) {
+    for (const p of platformFilter) {
+      if (!platforms.includes(p)) {
+        throw new InvalidArgumentError(
+          `--platform "${p}" is not declared in compatibility.platforms (${platforms.join(", ") || "empty"}).`,
+        );
+      }
+    }
+  }
+
+  const usedVersions = versionFilter.length > 0 ? versionFilter : versions;
+  const usedPlatforms = platformFilter.length > 0 ? platformFilter : platforms;
+
+  // If a project has no compatibility entries at all, emit a single "default"
+  // cell — preserves the prior behaviour of testing whatever the project is
+  // shaped like (compile-only suites without a platform classpath still work).
+  if (usedVersions.length === 0 && usedPlatforms.length === 0) {
+    return [{}];
+  }
+  if (usedVersions.length === 0) {
+    return usedPlatforms.map((platformId) => ({ platformId }));
+  }
+  if (usedPlatforms.length === 0) {
+    return usedVersions.map((mcVersion) => ({ mcVersion }));
+  }
+
+  const cells: MatrixCell[] = [];
+  for (const mcVersion of usedVersions) {
+    for (const platformId of usedPlatforms) {
+      cells.push({ mcVersion, platformId });
+    }
+  }
+  return cells;
 }
 
 /**
@@ -225,20 +435,95 @@ export function selectTestTargets(
   return [context.root];
 }
 
-function summaryLine(r: TestCommandResult["results"][number]): string {
-  if (r.error !== undefined) return `FAILED — ${r.error}`;
-  if (r.skipped === "no-test-dir") return "no test/ directory";
-  if (r.skipped === "no-sources") return "no .java sources in test/";
-  const t = r.tests;
+interface CellRollup {
+  tests?: { total: number; passed: number; failed: number; skipped: number };
+  failures?: Array<{
+    class: string;
+    test: string;
+    durationMs: number;
+    message?: string;
+    stackTrace?: string;
+    mcVersion?: string;
+    platformId?: string;
+  }>;
+  skipped?: "no-test-dir" | "no-sources";
+  error?: string;
+}
+
+/**
+ * Aggregate cell results into workspace-level rollup fields. Tests counts
+ * sum across cells; failures gain `mcVersion` / `platformId` tags so the
+ * caller can tell which cell each failure came from. `skipped` is only
+ * surfaced when *every* cell reported the same reason — a per-cell
+ * skip otherwise belongs in `cells[i].skipped`. `error` collects every
+ * cell's error message into a single newline-joined blob (with cell
+ * coordinates prefixed) so simple consumers don't have to walk `cells`.
+ */
+function rollupCells(cells: TestCellResult[]): CellRollup {
+  const out: CellRollup = {};
+
+  let totalRan = 0;
+  const totals = { total: 0, passed: 0, failed: 0, skipped: 0 };
+  for (const cell of cells) {
+    if (cell.tests === undefined) continue;
+    totalRan += 1;
+    totals.total += cell.tests.total;
+    totals.passed += cell.tests.passed;
+    totals.failed += cell.tests.failed;
+    totals.skipped += cell.tests.skipped;
+  }
+  if (totalRan > 0) out.tests = totals;
+
+  const failures: NonNullable<CellRollup["failures"]> = [];
+  for (const cell of cells) {
+    for (const f of cell.failures ?? []) {
+      failures.push({
+        ...f,
+        mcVersion: cell.mcVersion,
+        platformId: cell.platformId,
+      });
+    }
+  }
+  if (failures.length > 0) out.failures = failures;
+
+  if (cells.length > 0 && cells.every((c) => c.skipped !== undefined)) {
+    const reasons = new Set(cells.map((c) => c.skipped));
+    if (reasons.size === 1) {
+      out.skipped = cells[0].skipped;
+    }
+  }
+
+  const errorLines: string[] = [];
+  for (const cell of cells) {
+    if (cell.error === undefined) continue;
+    const label = formatCellLabel({ mcVersion: cell.mcVersion, platformId: cell.platformId });
+    errorLines.push(label === "default" ? cell.error : `[${label}] ${cell.error}`);
+  }
+  if (errorLines.length > 0) out.error = errorLines.join("\n");
+
+  return out;
+}
+
+function formatCellLabel(cell: MatrixCell): string {
+  const parts: string[] = [];
+  if (cell.platformId !== undefined) parts.push(cell.platformId);
+  if (cell.mcVersion !== undefined) parts.push(cell.mcVersion);
+  return parts.length > 0 ? parts.join(" ") : "default";
+}
+
+function summaryLine(cell: TestCellResult): string {
+  if (cell.error !== undefined) return `FAILED — ${cell.error}`;
+  if (cell.skipped === "no-test-dir") return "no test/ directory";
+  if (cell.skipped === "no-sources") return "no .java sources in test/";
+  const t = cell.tests;
   if (t === undefined) return "ok";
   const parts = [`${t.passed} passed`];
   if (t.failed > 0) parts.push(`${t.failed} failed`);
   if (t.skipped > 0) parts.push(`${t.skipped} skipped`);
-  return parts.join(", ") + ` (${r.durationMs}ms)`;
+  return parts.join(", ") + ` (${cell.durationMs}ms)`;
 }
 
 function renderHumanResult(
-  label: string,
   cases: TestCase[],
   totals: { total: number; passed: number; failed: number; skipped: number },
 ): void {
@@ -251,20 +536,20 @@ function renderHumanResult(
   }
 
   for (const [suite, entries] of bySuite) {
-    log.info(`  ${suite}`);
+    log.info(`    ${suite}`);
     for (const c of entries) {
       const glyph =
         c.status === "passed" ? green("✓") : c.status === "failed" ? red("✗") : yellow("○");
-      const line = `    ${glyph} ${c.name}`;
+      const line = `      ${glyph} ${c.name}`;
       const time = dim(`${c.durationMs}ms`);
       log.info(`${line}  ${time}`);
       if (c.status === "failed") {
         if (c.message !== undefined && c.message.length > 0) {
-          log.info(`        ${c.message}`);
+          log.info(`          ${c.message}`);
         }
         if (c.stackTrace !== undefined) {
           const first = c.stackTrace.split("\n").find((l) => l.trim().startsWith("at "));
-          if (first !== undefined) log.info(`        ${first.trim()}`);
+          if (first !== undefined) log.info(`          ${first.trim()}`);
         }
       }
     }
@@ -273,8 +558,16 @@ function renderHumanResult(
   const parts = [`${totals.passed} passed`];
   if (totals.failed > 0) parts.push(`${totals.failed} failed`);
   if (totals.skipped > 0) parts.push(`${totals.skipped} skipped`);
-  log.info("");
-  log.info(`  ${parts.join(", ")}`);
+  log.info(`    ${parts.join(", ")}`);
+}
+
+function parseList(value: string, previous: string[] | undefined): string[] {
+  const acc = previous ?? [];
+  for (const part of value.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.length > 0) acc.push(trimmed);
+  }
+  return acc;
 }
 
 /** Factory for the `pluggy test` commander command. */
@@ -286,10 +579,20 @@ export function testCommand(): Command {
       "--filter <pattern>",
       "Include tests matching classname glob, Class#method, or @tag:<name>.",
     )
-    .option("--fail-fast", "Stop after the first test failure.")
+    .option("--fail-fast", "Stop after the first test or matrix-cell failure.")
     .option("--clean", "Wipe the test build cache before running.")
     .option("--workspace <name>", "Test a single workspace.")
     .option("--workspaces", "Explicit all-workspaces test.")
+    .option(
+      "--mc-version <version>",
+      "Narrow the matrix to one MC version (repeatable, comma-separated).",
+      parseList,
+    )
+    .option(
+      "--platform <id>",
+      "Narrow the matrix to one platform id (repeatable, comma-separated).",
+      parseList,
+    )
     .action(async function action(this: Command, options) {
       const globalOpts = this.optsWithGlobals();
       const result = await runTestCommand({
@@ -298,6 +601,8 @@ export function testCommand(): Command {
         clean: options.clean === true,
         workspace: options.workspace,
         workspaces: options.workspaces === true,
+        mcVersions: options.mcVersion,
+        platforms: options.platform,
         json: globalOpts.json === true,
       });
       if (result.exitCode !== 0) {

--- a/src/platform/platform.test.ts
+++ b/src/platform/platform.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for `assertSamePlatformFamily` — the validator the test command
+ * runs before expanding `compatibility.platforms` into a matrix. Imports
+ * `../platform/index.ts` for its side-effect registrations.
+ */
+
+import { describe, expect, test } from "vite-plus/test";
+
+import { assertSamePlatformFamily } from "./index.ts";
+
+describe("assertSamePlatformFamily", () => {
+  test("paper + spigot share the bukkit family", () => {
+    expect(assertSamePlatformFamily(["paper", "spigot"])).toBe("bukkit");
+  });
+
+  test("returns the family for a single platform", () => {
+    expect(assertSamePlatformFamily(["velocity"])).toBe("velocity");
+  });
+
+  test("rejects mixing bukkit and velocity", () => {
+    expect(() => assertSamePlatformFamily(["paper", "velocity"])).toThrow(/must share one family/);
+  });
+
+  test("rejects mixing velocity and bungee", () => {
+    expect(() => assertSamePlatformFamily(["velocity", "waterfall"])).toThrow(
+      /must share one family/,
+    );
+  });
+
+  test("rejects an empty list", () => {
+    expect(() => assertSamePlatformFamily([])).toThrow(/empty/);
+  });
+
+  test("propagates getPlatform's error for unknown ids", () => {
+    expect(() => assertSamePlatformFamily(["paper", "bogus"])).toThrow(/'bogus' not found/);
+  });
+});

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -83,3 +83,37 @@ export function getPlatform(providerId: string): PlatformProvider {
 export function getRegisteredPlatforms(): string[] {
   return Object.keys(PLATFORMS);
 }
+
+/**
+ * Validate that every id in `platformIds` resolves to a registered platform
+ * and that they all share one `descriptor.family`. Returns that shared family.
+ *
+ * A plugin can only target one family at a time — bukkit-derived APIs and
+ * proxy APIs (velocity, bungee) don't share an entry-point class. Mixing
+ * them in `compatibility.platforms` is always a project-config bug.
+ */
+export function assertSamePlatformFamily(platformIds: string[]): PlatformFamily {
+  if (platformIds.length === 0) {
+    throw new Error("compatibility.platforms is empty — at least one platform is required.");
+  }
+
+  const byFamily = new Map<PlatformFamily, string[]>();
+  for (const id of platformIds) {
+    const family = getPlatform(id).descriptor.family;
+    const list = byFamily.get(family) ?? [];
+    list.push(id);
+    byFamily.set(family, list);
+  }
+
+  if (byFamily.size > 1) {
+    const groups = Array.from(byFamily.entries())
+      .map(([family, ids]) => `${family} (${ids.join(", ")})`)
+      .join(" vs ");
+    throw new Error(
+      `compatibility.platforms must share one family — got ${groups}. ` +
+        "Split platforms from different families into separate workspaces.",
+    );
+  }
+
+  return byFamily.keys().next().value as PlatformFamily;
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -42,7 +42,7 @@ import {
 } from "./cache.ts";
 import { resolveJdk, targetForHost, type DiscoArch, type DiscoOs } from "./disco.ts";
 import { installJdk } from "./install.ts";
-import { selectJdkForProject, type ProjectJdkSelection } from "./resolve.ts";
+import { selectJdkForProject, selectJdkForVersion, type ProjectJdkSelection } from "./resolve.ts";
 
 export interface EnsureJdkOptions {
   /** Disco distribution slug. Default `"temurin"`. */
@@ -124,6 +124,23 @@ export async function ensureJdkForProject(
   opts: EnsureJdkOptions = {},
 ): Promise<ResolvedJdk & { selection: ProjectJdkSelection }> {
   const selection = await selectJdkForProject(project);
+  const distribution = opts.distribution ?? selection.distribution;
+  const resolved = await ensureJdk(selection.major, { ...opts, distribution });
+  return { ...resolved, selection };
+}
+
+/**
+ * Resolve the JDK for a specific MC version of a project. Used by matrix
+ * callers (the test command) so each `(version, platform)` cell gets the
+ * JDK its MC version actually requires — 1.20.4 cells stay on Java 17 even
+ * if `versions[0]` is 1.21.
+ */
+export async function ensureJdkForVersion(
+  project: ResolvedProject,
+  mcVersion: string | undefined,
+  opts: EnsureJdkOptions = {},
+): Promise<ResolvedJdk & { selection: ProjectJdkSelection }> {
+  const selection = await selectJdkForVersion(project, mcVersion);
   const distribution = opts.distribution ?? selection.distribution;
   const resolved = await ensureJdk(selection.major, { ...opts, distribution });
   return { ...resolved, selection };

--- a/src/sdk/resolve.test.ts
+++ b/src/sdk/resolve.test.ts
@@ -14,7 +14,7 @@ vi.mock("../platform/spigot/buildtools.ts", () => ({
 
 import { getJavaRange } from "../platform/spigot/buildtools.ts";
 
-import { selectJdkForProject } from "./resolve.ts";
+import { selectJdkForProject, selectJdkForVersion } from "./resolve.ts";
 
 function project(overrides: Partial<ResolvedProject> = {}): ResolvedProject {
   return {
@@ -71,5 +71,35 @@ describe("selectJdkForProject", () => {
     );
     expect(sel.major).toBe(21);
     expect(sel.source).toBe("fallback-default");
+  });
+});
+
+describe("selectJdkForVersion", () => {
+  afterEach(() => {
+    vi.mocked(getJavaRange).mockReset();
+  });
+
+  test("uses the explicit MC version, not versions[0]", async () => {
+    vi.mocked(getJavaRange).mockImplementation(async (v: string) =>
+      v === "1.20.4" ? [17, 25] : v === "1.21.4" ? [21, 25] : undefined,
+    );
+    const p = project({ compatibility: { versions: ["1.21.4", "1.20.4"], platforms: ["paper"] } });
+
+    const sel20 = await selectJdkForVersion(p, "1.20.4");
+    expect(sel20.major).toBe(17);
+    expect(sel20.source).toBe("spigot-manifest");
+
+    const sel21 = await selectJdkForVersion(p, "1.21.4");
+    expect(sel21.major).toBe(21);
+    expect(sel21.source).toBe("spigot-manifest");
+  });
+
+  test("project pin still wins regardless of MC version", async () => {
+    vi.mocked(getJavaRange).mockResolvedValue([17, 25]);
+    const sel = await selectJdkForVersion(
+      project({ jdk: { major: 25, distribution: "graalvm_community" } }),
+      "1.20.4",
+    );
+    expect(sel).toEqual({ major: 25, distribution: "graalvm_community", source: "project-pin" });
   });
 });

--- a/src/sdk/resolve.ts
+++ b/src/sdk/resolve.ts
@@ -61,18 +61,24 @@ export interface ProjectJdkSelection {
 }
 
 /**
- * Resolve which JDK to install for a project. Pure compute — no FS or
- * network beyond `getJavaRange`'s 5s probe (which silently falls through
- * to the heuristic on failure).
+ * Resolve which JDK to install for a specific MC version of a project. Pure
+ * compute — no FS or network beyond `getJavaRange`'s 5s probe (which silently
+ * falls through to the heuristic on failure).
+ *
+ * `mcVersion` is taken explicitly so matrix-style callers (the test command
+ * iterating `compatibility.versions`) can pick the right JDK per cell rather
+ * than always using `versions[0]`.
  */
-export async function selectJdkForProject(project: ResolvedProject): Promise<ProjectJdkSelection> {
+export async function selectJdkForVersion(
+  project: ResolvedProject,
+  mcVersion: string | undefined,
+): Promise<ProjectJdkSelection> {
   const distribution = project.jdk?.distribution ?? DEFAULT_DISTRIBUTION;
 
   if (project.jdk?.major !== undefined) {
     return { major: project.jdk.major, distribution, source: "project-pin" };
   }
 
-  const mcVersion = project.compatibility?.versions?.[0];
   if (mcVersion === undefined) {
     return { major: 21, distribution, source: "fallback-default" };
   }
@@ -93,4 +99,9 @@ export async function selectJdkForProject(project: ResolvedProject): Promise<Pro
   // No prefix match — current latest LTS as the default. Better to over-install
   // than to refuse to build; user can pin if this is wrong.
   return { major: 21, distribution, source: "fallback-default" };
+}
+
+/** Resolve the JDK for the project's primary MC version (`versions[0]`). */
+export function selectJdkForProject(project: ResolvedProject): Promise<ProjectJdkSelection> {
+  return selectJdkForVersion(project, project.compatibility?.versions?.[0]);
 }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -30,7 +30,7 @@ import { writeFileLF } from "../portable.ts";
 import type { ResolvedProject } from "../project.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { resolveMaven } from "../resolver/maven.ts";
-import { ensureJdkForProject } from "../sdk/index.ts";
+import { ensureJdkForVersion } from "../sdk/index.ts";
 import { parseSource } from "../source.ts";
 
 import {
@@ -59,6 +59,16 @@ export interface TestRunOptions {
   filter?: string;
   /** Stop on first test failure. */
   failFast?: boolean;
+  /**
+   * MC version this run targets. Selects the JDK and the platform API jars.
+   * Defaults to `compatibility.versions[0]`.
+   */
+  mcVersion?: string;
+  /**
+   * Platform id this run targets. Selects which family's API jars are on
+   * the classpath. Defaults to `compatibility.platforms[0]`.
+   */
+  platformId?: string;
 }
 
 export type TestRunOutcome =
@@ -66,12 +76,17 @@ export type TestRunOutcome =
       status: "ok";
       durationMs: number;
       result: ParsedRunResult;
+      mcVersion?: string;
+      platformId?: string;
+      jdkMajor?: number;
     }
   | {
       status: "no-tests";
       durationMs: number;
       /** Why no tests ran — surfaced to the user. */
       reason: "no-test-dir" | "no-sources";
+      mcVersion?: string;
+      platformId?: string;
     };
 
 /**
@@ -87,16 +102,29 @@ export async function runTests(
 
   const testSourceDir = join(project.rootDir, "test");
   if (!(await isDirectory(testSourceDir))) {
-    return { status: "no-tests", durationMs: Date.now() - started, reason: "no-test-dir" };
+    return {
+      status: "no-tests",
+      durationMs: Date.now() - started,
+      reason: "no-test-dir",
+      mcVersion: opts.mcVersion,
+      platformId: opts.platformId,
+    };
   }
   if (!(await hasJavaSources(testSourceDir))) {
-    return { status: "no-tests", durationMs: Date.now() - started, reason: "no-sources" };
+    return {
+      status: "no-tests",
+      durationMs: Date.now() - started,
+      reason: "no-sources",
+      mcVersion: opts.mcVersion,
+      platformId: opts.platformId,
+    };
   }
 
-  const stagingId = createHash("sha256")
-    .update(`${project.name}\0${project.version}\0${project.rootDir}`)
-    .digest("hex")
-    .slice(0, 12);
+  const mcVersion = opts.mcVersion ?? project.compatibility?.versions?.[0];
+  const platformId = opts.platformId ?? project.compatibility?.platforms?.[0];
+
+  const stagingKey = `${project.name}\0${project.version}\0${project.rootDir}\0${mcVersion ?? ""}\0${platformId ?? ""}`;
+  const stagingId = createHash("sha256").update(stagingKey).digest("hex").slice(0, 12);
   const stagingDir = join(project.rootDir, STAGING_ROOT, `${stagingId}-test`);
 
   if (opts.clean === true) {
@@ -137,7 +165,12 @@ export async function runTests(
   const testRegistries = dedupe([...projectRegistries, MAVEN_CENTRAL]);
 
   const mainDeps = await resolveDeclared(project, "dependencies", projectRegistries);
-  const platformApiJars = await resolvePlatformApiJars(project, projectRegistries);
+  const platformApiJars = await resolvePlatformApiJars(
+    project,
+    projectRegistries,
+    platformId,
+    mcVersion,
+  );
   const mainClasspath = dedupe([...flattenJars(mainDeps.map((d) => d.dep)), ...platformApiJars]);
 
   const testDeps = await resolveDeclared(project, "testDependencies", testRegistries);
@@ -184,9 +217,10 @@ export async function runTests(
     junit.jarPath,
   ]);
 
-  // Resolve the JDK once and thread it through compile + launcher. Done up
-  // front so a cache miss only blocks once per `pluggy test` run.
-  const jdk = await ensureJdkForProject(project);
+  // Resolve the JDK once and thread it through compile + launcher. Keyed off
+  // the cell's MC version so matrix runs across `1.20.4` + `1.21` get Java 17
+  // and Java 21 respectively rather than always using `versions[0]`.
+  const jdk = await ensureJdkForVersion(project, mcVersion);
 
   await compileJava(project, {
     sourceDir: join(project.rootDir, "src"),
@@ -228,7 +262,14 @@ export async function runTests(
     );
   }
 
-  return { status: "ok", durationMs: Date.now() - started, result };
+  return {
+    status: "ok",
+    durationMs: Date.now() - started,
+    result,
+    mcVersion,
+    platformId,
+    jdkMajor: jdk.major,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -417,19 +458,19 @@ async function resolveDeclared(
 async function resolvePlatformApiJars(
   project: ResolvedProject,
   projectRegistries: string[],
+  platformId: string | undefined,
+  mcVersion: string | undefined,
 ): Promise<string[]> {
-  const platforms = project.compatibility?.platforms ?? [];
-  const versions = project.compatibility?.versions ?? [];
-  if (platforms.length === 0 || versions.length === 0) return [];
+  if (platformId === undefined || mcVersion === undefined) return [];
 
-  let primary;
+  let provider;
   try {
-    primary = getPlatform(platforms[0]);
+    provider = getPlatform(platformId);
   } catch {
     return [];
   }
 
-  const apiSpec = await primary.api(versions[0]);
+  const apiSpec = await provider.api(mcVersion);
   if (apiSpec.dependencies.length === 0) return [];
 
   const registries = dedupe([...apiSpec.repositories, ...projectRegistries]);


### PR DESCRIPTION
## Summary

- `pluggy test` now expands `compatibility.versions × compatibility.platforms` into a sequential matrix instead of only running `[0]`/`[0]`.
- Each cell provisions the JDK its MC version requires via new `selectJdkForVersion` / `ensureJdkForVersion` helpers (1.20.4 → 17, 1.21 → 21), so cross-version suites just work.
- Platforms are validated to share one family (bukkit / velocity / bungee) before expansion; mixed families fail fast with a clear message.
- New `--mc-version` and `--platform` filters narrow the matrix; `--fail-fast` now also stops at the first failed cell. Per-cell results show in human + JSON output, and workspace-level totals roll up with each failure tagged by its cell coordinates.

## Test plan

- [x] `vp test` (431 passed, 3 skipped)
- [x] `vp check` (format + lint + typecheck clean)
- [x] Manual: 4-cell matrix (`paper`/`spigot` × `1.21.4`/`1.20.4`) ran end-to-end in `playground/`; pluggy auto-installed JDK 17 for the 1.20.4 cells while reusing JDK 21 for 1.21.4
- [x] Manual: `compatibility.platforms: ["paper", "velocity"]` errors before any cell runs with `must share one family — got bukkit (paper) vs velocity (velocity)`
- [x] Manual: `bun build --compile --outfile=bin/pluggy ./src/index.ts` produces a working binary