### PR TITLE
feat(registry): add github: alias and Maven Central as a default

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -91,23 +91,34 @@ Maven, basename-without-`.jar` for files, workspace name for workspaces.
 
 ## Registries
 
-Maven dependencies need at least one entry in `project.json:registries`.
-Modrinth is implicit — no registry declaration is required.
+Maven Central (`https://repo1.maven.org/maven2/`) is appended automatically,
+so a Maven dependency that lives there needs no `registries` entry at all.
+Declare extra registries when you depend on artifacts that Central doesn't
+host (PaperMC, Spigot snapshots, GitHub Packages, …). Modrinth is implicit
+too — no registry declaration is required.
 
 ```json
 "registries": [
-  "https://repo1.maven.org/maven2/",
   "https://repo.papermc.io/repository/maven-public/"
 ]
 ```
 
-For authenticated registries use the object form. `list` shows which
-registries have credentials attached, but never prints the values:
+### Aliases
+
+A short scheme expands to a full URL so common registries are easy to
+declare:
+
+| Alias               | Expands to                                |
+| ------------------- | ----------------------------------------- |
+| `github:owner/repo` | `https://maven.pkg.github.com/owner/repo` |
+
+Aliases work in both string and object form; credentials stay attached:
 
 ```json
 "registries": [
+  "github:my-org/public-libs",
   {
-    "url": "https://maven.pkg.github.com/org/repo",
+    "url": "github:my-org/private",
     "credentials": {
       "username": "ci-bot",
       "password": "${GITHUB_TOKEN}"
@@ -116,9 +127,10 @@ registries have credentials attached, but never prints the values:
 ]
 ```
 
-Registry URLs are tried in declaration order. The platform's own Maven
-repository (e.g. PaperMC for Paper's `paper-api`) is prepended automatically
-during a build — you don't need to list it in `registries`.
+Registry URLs are tried in declaration order, then `DEFAULT_MAVEN_REGISTRIES`
+(Maven Central). The platform's own Maven repository (e.g. PaperMC for
+Paper's `paper-api`) is prepended automatically during a build — you don't
+need to list it in `registries`.
 
 ## Lockfile
 

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -20,9 +20,8 @@ which workspace you're sitting in.
     "platforms": ["paper"]
   },
   "registries": [
-    "https://repo1.maven.org/maven2/",
     {
-      "url": "https://maven.pkg.github.com/my-org/private",
+      "url": "github:my-org/private",
       "credentials": {
         "username": "${GITHUB_ACTOR}",
         "password": "${GITHUB_TOKEN}"
@@ -179,13 +178,19 @@ Array of entries. Each entry is either:
 - a bare URL string, or
 - an object `{ "url": "...", "credentials": { "username": "...", "password": "..." } }`.
 
-Registries apply to Maven dependencies. The Modrinth API is implicit and
-doesn't need declaring. When credentials are set, `list` prints
-`[authenticated]` next to the URL but never surfaces the values themselves —
-they're read when the Maven resolver needs them.
+The URL field accepts an alias as a shorthand: `github:owner/repo`
+expands to `https://maven.pkg.github.com/owner/repo`.
 
-The list is deduplicated by URL. In a monorepo, the root's registries are
-unioned with each workspace's registries; duplicates drop.
+Registries apply to Maven dependencies. Maven Central
+(`https://repo1.maven.org/maven2/`) is appended automatically, so artifacts
+hosted there resolve without any explicit `registries` entry. The Modrinth
+API is implicit and doesn't need declaring either. When credentials are set,
+`list` prints `[authenticated]` next to the URL but never surfaces the
+values themselves — they're read when the Maven resolver needs them.
+
+The list is deduplicated by URL (trailing-slash variants count as the
+same). In a monorepo, the root's registries are unioned with each
+workspace's registries; duplicates drop.
 
 ### `dependencies` (optional)
 

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -12,6 +12,7 @@ import { log } from "../logging.ts";
 import { getPlatform } from "../platform/index.ts";
 import { writeFileLF } from "../portable.ts";
 import type { ResolvedProject } from "../project.ts";
+import { effectiveRegistries } from "../registry.ts";
 import { parseSource } from "../source.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { resolveMaven } from "../resolver/maven.ts";
@@ -202,11 +203,7 @@ function hasUserDescriptor(project: ResolvedProject, descriptorPath: string): bo
 }
 
 function collectRegistries(project: ResolvedProject): string[] {
-  const out: string[] = [];
-  for (const entry of project.registries ?? []) {
-    out.push(typeof entry === "string" ? entry : entry.url);
-  }
-  return out;
+  return effectiveRegistries(project.registries);
 }
 
 async function resolveDeclaredDependencies(

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -7,6 +7,7 @@ import process from "node:process";
 import { InvalidArgumentError } from "commander";
 
 import type { ResolvedProject } from "../project.ts";
+import { DEFAULT_MAVEN_REGISTRIES, registryUrl } from "../registry.ts";
 import type { ResolveContext } from "../resolver/index.ts";
 import type { WorkspaceContext } from "../workspace.ts";
 import { findWorkspace, resolveWorkspaceContext } from "../workspace.ts";
@@ -128,17 +129,17 @@ export function buildResolveContext(
 ): ResolveContext {
   const registries: string[] = [];
   const seen = new Set<string>();
-  const push = (entry: string | { url: string } | undefined): void => {
-    if (entry === undefined) return;
-    const url = typeof entry === "string" ? entry : entry.url;
-    if (seen.has(url)) return;
-    seen.add(url);
+  const push = (url: string): void => {
+    const key = url.endsWith("/") ? url.slice(0, -1) : url;
+    if (seen.has(key)) return;
+    seen.add(key);
     registries.push(url);
   };
-  for (const r of context.root.registries ?? []) push(r);
+  for (const r of context.root.registries ?? []) push(registryUrl(r));
   for (const ws of context.workspaces) {
-    for (const r of ws.project.registries ?? []) push(r);
+    for (const r of ws.project.registries ?? []) push(registryUrl(r));
   }
+  for (const url of DEFAULT_MAVEN_REGISTRIES) push(url);
 
   return {
     rootDir: context.root.rootDir,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,6 +14,7 @@ import { type LockfileEntry, type TransitiveEntry, readLock } from "../lockfile.
 import { bold, green, log, red, yellow } from "../logging.ts";
 import { getPlatform, getRegisteredPlatforms } from "../platform/index.ts";
 import { getCachePath, type ResolvedProject } from "../project.ts";
+import { registryUrl } from "../registry.ts";
 import { getLatestModrinthVersion } from "../resolver/modrinth.ts";
 import { getCachedJdk } from "../sdk/index.ts";
 import { selectJdkForProject } from "../sdk/resolve.ts";
@@ -424,8 +425,7 @@ export async function checkRegistries(project: ResolvedProject): Promise<CheckRe
     ];
   }
   for (const entry of registries) {
-    const url = typeof entry === "string" ? entry : entry.url;
-    out.push(await checkOneRegistry(url));
+    out.push(await checkOneRegistry(registryUrl(entry)));
   }
   return out;
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,7 +4,8 @@ import { Command } from "commander";
 
 import { bold, dim, log, yellow } from "../logging.ts";
 import { readLock, type TransitiveEntry } from "../lockfile.ts";
-import type { Dependency, Registry, ResolvedProject } from "../project.ts";
+import type { Dependency, ResolvedProject } from "../project.ts";
+import { DEFAULT_MAVEN_REGISTRIES, registryUrl } from "../registry.ts";
 import { getLatestModrinthVersion } from "../resolver/modrinth.ts";
 import { parseSource, type ResolvedSource } from "../source.ts";
 import {
@@ -261,18 +262,19 @@ function collectRegistries(ctx: WorkspaceContext): RegistryEntry[] {
   const raw = project.registries ?? [];
   const out: RegistryEntry[] = [];
   const seen = new Set<string>();
-  for (const entry of raw) {
-    const { url, authenticated } = normalizeRegistry(entry);
-    if (seen.has(url)) continue;
-    seen.add(url);
+  const push = (url: string, authenticated: boolean): void => {
+    const key = url.endsWith("/") ? url.slice(0, -1) : url;
+    if (seen.has(key)) return;
+    seen.add(key);
     out.push({ url, authenticated });
+  };
+  for (const entry of raw) {
+    const url = registryUrl(entry);
+    const authenticated = typeof entry !== "string" && entry.credentials !== undefined;
+    push(url, authenticated);
   }
+  for (const url of DEFAULT_MAVEN_REGISTRIES) push(url, false);
   return out;
-}
-
-function normalizeRegistry(entry: string | Registry): RegistryEntry {
-  if (typeof entry === "string") return { url: entry, authenticated: false };
-  return { url: entry.url, authenticated: entry.credentials !== undefined };
 }
 
 function printHumanList(result: ListResult, outdatedMode: boolean): void {

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -17,6 +17,7 @@ import { getPlatform } from "../platform/index.ts";
 import type { DescriptorSpec } from "../platform/platform.ts";
 import { linkOrCopy } from "../portable.ts";
 import { getCachePath, type HotswapConfig, type ResolvedProject } from "../project.ts";
+import { effectiveRegistries } from "../registry.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { ensureJdkForProject } from "../sdk/index.ts";
 import { parseSource } from "../source.ts";
@@ -313,7 +314,7 @@ async function resolveRuntimePluginDeps(
   const deps = project.dependencies;
   if (deps === undefined || deps === null) return [];
 
-  const registries = (project.registries ?? []).map((r) => (typeof r === "string" ? r : r.url));
+  const registries = effectiveRegistries(project.registries);
 
   const results: ResolvedDependency[] = [];
   for (const [name, raw] of Object.entries(deps)) {

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vite-plus/test";
+
+import {
+  DEFAULT_MAVEN_REGISTRIES,
+  dedupeRegistryUrls,
+  effectiveRegistries,
+  expandRegistryAlias,
+  registryUrl,
+} from "./registry.ts";
+
+describe("expandRegistryAlias", () => {
+  test("expands `github:owner/repo` to the GitHub Packages URL", () => {
+    expect(expandRegistryAlias("github:my-org/my-repo")).toBe(
+      "https://maven.pkg.github.com/my-org/my-repo",
+    );
+  });
+
+  test("passes http(s) URLs through unchanged", () => {
+    expect(expandRegistryAlias("https://repo1.maven.org/maven2/")).toBe(
+      "https://repo1.maven.org/maven2/",
+    );
+    expect(expandRegistryAlias("http://example.com/maven")).toBe("http://example.com/maven");
+  });
+
+  test("returns unknown schemes verbatim", () => {
+    expect(expandRegistryAlias("nexus:my-team/internal")).toBe("nexus:my-team/internal");
+  });
+
+  test("returns plain strings without a scheme verbatim", () => {
+    expect(expandRegistryAlias("repo.example.com")).toBe("repo.example.com");
+  });
+});
+
+describe("registryUrl", () => {
+  test("expands aliases on object-form Registry entries", () => {
+    expect(
+      registryUrl({
+        url: "github:org/private",
+        credentials: { username: "ci", password: "x" },
+      }),
+    ).toBe("https://maven.pkg.github.com/org/private");
+  });
+});
+
+describe("dedupeRegistryUrls", () => {
+  test("collapses trailing-slash variants of the same URL", () => {
+    expect(
+      dedupeRegistryUrls(["https://repo1.maven.org/maven2", "https://repo1.maven.org/maven2/"]),
+    ).toEqual(["https://repo1.maven.org/maven2"]);
+  });
+
+  test("preserves the first-seen form", () => {
+    expect(
+      dedupeRegistryUrls(["https://repo1.maven.org/maven2/", "https://repo1.maven.org/maven2"]),
+    ).toEqual(["https://repo1.maven.org/maven2/"]);
+  });
+});
+
+describe("effectiveRegistries", () => {
+  test("appends Maven Central when not declared", () => {
+    expect(effectiveRegistries(["https://repo.papermc.io/repository/maven-public/"])).toEqual([
+      "https://repo.papermc.io/repository/maven-public/",
+      ...DEFAULT_MAVEN_REGISTRIES,
+    ]);
+  });
+
+  test("does not duplicate Maven Central when the user already declared it", () => {
+    const out = effectiveRegistries(["https://repo1.maven.org/maven2/"]);
+    expect(out).toEqual(["https://repo1.maven.org/maven2/"]);
+  });
+
+  test("expands `github:` aliases in declared entries", () => {
+    const out = effectiveRegistries([
+      { url: "github:org/private", credentials: { username: "u", password: "p" } },
+    ]);
+    expect(out).toEqual(["https://maven.pkg.github.com/org/private", ...DEFAULT_MAVEN_REGISTRIES]);
+  });
+
+  test("returns just the defaults when declared is undefined", () => {
+    expect(effectiveRegistries(undefined)).toEqual([...DEFAULT_MAVEN_REGISTRIES]);
+  });
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,58 @@
+/**
+ * Registry URL handling: scheme aliases (e.g. `github:owner/repo` →
+ * `https://maven.pkg.github.com/owner/repo`) and the Maven registries
+ * appended by default to every project's effective list.
+ */
+
+import type { Registry } from "./project.ts";
+
+/** Maven registries appended to every project's declared list. */
+export const DEFAULT_MAVEN_REGISTRIES: ReadonlyArray<string> = ["https://repo1.maven.org/maven2/"];
+
+const ALIASES: Record<string, (rest: string) => string> = {
+  github: (rest) => `https://maven.pkg.github.com/${rest}`,
+};
+
+/**
+ * Expand a scheme alias like `github:owner/repo` into a full URL. Bare
+ * `http(s)://…` URLs and unknown schemes pass through unchanged.
+ */
+export function expandRegistryAlias(url: string): string {
+  const colon = url.indexOf(":");
+  if (colon === -1) return url;
+  const scheme = url.slice(0, colon);
+  if (scheme === "http" || scheme === "https") return url;
+  const expander = ALIASES[scheme];
+  if (expander === undefined) return url;
+  return expander(url.slice(colon + 1));
+}
+
+/** Pull the URL out of a Registry entry, expanding any alias. */
+export function registryUrl(entry: string | Registry): string {
+  return expandRegistryAlias(typeof entry === "string" ? entry : entry.url);
+}
+
+/** Dedupe a URL list, treating trailing-slash variants as the same entry. */
+export function dedupeRegistryUrls(urls: ReadonlyArray<string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const u of urls) {
+    const key = u.endsWith("/") ? u.slice(0, -1) : u;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(u);
+  }
+  return out;
+}
+
+/**
+ * Final URL list the resolver should walk: declared entries (with aliases
+ * expanded) followed by `DEFAULT_MAVEN_REGISTRIES`, deduped.
+ */
+export function effectiveRegistries(
+  declared: ReadonlyArray<string | Registry> | undefined,
+): string[] {
+  const urls: string[] = [];
+  for (const entry of declared ?? []) urls.push(registryUrl(entry));
+  return dedupeRegistryUrls([...urls, ...DEFAULT_MAVEN_REGISTRIES]);
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -28,6 +28,7 @@ import { log } from "../logging.ts";
 import { getPlatform } from "../platform/index.ts";
 import { writeFileLF } from "../portable.ts";
 import type { ResolvedProject } from "../project.ts";
+import { effectiveRegistries } from "../registry.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { resolveMaven } from "../resolver/maven.ts";
 import { ensureJdkForVersion } from "../sdk/index.ts";
@@ -38,9 +39,6 @@ import {
   parseJUnitReports,
   type TestRunResult as ParsedRunResult,
 } from "./runner.ts";
-
-/** Maven Central — always appended to the test-time registry list. */
-const MAVEN_CENTRAL = "https://repo1.maven.org/maven2";
 
 /** Pinned JUnit Platform Console Standalone — single jar, includes Jupiter + Vintage. */
 const JUNIT_CONSOLE = {
@@ -156,13 +154,10 @@ export async function runTests(
   await rm(reportsDir, { recursive: true, force: true });
   await mkdir(reportsDir, { recursive: true });
 
-  // Project-declared registries (strings or {url, ...}).
-  const projectRegistries: string[] = [];
-  for (const entry of project.registries ?? []) {
-    projectRegistries.push(typeof entry === "string" ? entry : entry.url);
-  }
-  // Test-time registries always include Maven Central so JUnit can be fetched.
-  const testRegistries = dedupe([...projectRegistries, MAVEN_CENTRAL]);
+  // Effective registries already include Maven Central (from
+  // DEFAULT_MAVEN_REGISTRIES) so JUnit can be fetched without forcing the
+  // user to declare it.
+  const projectRegistries = effectiveRegistries(project.registries);
 
   const mainDeps = await resolveDeclared(project, "dependencies", projectRegistries);
   const platformApiJars = await resolvePlatformApiJars(
@@ -173,7 +168,7 @@ export async function runTests(
   );
   const mainClasspath = dedupe([...flattenJars(mainDeps.map((d) => d.dep)), ...platformApiJars]);
 
-  const testDeps = await resolveDeclared(project, "testDependencies", testRegistries);
+  const testDeps = await resolveDeclared(project, "testDependencies", projectRegistries);
   const junit = await resolveMaven(
     JUNIT_CONSOLE.groupId,
     JUNIT_CONSOLE.artifactId,
@@ -182,7 +177,7 @@ export async function runTests(
       rootDir: project.rootDir,
       includePrerelease: false,
       force: false,
-      registries: testRegistries,
+      registries: projectRegistries,
     },
   );
 


### PR DESCRIPTION
## Summary

- Add a `github:owner/repo` registry alias that expands to `https://maven.pkg.github.com/owner/repo` (works in both string and object form; credentials stay attached).
- Append Maven Central (`https://repo1.maven.org/maven2/`) to every project's effective registry list automatically, so artifacts hosted there resolve without an explicit declaration.
- New `src/registry.ts` owns alias expansion, dedupe (trailing-slash variants collapse), and the default list, and is wired into `build`, `test`, `dev`, `list`, `install`/`remove`, and `doctor` so behaviour is consistent everywhere.
- Docs updated in `docs/dependencies.md` (new Aliases subsection + Maven Central note) and `docs/project-json.md`.

## Test plan

- [x] `vp test` (442 passed, 3 skipped — unchanged)
- [x] `vp check` (format + lint + types clean)
- [x] New unit tests in `src/registry.test.ts` cover alias expansion, dedupe semantics, and `effectiveRegistries`