### PR TITLE
fix(dev): scope project.json watcher to avoid rebuild loops

### DIFF
--- a/src/dev/watch.test.ts
+++ b/src/dev/watch.test.ts
@@ -199,6 +199,30 @@ describe("watchProject", () => {
     }
   });
 
+  test("ignores non-project.json events from the project root", async () => {
+    const onChange = vi.fn(async () => {});
+    const project = makeProject(workDir);
+    const dispose = watchProject(project, { debounceMs: 10, onChange });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const rootWatcher = controllers.find((c) => c.target === workDir);
+    expect(rootWatcher).toBeDefined();
+
+    rootWatcher?.push({ eventType: "change", filename: "bin/repro-1.0.0.jar" });
+    rootWatcher?.push({ eventType: "rename", filename: ".pluggy-build" });
+    rootWatcher?.push({ eventType: "change", filename: "dev" });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onChange).not.toHaveBeenCalled();
+
+    rootWatcher?.push({ eventType: "change", filename: "project.json" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
   test("includes resource paths in the watch set", async () => {
     const { mkdir } = await import("node:fs/promises");
     await mkdir(join(workDir, "i18n"), { recursive: true });

--- a/src/dev/watch.ts
+++ b/src/dev/watch.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, statSync } from "node:fs";
 import { watch } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 
 import { log } from "../logging.ts";
 import type { ResolvedProject } from "../project.ts";
@@ -16,6 +16,13 @@ export interface WatchOptions {
   debounceMs: number;
   /** Called when a rebuild-worthy change is detected (already debounced). */
   onChange: () => Promise<void>;
+}
+
+interface WatchTarget {
+  path: string;
+  recursive: boolean;
+  /** If set, only events whose filename matches will trigger onChange. */
+  filename?: string;
 }
 
 /**
@@ -64,17 +71,35 @@ export function watchProject(project: ResolvedProject, opts: WatchOptions): () =
 }
 
 /**
- * Collect directory paths to watch. Resource-file mappings are normalized to
- * their parent directory — atomic-rewrite editors evict the file's inode,
- * which kills a file-level watcher; watching the dir survives.
+ * Collect watch targets. Source and resource directories are watched
+ * recursively; `project.json` is watched file-scoped (parent dir,
+ * non-recursive, filename filter) so pluggy's own writes into `bin/`,
+ * `dev/`, and `.pluggy-build/` do not trigger rebuild loops.
+ *
+ * Resource-file mappings are normalized to their parent directory — atomic-
+ * rewrite editors evict the file's inode, which kills a file-level watcher;
+ * watching the dir survives.
  */
-function collectWatchTargets(project: ResolvedProject): string[] {
-  const roots = new Set<string>();
+function collectWatchTargets(project: ResolvedProject): WatchTarget[] {
+  const targets: WatchTarget[] = [];
+  const dirs = new Set<string>();
+
+  const addDir = (path: string): void => {
+    if (dirs.has(path)) return;
+    dirs.add(path);
+    targets.push({ path, recursive: true });
+  };
 
   const srcDir = resolve(project.rootDir, "src");
-  if (existsSync(srcDir)) roots.add(srcDir);
+  if (existsSync(srcDir)) addDir(srcDir);
 
-  roots.add(dirname(project.projectFile));
+  if (existsSync(project.projectFile)) {
+    targets.push({
+      path: dirname(project.projectFile),
+      recursive: false,
+      filename: basename(project.projectFile),
+    });
+  }
 
   const resources = project.resources;
   if (resources !== undefined && resources !== null) {
@@ -83,25 +108,26 @@ function collectWatchTargets(project: ResolvedProject): string[] {
       if (!existsSync(absolute)) continue;
       try {
         const info = statSync(absolute);
-        roots.add(info.isDirectory() ? absolute : dirname(absolute));
+        addDir(info.isDirectory() ? absolute : dirname(absolute));
       } catch {
         // Path vanished between existsSync and statSync.
       }
     }
   }
 
-  return [...roots];
+  return targets;
 }
 
 async function consumeWatcher(
-  target: string,
+  target: WatchTarget,
   signal: AbortSignal,
   onEvent: () => void,
 ): Promise<void> {
   try {
-    const iter = watch(target, { recursive: true, signal });
-    for await (const _evt of iter) {
+    const iter = watch(target.path, { recursive: target.recursive, signal });
+    for await (const evt of iter) {
       if (signal.aborted) return;
+      if (target.filename !== undefined && evt.filename !== target.filename) continue;
       onEvent();
     }
   } catch (err: unknown) {
@@ -109,6 +135,8 @@ async function consumeWatcher(
     if (signal.aborted) return;
     const e = err as { name?: string; code?: string };
     if (e.name === "AbortError" || e.code === "ABORT_ERR") return;
-    log.debug(`watch: watcher on "${target}" failed: ${(err as Error).message ?? String(err)}`);
+    log.debug(
+      `watch: watcher on "${target.path}" failed: ${(err as Error).message ?? String(err)}`,
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Closes #12
- Watch the project-file directory non-recursively with a filename filter for `project.json`, so pluggy's own writes into `bin/`, `dev/`, and `.pluggy-build/` no longer retrigger the dev rebuild loop.
- Introduce a `WatchTarget` shape so individual watchers can opt into recursion and filename filtering; `src/` and resource directories still use the recursive path.
- Add a regression test that pushes synthetic events for `bin/`, `.pluggy-build`, `dev`, and `project.json` against the root watcher and asserts only the last triggers `onChange`.

## Test plan

- [x] `vp test`
- [x] `vp lint`
- [ ] Manual: `pluggy init` + `pluggy dev` in `playground/` and confirm no `change detected` lines fire during Paper bootstrap.