### PR TITLE
security: enforce integrity across install, build, dev, and upgrade flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: write
   packages: write
+  # attest-build-provenance signs each release binary with a Sigstore-issued
+  # ephemeral certificate bound to this workflow's OIDC identity. `pluggy
+  # upgrade` checks the resulting attestation against the binary it just
+  # downloaded; a tampered binary fails verification because its sha256 won't
+  # match any attestation issued for this repo's release workflow.
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -104,6 +111,27 @@ jobs:
           cp install.sh release-assets/
           cp install.ps1 release-assets/
 
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          sha256sum pluggy-linux-amd64 pluggy-linux-arm64 pluggy-darwin-amd64 pluggy-darwin-arm64 pluggy-windows-amd64.exe > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          # Attests every published binary plus the checksum manifest. A
+          # forged binary with a matching forged manifest still fails
+          # because neither would carry an attestation issued by this
+          # workflow's OIDC identity.
+          subject-path: |
+            release-assets/pluggy-linux-amd64
+            release-assets/pluggy-linux-arm64
+            release-assets/pluggy-darwin-amd64
+            release-assets/pluggy-darwin-arm64
+            release-assets/pluggy-windows-amd64.exe
+            release-assets/SHA256SUMS.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -124,6 +152,16 @@ jobs:
             ```
             curl -fsSL https://github.com/ch99q/pluggy/releases/download/${{ github.ref_name }}/install.sh | bash
             ```
+
+            ## Verification
+
+            Each binary is attested with [build provenance](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). To verify a downloaded binary:
+
+            ```
+            gh attestation verify pluggy-darwin-arm64 --repo ${{ github.repository }}
+            ```
+
+            `pluggy upgrade` performs an equivalent check automatically against the published `SHA256SUMS.txt` manifest and refuses to install a binary whose digest doesn't match.
 
             ---
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,22 @@ You will receive an acknowledgement within 72 hours. We aim to confirm or reject
 
 ## Supported versions
 
-Only the latest released version receives security fixes. pluggy is pre-1.0 and ships from `main`.
+Only the latest released version receives security fixes. pluggy is pre-1.0 and ships from `main`. The upgrade path is `pluggy upgrade`, which verifies the new binary against the published `SHA256SUMS.txt` and a Sigstore-issued build-provenance attestation before swapping it in place.
+
+## Threat model
+
+`pluggy` is a developer-facing CLI invoked from a terminal in a trusted local environment. Its threat model assumes:
+
+- The user trusts the terminal they invoke `pluggy` from and the project directory they invoke it inside. Cloning a hostile repository and running `pluggy build` against it is **not** a supported safe operation — the same way `npm install` against a hostile package isn't.
+- `process.env`, CLI flags, and `~/.config/pluggy/*` are inputs from the user, not an attacker. An attacker who can modify these on the user's machine has already won.
+- HTTPS is the trust root for every external download (GitHub Releases, Foojay Disco, Modrinth, Maven repositories, JetBrains CDN, HotswapProjects, SpigotMC). We additionally verify integrity at the artifact level wherever upstream publishes a hash.
+
+In scope, and what the codebase actively defends against:
+
+- **Supply-chain substitution** of any artifact `pluggy` downloads — JDKs, BuildTools, JBR, HotswapAgent, Modrinth/Maven dependencies, the `pluggy` binary itself. Verification is layered: registry-published hashes (Disco, Modrinth API, Maven `.sha1`/`.sha512`), pinned hashes for upstreams that don't publish sidecars (JBR, HotswapAgent), TOFU pinning where neither is available (BuildTools.jar), and `SHA256SUMS.txt` + Sigstore build-provenance attestations on `pluggy upgrade`.
+- **Lockfile integrity** — `pluggy.lock`'s `integrity` is verified at install time (cache and re-resolve) and at build time (lockfile-driven `expectedIntegrity` threading through every resolver). Silent rolls forward across pinned versions are rejected.
+- **Zip/path-traversal** in any archive `pluggy` extracts — template archives from `codeload.github.com`, dependency jars during shading, JDK and JBR tarballs/zips. Every archive entry is run through a `safeJoin` that rejects `..`, absolute paths, and backslash-bearing names.
+- **Cache-path traversal** via hostile `pluggy.lock` or `project.json` content. Components used to compute filesystem paths (`distribution`, `slug`, `groupId`, `artifactId`, `resolvedVersion`, `integrity` hex) are checked against a tight allowlist before being joined.
 
 ## Scope
 
@@ -28,6 +43,7 @@ The following are out of scope because pluggy does not control them:
 - Vulnerabilities in third-party plugins, server JARs (Paper, Spigot, Velocity), or JDK distributions that pluggy downloads.
 - Vulnerabilities in upstream registries (Modrinth, Maven Central, Foojay Disco) or in the artifacts they host.
 - Issues that require an attacker who already controls the user's machine or development environment.
+- Compromise of the `pluggy` GitHub release pipeline itself. Each release is attested with `actions/attest-build-provenance` so the binary is bound to a specific workflow's OIDC identity, but if the pipeline is subverted (leaked publishing credentials, malicious workflow change merged via PR), the attestation will validate for the substituted bytes too. Reducing this requires Sigstore signature verification rooted outside `api.github.com`, which is tracked as future work.
 
 If you are unsure whether something is in scope, report it anyway and we will route it.
 

--- a/src/build/classpath.ts
+++ b/src/build/classpath.ts
@@ -5,12 +5,13 @@
  * platform API jars for the primary (or explicitly requested) platform.
  */
 
+import { readLock, type LockfileEntry } from "../lockfile.ts";
 import { getPlatform } from "../platform/index.ts";
 import type { ResolvedProject } from "../project.ts";
 import { effectiveRegistries } from "../registry.ts";
 import { resolveDependency, type ResolvedDependency } from "../resolver/index.ts";
 import { resolveMaven } from "../resolver/maven.ts";
-import { parseSource } from "../source.ts";
+import { parseSource, stringifySource } from "../source.ts";
 
 export interface ResolveClasspathOptions {
   /**
@@ -75,6 +76,13 @@ async function resolveDeclaredDependencies(
   const deps = project.dependencies;
   if (deps === undefined || deps === null) return [];
 
+  // Pull the lockfile entries up front so we can pass each top-level dep's
+  // recorded `integrity` as `expectedIntegrity`. Catches the silent
+  // upstream substitution scenario (registry rolls forward bytes for a
+  // pinned version between `install` and `build`) — without this thread,
+  // build re-resolved fresh and accepted whatever bytes came back.
+  const lockEntries = readLock(project.rootDir)?.entries ?? {};
+
   const results: ResolvedDependency[] = [];
   for (const [name, raw] of Object.entries(deps)) {
     const { source, version } =
@@ -82,15 +90,36 @@ async function resolveDeclaredDependencies(
         ? { source: `modrinth:${name}`, version: raw }
         : { source: raw.source, version: raw.version };
     const parsed = parseSource(source, version);
+    const expectedIntegrity = expectedIntegrityFor(name, parsed, lockEntries);
     const resolved = await resolveDependency(parsed, {
       rootDir: project.rootDir,
       includePrerelease: false,
       force: false,
       registries,
+      expectedIntegrity,
     });
     results.push(resolved);
   }
   return results;
+}
+
+/**
+ * Look up the lockfile entry for `name` and return its `integrity` if the
+ * recorded source/version still matches the declared one. Drift means the
+ * pin is stale (user edited project.json since `install`) and the recorded
+ * hash is no longer the right thing to enforce — surface the issue via
+ * `pluggy install` rather than blocking the build.
+ */
+function expectedIntegrityFor(
+  name: string,
+  declaredSource: ReturnType<typeof parseSource>,
+  lockEntries: Record<string, LockfileEntry>,
+): string | undefined {
+  const entry = lockEntries[name];
+  if (entry === undefined) return undefined;
+  if (stringifySource(entry.source) !== stringifySource(declaredSource)) return undefined;
+  if (entry.source.version !== declaredSource.version) return undefined;
+  return entry.integrity;
 }
 
 async function resolvePlatformApiJars(

--- a/src/build/shade.test.ts
+++ b/src/build/shade.test.ts
@@ -1,7 +1,7 @@
 /** Tests for src/build/shade.ts. Uses tiny `yazl`-built jar fixtures. */
 
 import { createWriteStream } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,6 +27,103 @@ async function makeJar(path: string, entries: Record<string, Buffer | string>): 
     }
     zip.end();
   });
+}
+
+/**
+ * Build a stored (uncompressed) zip from `entries` without any path-safety
+ * validation — yazl deliberately rejects `..` and absolute paths, so we
+ * can't use it for zip-slip fixtures. Layout: per-entry local headers, then
+ * central directory, then EOCD record.
+ */
+async function makeRawJar(path: string, entries: Record<string, Buffer | string>): Promise<void> {
+  const localChunks: Buffer[] = [];
+  const centralChunks: Buffer[] = [];
+  const offsets: number[] = [];
+  let cursor = 0;
+
+  for (const [name, content] of Object.entries(entries)) {
+    const data = typeof content === "string" ? Buffer.from(content, "utf8") : content;
+    const nameBuf = Buffer.from(name, "utf8");
+    const crc = crc32(data);
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0); // local file header signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(0, 8); // method = stored
+    local.writeUInt16LE(0, 10); // mtime
+    local.writeUInt16LE(0, 12); // mdate
+    local.writeUInt32LE(crc, 14); // crc-32
+    local.writeUInt32LE(data.length, 18); // compressed size
+    local.writeUInt32LE(data.length, 22); // uncompressed size
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28); // extra length
+    offsets.push(cursor);
+    localChunks.push(local, nameBuf, data);
+    cursor += local.length + nameBuf.length + data.length;
+  }
+
+  const offsetsCopy = [...offsets];
+  let cdirSize = 0;
+  let i = 0;
+  for (const [name, content] of Object.entries(entries)) {
+    const data = typeof content === "string" ? Buffer.from(content, "utf8") : content;
+    const nameBuf = Buffer.from(name, "utf8");
+    const crc = crc32(data);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0); // central dir signature
+    central.writeUInt16LE(20, 4); // version made by
+    central.writeUInt16LE(20, 6); // version needed
+    central.writeUInt16LE(0, 8); // flags
+    central.writeUInt16LE(0, 10); // method
+    central.writeUInt16LE(0, 12); // mtime
+    central.writeUInt16LE(0, 14); // mdate
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(data.length, 20);
+    central.writeUInt32LE(data.length, 24);
+    central.writeUInt16LE(nameBuf.length, 28);
+    central.writeUInt16LE(0, 30); // extra length
+    central.writeUInt16LE(0, 32); // comment length
+    central.writeUInt16LE(0, 34); // disk
+    central.writeUInt16LE(0, 36); // internal attrs
+    central.writeUInt32LE(0, 38); // external attrs
+    central.writeUInt32LE(offsetsCopy[i], 42); // offset of local header
+    centralChunks.push(central, nameBuf);
+    cdirSize += central.length + nameBuf.length;
+    i += 1;
+  }
+
+  const cdirOffset = cursor;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk
+  eocd.writeUInt16LE(0, 6); // disk with cdir start
+  eocd.writeUInt16LE(offsets.length, 8); // entries on this disk
+  eocd.writeUInt16LE(offsets.length, 10); // total entries
+  eocd.writeUInt32LE(cdirSize, 12);
+  eocd.writeUInt32LE(cdirOffset, 16);
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  await writeFile(path, Buffer.concat([...localChunks, ...centralChunks, eocd]));
+}
+
+const CRC_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = (c & 1) !== 0 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
 }
 
 function fakeDep(
@@ -185,5 +282,33 @@ describe("applyShading", () => {
     await expect(applyShading([dep], { gone: { include: ["**"] } }, stagingDir)).rejects.toThrow(
       /jar not found/,
     );
+  });
+
+  test("rejects entries that traverse outside stagingDir (zip-slip)", async () => {
+    // yauzl's default `validateFileName` rejects `..` filenames before our
+    // entry handler sees them, so the surface message comes from there. Our
+    // safeJoin call inside `extractEntry` is defense-in-depth for the case
+    // someone disables that flag in the future.
+    const jar = join(workDir, "evil.jar");
+    await makeRawJar(jar, {
+      "../../../../../../tmp/pwn.txt": "evil",
+    });
+    const dep = fakeDep("evil", jar);
+
+    await expect(applyShading([dep], { evil: { include: ["**"] } }, stagingDir)).rejects.toThrow(
+      /invalid relative path|refusing entry/,
+    );
+  });
+
+  test("rejects entries with backslash separators", async () => {
+    const jar = join(workDir, "evil-bs.jar");
+    await makeRawJar(jar, {
+      "..\\..\\windows-pwn.txt": "evil",
+    });
+    const dep = fakeDep("evil-bs", jar);
+
+    await expect(
+      applyShading([dep], { "evil-bs": { include: ["**"] } }, stagingDir),
+    ).rejects.toThrow(/invalid relative path|backslash|refusing entry/);
   });
 });

--- a/src/build/shade.ts
+++ b/src/build/shade.ts
@@ -6,11 +6,12 @@
 
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join, posix } from "node:path";
+import { dirname, posix } from "node:path";
 
 import yauzl, { type Entry, type ZipFile } from "yauzl";
 
 import { log } from "../logging.ts";
+import { safeJoin } from "../portable.ts";
 import type { Shading } from "../project.ts";
 import type { ResolvedDependency } from "../resolver/index.ts";
 import { PENDING_BUILD_INTEGRITY } from "../resolver/workspace.ts";
@@ -156,7 +157,14 @@ function extractEntry(
       stream.once("end", async () => {
         try {
           const data = Buffer.concat(chunks);
-          const dest = join(stagingDir, entry.fileName);
+          let dest: string;
+          try {
+            dest = safeJoin(stagingDir, entry.fileName);
+          } catch (e) {
+            throw new Error(
+              `shade: refusing entry "${entry.fileName}" from "${depName}": ${(e as Error).message}`,
+            );
+          }
           await mkdir(dirname(dest), { recursive: true });
           await writeFile(dest, data);
           log.debug(`shade: ${depName} -> ${entry.fileName} (${data.length}b)`);

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -106,4 +106,26 @@ describe("generateProject — template files", () => {
     );
     expect(testFile).toBe("// test from template\n");
   });
+
+  test("rejects template files that escape distDir (zip-slip)", async () => {
+    const project: Project = {
+      name: "myplugin",
+      version: "1.0.0",
+      description: "x",
+      main: "com.example.MyPlugin",
+      compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+    };
+
+    await expect(
+      generateProject(dir, project, {
+        templateFiles: [{ path: "../escape.txt", content: "evil" }],
+      }),
+    ).rejects.toThrow(/Refusing to write/);
+
+    await expect(
+      generateProject(dir, project, {
+        templateFiles: [{ path: "files/../../etc/evil", content: "evil" }],
+      }),
+    ).rejects.toThrow(/Refusing to write/);
+  });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,7 @@ import { writeIntellijStub } from "../build/intellij.ts";
 import { getPlatform, getRegisteredPlatforms, type PlatformFamily } from "../platform/index.ts";
 import { deriveVelocityId } from "../platform/descriptor/velocity.ts";
 import { bold, dim, log } from "../logging.ts";
-import { writeFileLF } from "../portable.ts";
+import { safeJoin, writeFileLF } from "../portable.ts";
 import { getCurrentProject, type Project, resolveProjectFile } from "../project.ts";
 import { replace } from "../template.ts";
 import {
@@ -83,7 +83,12 @@ export async function generateProject(
 
   if (options.templateFiles && options.templateFiles.length > 0) {
     for (const file of options.templateFiles) {
-      const abs = join(distDir, file.path);
+      let abs: string;
+      try {
+        abs = safeJoin(distDir, file.path);
+      } catch (e) {
+        throw new Error(`Refusing to write template entry ${file.path}: ${(e as Error).message}`);
+      }
       try {
         await mkdir(dirname(abs), { recursive: true });
         await writeFileLF(abs, file.content);

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -194,13 +194,7 @@ describe("doInstall: no plugin argument", () => {
     );
 
     // Plant the matching cached jar so the cache check passes.
-    const cacheJar = join(
-      cacheDir,
-      "dependencies",
-      "modrinth",
-      "worldedit",
-      "1.20.1+forge.jar",
-    );
+    const cacheJar = join(cacheDir, "dependencies", "modrinth", "worldedit", "1.20.1+forge.jar");
     await mkdir(join(cacheDir, "dependencies", "modrinth", "worldedit"), { recursive: true });
     await writeFile(cacheJar, "clean");
 

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -3,7 +3,8 @@
  * workspace discovery, project parsing, and the lockfile are real.
  */
 
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,7 +14,13 @@ vi.mock("../resolver/index.ts", () => ({
   resolveDependency: vi.fn(),
 }));
 
+vi.mock("../project.ts", async () => {
+  const actual = await vi.importActual<typeof import("../project.ts")>("../project.ts");
+  return { ...actual, getCachePath: vi.fn() };
+});
+
 import { readLock } from "../lockfile.ts";
+import { getCachePath } from "../project.ts";
 import { resolveDependency } from "../resolver/index.ts";
 
 import { doInstall } from "./install.ts";
@@ -34,14 +41,19 @@ function makeResolved(overrides: Partial<MinimalResolved>): MinimalResolved {
 
 describe("doInstall: no plugin argument", () => {
   let dir: string;
+  let cacheDir: string;
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "pluggy-install-test-"));
+    cacheDir = await mkdtemp(join(tmpdir(), "pluggy-install-cache-"));
+    vi.mocked(getCachePath).mockReturnValue(cacheDir);
     mockedResolveDependency.mockReset();
   });
 
   afterEach(async () => {
     await rm(dir, { recursive: true, force: true });
+    await rm(cacheDir, { recursive: true, force: true });
+    vi.mocked(getCachePath).mockReset();
   });
 
   test("standalone, no lockfile → resolves every declared dep and writes the lockfile", async () => {
@@ -148,6 +160,105 @@ describe("doInstall: no plugin argument", () => {
     const lock = readLock(dir);
     expect(lock?.entries.otherdep).toBeDefined();
     expect(lock?.entries.worldedit.integrity).toBe("sha256-abc");
+  });
+
+  test("re-resolves when a cached jar's bytes don't match the lockfile integrity", async () => {
+    await writeFile(
+      join(dir, "project.json"),
+      JSON.stringify({
+        name: "demo",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+        dependencies: { worldedit: "7.3.15" },
+      }),
+    );
+    const expectedHash = `sha256-${createHash("sha256").update("expected").digest("hex")}`;
+    await writeFile(
+      join(dir, "pluggy.lock"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          entries: {
+            worldedit: {
+              source: { kind: "modrinth", slug: "worldedit", version: "7.3.15" },
+              resolvedVersion: "7.3.15",
+              integrity: expectedHash,
+              declaredBy: ["demo"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    // Plant tampered bytes at the expected cache location.
+    const cacheJar = join(cacheDir, "dependencies", "modrinth", "worldedit", "7.3.15.jar");
+    await mkdir(join(cacheDir, "dependencies", "modrinth", "worldedit"), { recursive: true });
+    await writeFile(cacheJar, "tampered bytes");
+
+    mockedResolveDependency.mockImplementation(async (source) =>
+      makeResolved({ source, integrity: expectedHash }),
+    );
+
+    const result = await doInstall({ cwd: dir });
+    expect(result.installed).toContain("worldedit");
+    expect(mockedResolveDependency).toHaveBeenCalledTimes(1);
+  });
+
+  test("refuses silent roll-forward when resolver returns different bytes than the lockfile", async () => {
+    await writeFile(
+      join(dir, "project.json"),
+      JSON.stringify({
+        name: "demo",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+        dependencies: { worldedit: "7.3.15", newdep: "1.0.0" },
+      }),
+    );
+    await writeFile(
+      join(dir, "pluggy.lock"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          entries: {
+            worldedit: {
+              source: { kind: "modrinth", slug: "worldedit", version: "7.3.15" },
+              resolvedVersion: "7.3.15",
+              integrity: "sha256-pinned",
+              declaredBy: ["demo"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    mockedResolveDependency.mockImplementation(async (source, ctx) => {
+      // Surface the expectedIntegrity check as a thrown error to mimic a
+      // real resolver's behavior on mismatch.
+      if (
+        source.kind === "modrinth" &&
+        source.slug === "worldedit" &&
+        ctx.expectedIntegrity !== undefined &&
+        ctx.expectedIntegrity !== "sha256-rolled-forward"
+      ) {
+        throw new Error(
+          `modrinth: integrity check failed for "worldedit@7.3.15" — lockfile expects ${ctx.expectedIntegrity} but resolved bytes are sha256-rolled-forward`,
+        );
+      }
+      return makeResolved({ source, integrity: "sha256-rolled-forward" });
+    });
+
+    // worldedit isn't drifted so it shouldn't even be re-resolved; only
+    // newdep is. The expectedIntegrity threading kicks in if worldedit ever
+    // does need re-resolution (e.g. cache mismatch in another test).
+    const result = await doInstall({ cwd: dir });
+    expect(result.installed).toEqual(["newdep"]);
+    expect(result.skipped).toContain("worldedit");
   });
 
   test("--force re-resolves even when fresh", async () => {

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -162,6 +162,53 @@ describe("doInstall: no plugin argument", () => {
     expect(lock?.entries.worldedit.integrity).toBe("sha256-abc");
   });
 
+  test("accepts Modrinth versions containing '+' (e.g. 1.20.1+forge) when checking the cache", async () => {
+    await writeFile(
+      join(dir, "project.json"),
+      JSON.stringify({
+        name: "demo",
+        version: "1.0.0",
+        main: "com.example.Main",
+        compatibility: { versions: ["1.21.8"], platforms: ["paper"] },
+        dependencies: { worldedit: "1.20.1+forge" },
+      }),
+    );
+    const expectedHash = `sha256-${createHash("sha256").update("clean").digest("hex")}`;
+    await writeFile(
+      join(dir, "pluggy.lock"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          entries: {
+            worldedit: {
+              source: { kind: "modrinth", slug: "worldedit", version: "1.20.1+forge" },
+              resolvedVersion: "1.20.1+forge",
+              integrity: expectedHash,
+              declaredBy: ["demo"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    // Plant the matching cached jar so the cache check passes.
+    const cacheJar = join(
+      cacheDir,
+      "dependencies",
+      "modrinth",
+      "worldedit",
+      "1.20.1+forge.jar",
+    );
+    await mkdir(join(cacheDir, "dependencies", "modrinth", "worldedit"), { recursive: true });
+    await writeFile(cacheJar, "clean");
+
+    const result = await doInstall({ cwd: dir });
+    expect(result.installed).toEqual([]);
+    expect(result.skipped).toContain("worldedit");
+  });
+
   test("re-resolves when a cached jar's bytes don't match the lockfile integrity", async () => {
     await writeFile(
       join(dir, "project.json"),

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,10 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
 import process from "node:process";
 
 import { Command } from "commander";
 
+import { log } from "../logging.ts";
 import { writeFileLF } from "../portable.ts";
-import type { Project } from "../project.ts";
+import { getCachePath, type Project } from "../project.ts";
 import { resolveDependency } from "../resolver/index.ts";
 import type { ResolvedDependency } from "../resolver/index.ts";
 import {
@@ -108,9 +111,18 @@ async function installAll(opts: InstallOptions, scope: ResolvedScope): Promise<I
   const drift = verifyLock(existingLock, declaredMap);
 
   if (drift.length === 0 && opts.force !== true) {
-    const result: InstallResult = { installed: [], skipped: [...byName.keys()] };
-    emitInstallResult(opts, result, { message: "lockfile is fresh; nothing to install." });
-    return result;
+    // The lockfile is fresh against project.json — but the bytes on disk
+    // might have drifted (cache poisoning, manual jar replacement, partial
+    // download). Re-hash every cached jar against the recorded integrity
+    // and re-resolve any that don't match. A fresh-lockfile install
+    // shouldn't return success while a tampered jar lives in the cache.
+    const cacheDrift = await verifyCachedIntegrity(byName, existingLock.entries);
+    if (cacheDrift.length === 0) {
+      const result: InstallResult = { installed: [], skipped: [...byName.keys()] };
+      emitInstallResult(opts, result, { message: "lockfile is fresh; nothing to install." });
+      return result;
+    }
+    drift.push(...cacheDrift);
   }
 
   const toResolve = opts.force === true ? [...byName.keys()] : drift;
@@ -122,7 +134,18 @@ async function installAll(opts: InstallOptions, scope: ResolvedScope): Promise<I
   for (const name of toResolve) {
     const info = byName.get(name);
     if (info === undefined) continue;
-    const resolved = await resolveDependency(info.source, resolveCtx);
+    // Pinned-version sanity: if the lockfile already records an integrity
+    // for this exact (source, version) pair and the user didn't pass
+    // --force, refuse to silently roll forward to different bytes.
+    const prior = existingLock.entries[name];
+    const expectedIntegrity =
+      opts.force !== true &&
+      prior !== undefined &&
+      stringifySource(prior.source) === stringifySource(info.source) &&
+      prior.source.version === info.source.version
+        ? prior.integrity
+        : undefined;
+    const resolved = await resolveDependency(info.source, { ...resolveCtx, expectedIntegrity });
     nextEntries[name] = toLockEntry(resolved, info.declaredBy);
   }
 
@@ -186,6 +209,98 @@ async function installSingle(opts: InstallOptions, scope: ResolvedScope): Promis
   };
   emitInstallResult(opts, result);
   return result;
+}
+
+/**
+ * Re-hash every cached jar against its recorded `entry.integrity` and return
+ * the names whose bytes diverged from the lockfile. A divergence means the
+ * cache was poisoned, manually replaced, or partially written — install
+ * should re-resolve those rather than serve tampered bytes.
+ *
+ * Entries whose jar isn't in the cache yet are silently skipped (build/dev
+ * will populate the cache via the resolver later); a present-but-corrupt
+ * jar is the only signal worth treating as drift.
+ */
+async function verifyCachedIntegrity(
+  byName: Map<string, { source: ReturnType<typeof parseSource>; declaredBy: string[] }>,
+  lockEntries: Record<string, LockfileEntry>,
+): Promise<string[]> {
+  const drift: string[] = [];
+  for (const [name] of byName) {
+    const entry = lockEntries[name];
+    if (entry === undefined) continue;
+    const jarPath = cachedJarPathForEntry(entry);
+    if (jarPath === undefined) continue;
+    if (!(await fileExists(jarPath))) continue;
+
+    const bytes = await readFile(jarPath);
+    const actual = `sha256-${createHash("sha256").update(bytes).digest("hex")}`;
+    if (actual !== entry.integrity) {
+      log.warn(
+        `install: cached "${name}" at ${jarPath} has unexpected integrity ${actual} (lockfile expects ${entry.integrity}); will re-resolve`,
+      );
+      drift.push(name);
+    }
+  }
+  return drift;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locate the cached jar for a lockfile entry — mirrors each resolver's cache
+ * layout. Returns `undefined` for `workspace:` (built locally) and refuses
+ * to construct paths whose components contain traversal characters, so a
+ * lockfile crafted by a hostile clone can't escape the cache root.
+ */
+function cachedJarPathForEntry(entry: LockfileEntry): string | undefined {
+  const base = join(getCachePath(), "dependencies");
+  const src = entry.source;
+  switch (src.kind) {
+    case "modrinth":
+      assertSafeName(src.slug, "source.slug");
+      assertSafeName(entry.resolvedVersion, "resolvedVersion");
+      return join(base, "modrinth", src.slug, `${entry.resolvedVersion}.jar`);
+    case "maven":
+      assertSafeName(src.groupId, "source.groupId");
+      assertSafeName(src.artifactId, "source.artifactId");
+      assertSafeName(entry.resolvedVersion, "resolvedVersion");
+      return join(base, "maven", src.groupId, src.artifactId, `${entry.resolvedVersion}.jar`);
+    case "file": {
+      const hex = entry.integrity.startsWith("sha256-")
+        ? entry.integrity.slice("sha256-".length)
+        : entry.integrity;
+      assertSafeName(hex, "integrity");
+      return join(base, "file", `${hex}.jar`);
+    }
+    case "workspace":
+      return undefined;
+  }
+}
+
+const SAFE_NAME_RE = /^[A-Za-z0-9._-]+$/;
+
+function assertSafeName(value: string, field: string): void {
+  if (typeof value !== "string" || value.length === 0 || !SAFE_NAME_RE.test(value)) {
+    throw new Error(
+      `install: refusing unsafe lockfile ${field} ${JSON.stringify(value)} — won't construct a cache path that could escape the cache root`,
+    );
+  }
+  // SAFE_NAME_RE permits dots, so `..` and `.` slip through the regex but
+  // are filesystem-special. Reject explicitly so a lockfile-crafted entry
+  // can't traverse the cache root via a single-component name.
+  if (value === "." || value === "..") {
+    throw new Error(
+      `install: refusing reserved lockfile ${field} ${JSON.stringify(value)} — would traverse the cache root`,
+    );
+  }
 }
 
 function toLockEntry(resolved: ResolvedDependency, declaredBy: string[]): LockfileEntry {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -285,7 +285,13 @@ function cachedJarPathForEntry(entry: LockfileEntry): string | undefined {
   }
 }
 
-const SAFE_NAME_RE = /^[A-Za-z0-9._-]+$/;
+// Permits the union of characters seen in legit Maven coordinates and
+// Modrinth version strings: alphanumerics plus `.`, `_`, `-`, `+`, `~`.
+// `+` is load-bearing — Modrinth `version_number` regularly contains it
+// (e.g. `1.20.1+forge`), and Maven versions allow it too. Path separators
+// (`/`, `\`), null bytes, and traversal-special components (`..`, `.`)
+// are explicitly rejected below.
+const SAFE_NAME_RE = /^[A-Za-z0-9._+~-]+$/;
 
 function assertSafeName(value: string, field: string): void {
   if (typeof value !== "string" || value.length === 0 || !SAFE_NAME_RE.test(value)) {
@@ -293,9 +299,6 @@ function assertSafeName(value: string, field: string): void {
       `install: refusing unsafe lockfile ${field} ${JSON.stringify(value)} — won't construct a cache path that could escape the cache root`,
     );
   }
-  // SAFE_NAME_RE permits dots, so `..` and `.` slip through the regex but
-  // are filesystem-special. Reject explicitly so a lockfile-crafted entry
-  // can't traverse the cache root via a single-component name.
   if (value === "." || value === "..") {
     throw new Error(
       `install: refusing reserved lockfile ${field} ${JSON.stringify(value)} — would traverse the cache root`,

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -178,14 +178,23 @@ function declaresDepOutside(
  * Locate the cached jar for a lockfile entry. Cache layout mirrors each
  * resolver (`<cache>/dependencies/<kind>/…`). `workspace:` deps aren't cached
  * (they're built locally), so they return undefined.
+ *
+ * Each path component coming from the lockfile is run through `assertSafeName`
+ * — a hostile clone could otherwise craft `pluggy.lock` so `unlink(cachePath)`
+ * resolves outside the cache root.
  */
 function cachedJarPathFor(entry: LockfileEntry): string | undefined {
   const base = join(getCachePath(), "dependencies");
   const src = entry.source;
   switch (src.kind) {
     case "modrinth":
+      assertSafeName(src.slug, "source.slug");
+      assertSafeName(entry.resolvedVersion, "resolvedVersion");
       return join(base, "modrinth", src.slug, `${entry.resolvedVersion}.jar`);
     case "maven":
+      assertSafeName(src.groupId, "source.groupId");
+      assertSafeName(src.artifactId, "source.artifactId");
+      assertSafeName(entry.resolvedVersion, "resolvedVersion");
       return join(base, "maven", src.groupId, src.artifactId, `${entry.resolvedVersion}.jar`);
     case "file": {
       // file-resolver cache key is `sha256-<hex>.jar`; lockfile integrity is
@@ -193,10 +202,28 @@ function cachedJarPathFor(entry: LockfileEntry): string | undefined {
       const hex = entry.integrity.startsWith("sha256-")
         ? entry.integrity.slice("sha256-".length)
         : entry.integrity;
+      assertSafeName(hex, "integrity");
       return join(base, "file", `${hex}.jar`);
     }
     case "workspace":
       return undefined;
+  }
+}
+
+// Mirrors `commands/install.ts:SAFE_NAME_RE`. `+` is load-bearing for
+// real-world Modrinth/Maven versions (e.g. `1.20.1+forge`).
+const SAFE_NAME_RE = /^[A-Za-z0-9._+~-]+$/;
+
+function assertSafeName(value: string, field: string): void {
+  if (typeof value !== "string" || value.length === 0 || !SAFE_NAME_RE.test(value)) {
+    throw new Error(
+      `remove: refusing unsafe lockfile ${field} ${JSON.stringify(value)} — won't construct a cache path that could escape the cache root`,
+    );
+  }
+  if (value === "." || value === "..") {
+    throw new Error(
+      `remove: refusing reserved lockfile ${field} ${JSON.stringify(value)} — would traverse the cache root`,
+    );
   }
 }
 

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -32,24 +32,11 @@ import { bold, dim, green, log, red, yellow } from "../logging.ts";
 
 import { ensureJdk, getCachedJdk, gc, listInstalled, removeJdk } from "../sdk/index.ts";
 import { selectJdkForProject } from "../sdk/resolve.ts";
-
-/**
- * Distributions auto-installable via `pluggy sdk install`. GraalVM CE is
- * included for plugins that use Polyglot/Truffle scripting (Oracle's paid
- * `graalvm` is excluded — auto-installing it would require user license
- * consent we can't model here). Expanding this list is safe; narrowing it
- * isn't, so be conservative when adding.
- */
-const ALLOWED_DISTRIBUTIONS = [
-  "temurin",
-  "zulu",
-  "liberica",
-  "corretto",
-  "microsoft",
-  "graalvm_community",
-] as const;
-
-type AllowedDistribution = (typeof ALLOWED_DISTRIBUTIONS)[number];
+import {
+  ALLOWED_DISTRIBUTIONS,
+  parseDistribution,
+  type AllowedDistribution,
+} from "../sdk/distributions.ts";
 
 interface SdkGlobalOpts {
   json?: boolean;
@@ -307,15 +294,6 @@ function parseMajor(value: string): number {
     throw new InvalidArgumentError(`"${value}" is not a valid Java major release`);
   }
   return n;
-}
-
-function parseDistribution(value: string): AllowedDistribution {
-  if (!ALLOWED_DISTRIBUTIONS.includes(value as AllowedDistribution)) {
-    throw new InvalidArgumentError(
-      `unknown distribution "${value}". Allowed: ${ALLOWED_DISTRIBUTIONS.join(", ")}`,
-    );
-  }
-  return value as AllowedDistribution;
 }
 
 function parseKeep(value: string): number {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,6 +1,7 @@
-import { createHash } from "node:crypto";
+import { createHash, X509Certificate } from "node:crypto";
 import { access, chmod, constants, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { Buffer } from "node:buffer";
 import { dirname, join } from "node:path";
 import process from "node:process";
 
@@ -105,11 +106,11 @@ function isSystemPath(path: string): boolean {
  * workflow, so a missing manifest means we're being asked to upgrade to an
  * unsigned release and `pluggy upgrade` refuses by design.
  *
- * `actions/attest-build-provenance` ships the manifest itself with a
- * Sigstore attestation, so a `gh attestation verify SHA256SUMS.txt --repo
- * <repo>` round-trip catches a tampered manifest at the OIDC-identity
- * level. We don't carry that verifier in-binary yet (it's a follow-up);
- * the manifest hash check below catches simple asset-only substitution.
+ * The manifest itself isn't trust-rooted — an attacker substituting both
+ * the binary and the manifest URL still wins this layer. The downstream
+ * attestation check (`assertAttestedByWorkflow`) closes that gap by
+ * binding the binary's sha256 to a Sigstore certificate issued for this
+ * repo's release workflow.
  */
 async function fetchExpectedSha256(
   repository: string,
@@ -183,6 +184,8 @@ async function replaceInPlace(
     );
   }
 
+  await assertAttestedByWorkflow(repository, actualSha, assetName);
+
   const tempDir = await mkdtemp(join(tmpdir(), "pluggy-upgrade-"));
   const stagedPath = join(tempDir, "pluggy-new");
   await writeFile(stagedPath, bytes);
@@ -206,6 +209,128 @@ async function replaceInPlace(
 
   await rm(tempDir, { recursive: true, force: true });
   return { backupPath };
+}
+
+/**
+ * Cross-check the downloaded asset's sha256 against GitHub's attestation
+ * store. `actions/attest-build-provenance` records a Sigstore attestation
+ * for every release artifact; the GitHub API exposes those at
+ * `/repos/{owner}/{repo}/attestations/sha256:{hex}`. We require:
+ *
+ *   1. At least one attestation exists for the binary's sha256 in this
+ *      repo's attestation store.
+ *   2. The attestation's leaf certificate's SAN identifies the issuing
+ *      OIDC identity as this repo's `.github/workflows/*.yml` workflow.
+ *
+ * (1) means an attacker who substitutes only the asset URL fails — they
+ * can't generate an attestation for arbitrary bytes without GitHub's
+ * Fulcio-issued cert. (2) hardens against an attacker substituting both
+ * the asset and an attestation from an unrelated repo: the cert's
+ * subject-alternative-name is bound to the OIDC identity that requested
+ * it, so a different workflow's attestation has a different SAN.
+ *
+ * We deliberately don't verify the Sigstore signature in-binary — that
+ * would mean shipping a Fulcio trust root and a full bundle verifier, a
+ * substantial amount of crypto code. The check above trusts GitHub's
+ * attestation API as a transport (same channel as the asset download),
+ * which is a meaningful improvement over no attestation at all without
+ * the implementation cost of a complete client-side Sigstore verifier.
+ */
+async function assertAttestedByWorkflow(
+  repository: string,
+  sha256Hex: string,
+  assetName: string,
+): Promise<void> {
+  const url = `https://api.github.com/repos/${repository}/attestations/sha256:${sha256Hex}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `failed to verify attestation for ${assetName}: GitHub API returned ${res.status} ${res.statusText} for ${url}. ` +
+        `Refusing to install a binary with no recorded build provenance.`,
+    );
+  }
+  const data = (await res.json()) as { attestations?: { bundle?: unknown }[] };
+  const attestations = Array.isArray(data.attestations) ? data.attestations : [];
+  if (attestations.length === 0) {
+    throw new Error(
+      `no build-provenance attestation found for ${assetName} in ${repository}. ` +
+        `Refusing to install — every release after this version must be attested by the release workflow. ` +
+        `If this is unexpected, report at https://github.com/${repository}/issues.`,
+    );
+  }
+
+  const expectedIdentityPrefix = `https://github.com/${repository}/.github/workflows/`;
+  const errors: string[] = [];
+  for (const att of attestations) {
+    const bundle = att.bundle;
+    if (bundle === null || typeof bundle !== "object") continue;
+    const certPem = extractLeafCertificatePem(bundle as Record<string, unknown>);
+    if (certPem === undefined) {
+      errors.push("attestation bundle had no leaf certificate");
+      continue;
+    }
+    let cert: X509Certificate;
+    try {
+      cert = new X509Certificate(certPem);
+    } catch (err) {
+      errors.push(`certificate parse failed: ${(err as Error).message}`);
+      continue;
+    }
+    const san = cert.subjectAltName ?? "";
+    if (san.includes(expectedIdentityPrefix)) {
+      log.debug(`upgrade: attestation OK for ${assetName} (SAN matches ${expectedIdentityPrefix})`);
+      return;
+    }
+    errors.push(
+      `attestation SAN ${JSON.stringify(san.slice(0, 200))} does not include ${expectedIdentityPrefix}`,
+    );
+  }
+  throw new Error(
+    `attestation identity mismatch for ${assetName} — none of the ${attestations.length} attestation(s) were issued for ${expectedIdentityPrefix}*. ` +
+      `Refusing to install. Details: ${errors.join("; ")}`,
+  );
+}
+
+/**
+ * Pull the leaf certificate (PEM-encoded) out of a Sigstore bundle. Handles
+ * both the legacy `x509CertificateChain.certificates[0]` and modern
+ * `certificate` shapes that GitHub's attestation API returns. The cert's
+ * raw bytes are base64-encoded DER; we re-wrap as PEM for X509Certificate.
+ */
+function extractLeafCertificatePem(bundle: Record<string, unknown>): string | undefined {
+  const vm = bundle.verificationMaterial;
+  if (vm === null || typeof vm !== "object") return undefined;
+  const material = vm as Record<string, unknown>;
+
+  let rawBytesB64: string | undefined;
+
+  const direct = material.certificate as { rawBytes?: unknown } | undefined;
+  if (direct !== undefined && typeof direct.rawBytes === "string") {
+    rawBytesB64 = direct.rawBytes;
+  }
+
+  if (rawBytesB64 === undefined) {
+    const chain = material.x509CertificateChain as
+      | { certificates?: { rawBytes?: unknown }[] }
+      | undefined;
+    const first = chain?.certificates?.[0];
+    if (first !== undefined && typeof first.rawBytes === "string") {
+      rawBytesB64 = first.rawBytes;
+    }
+  }
+
+  if (rawBytesB64 === undefined) return undefined;
+
+  // base64 → DER → PEM-wrapped, which is what X509Certificate accepts.
+  const der = Buffer.from(rawBytesB64, "base64");
+  const b64 = der.toString("base64");
+  const wrapped = b64.replace(/(.{64})/g, "$1\n");
+  return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----\n`;
 }
 
 function printPermissionGuidance(repository: string, currentBinaryPath: string): void {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { access, chmod, constants, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -98,15 +99,70 @@ function isSystemPath(path: string): boolean {
 }
 
 /**
+ * Fetch `SHA256SUMS.txt` for the release and return a map of `assetName ->
+ * lowercase hex sha256`. Throws when the manifest is missing — the install
+ * pipeline only began publishing the manifest with this version's release
+ * workflow, so a missing manifest means we're being asked to upgrade to an
+ * unsigned release and `pluggy upgrade` refuses by design.
+ *
+ * `actions/attest-build-provenance` ships the manifest itself with a
+ * Sigstore attestation, so a `gh attestation verify SHA256SUMS.txt --repo
+ * <repo>` round-trip catches a tampered manifest at the OIDC-identity
+ * level. We don't carry that verifier in-binary yet (it's a follow-up);
+ * the manifest hash check below catches simple asset-only substitution.
+ */
+async function fetchExpectedSha256(
+  repository: string,
+  tag: string,
+  assetName: string,
+): Promise<string> {
+  const manifestUrl = `https://github.com/${repository}/releases/download/${tag}/SHA256SUMS.txt`;
+  const res = await fetch(manifestUrl);
+  if (!res.ok) {
+    throw new Error(
+      `failed to fetch ${manifestUrl}: ${res.status} ${res.statusText}. ` +
+        `This release does not publish a checksum manifest; refusing to upgrade to an unverified binary. ` +
+        `Re-install manually if you trust this release: ` +
+        `curl -fsSL https://github.com/${repository}/releases/download/${tag}/install.sh | bash`,
+    );
+  }
+  const text = await res.text();
+  const expected = parseShaManifest(text, assetName);
+  if (expected === undefined) {
+    throw new Error(
+      `SHA256SUMS.txt at ${manifestUrl} has no entry for "${assetName}". Refusing to upgrade.`,
+    );
+  }
+  return expected;
+}
+
+/** Parse `<sha256-hex>  <filename>` lines, return the hex matching `name` (or undefined). */
+function parseShaManifest(text: string, name: string): string | undefined {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    // sha256sum format: "<hex><space><space><filename>" — but tolerate one or
+    // more spaces / tabs to match other generators.
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (match === null) continue;
+    if (match[2].trim() === name) return match[1].toLowerCase();
+  }
+  return undefined;
+}
+
+/**
  * Download the release asset for the current platform into a temp file,
- * rename the running binary out of the way (Windows tolerates this; Unix
- * is routine), and move the new binary into its place. On failure, the
- * old binary is restored from the `.old` backup so the user isn't left
- * with a broken install.
+ * verify it against `SHA256SUMS.txt`, rename the running binary out of the
+ * way (Windows tolerates this; Unix is routine), and move the new binary
+ * into its place. On failure, the old binary is restored from the `.old`
+ * backup so the user isn't left with a broken install.
  */
 async function replaceInPlace(
   downloadUrl: string,
   currentBinaryPath: string,
+  expectedSha256: string,
+  assetName: string,
+  repository: string,
 ): Promise<{ backupPath: string }> {
   const binaryRes = await fetch(downloadUrl);
   if (!binaryRes.ok) {
@@ -117,6 +173,14 @@ async function replaceInPlace(
   const bytes = new Uint8Array(await binaryRes.arrayBuffer());
   if (bytes.length === 0) {
     throw new Error(`downloaded asset from ${downloadUrl} is empty`);
+  }
+
+  const actualSha = createHash("sha256").update(bytes).digest("hex");
+  if (actualSha !== expectedSha256) {
+    throw new Error(
+      `integrity check failed for ${assetName} — SHA256SUMS.txt expects ${expectedSha256} but downloaded bytes hash to ${actualSha}. ` +
+        `Refusing to install a tampered binary; please report at https://github.com/${repository}/issues.`,
+    );
   }
 
   const tempDir = await mkdtemp(join(tmpdir(), "pluggy-upgrade-"));
@@ -219,7 +283,18 @@ export function upgradeCommand(options: UpgradeOptions): Command {
       log.info(`${dim(`downloading ${downloadUrl}`)}`);
 
       try {
-        const { backupPath } = await replaceInPlace(downloadUrl, currentBinaryPath);
+        const expectedSha = await fetchExpectedSha256(
+          options.repository,
+          release.tag_name,
+          assetName,
+        );
+        const { backupPath } = await replaceInPlace(
+          downloadUrl,
+          currentBinaryPath,
+          expectedSha,
+          assetName,
+          options.repository,
+        );
         log.success(
           `pluggy ${release.tag_name} installed at ${currentBinaryPath} (previous binary backed up to ${backupPath})`,
         );

--- a/src/dev/hotswap.ts
+++ b/src/dev/hotswap.ts
@@ -16,8 +16,9 @@
  */
 
 import type { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { log } from "../logging.ts";
@@ -27,17 +28,41 @@ import { getCachePath } from "../project.ts";
 /**
  * Pinned HotswapAgent release. Bump deliberately — agent log markers and
  * config keys can shift between majors and `wait()` parses them.
+ *
+ * After bumping `HOTSWAP_AGENT_VERSION`, replace `HOTSWAP_AGENT_SHA256` with
+ * the SHA-256 of the new release JAR. The integrity check refuses the
+ * download otherwise — a missing pin is treated as a release-process bug.
  */
 export const HOTSWAP_AGENT_VERSION = "2.0.3";
+const HOTSWAP_AGENT_SHA256: Record<string, string> = {
+  "2.0.3": "4ef49724b7d8523536d2e2a7310f827f4db9f4fed3489224e05d7bf87f0594f9",
+};
 
 const AGENT_RELEASE_URL = (version: string): string =>
   `https://github.com/HotswapProjects/HotswapAgent/releases/download/RELEASE-${version}/hotswap-agent-${version}.jar`;
 
 /** Cached path to the HotswapAgent JAR (download on miss). */
 export async function ensureAgent(version = HOTSWAP_AGENT_VERSION): Promise<string> {
+  const expectedSha = HOTSWAP_AGENT_SHA256[version];
+  if (expectedSha === undefined) {
+    throw new Error(
+      `hotswap: no pinned SHA-256 for HotswapAgent ${version} — refusing to download an unverified agent. ` +
+        `Add the expected hash to HOTSWAP_AGENT_SHA256 in src/dev/hotswap.ts.`,
+    );
+  }
+
   const cacheDir = join(getCachePath(), "agents");
   const dest = join(cacheDir, `hotswap-agent-${version}.jar`);
-  if (existsSync(dest)) return dest;
+  if (existsSync(dest)) {
+    const cachedSha = createHash("sha256")
+      .update(await readFile(dest))
+      .digest("hex");
+    if (cachedSha === expectedSha) return dest;
+    log.warn(
+      `hotswap: cached agent at ${dest} has unexpected sha256 ${cachedSha} (expected ${expectedSha}); re-downloading`,
+    );
+    await rm(dest, { force: true });
+  }
 
   await mkdir(cacheDir, { recursive: true });
   const url = AGENT_RELEASE_URL(version);
@@ -46,8 +71,16 @@ export async function ensureAgent(version = HOTSWAP_AGENT_VERSION): Promise<stri
   if (!res.ok) {
     throw new Error(`hotswap: agent download failed (${res.status} ${res.statusText}) — ${url}`);
   }
+  const buf = new Uint8Array(await res.arrayBuffer());
+  const actualSha = createHash("sha256").update(buf).digest("hex");
+  if (actualSha !== expectedSha) {
+    throw new Error(
+      `hotswap: integrity check failed for hotswap-agent-${version}.jar — expected sha256 ${expectedSha}, got ${actualSha}. ` +
+        `Refusing to load an unverified javaagent; please report at https://github.com/ch99q/pluggy/issues.`,
+    );
+  }
   const tmp = `${dest}.partial`;
-  await writeFile(tmp, new Uint8Array(await res.arrayBuffer()));
+  await writeFile(tmp, buf);
   await rename(tmp, dest);
   log.debug(`hotswap: cached agent at ${dest}`);
   return dest;

--- a/src/dev/jbr.ts
+++ b/src/dev/jbr.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readdir, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -25,9 +26,27 @@ import { getCachePath } from "../project.ts";
  *
  * Update by browsing https://github.com/JetBrains/JetBrainsRuntime/releases
  * and copying the `jbrsdk-<version>-<os>-<arch>-<build>.tar.gz` filename.
+ * After bumping the version/build, also recompute the per-target SHA-256s
+ * in `JBR_SHA256` — without that, the integrity check fails fast and dev
+ * mode refuses to run, which is the safe default.
  */
 export const JBR_VERSION = "25.0.2";
 export const JBR_BUILD = "b432.48";
+
+/**
+ * Expected SHA-256 of each JBR tarball, keyed by `${os}-${arch}`. Verified
+ * after download and before extraction. A mismatch aborts with a clear error
+ * — corrupt cache or hostile substitution both surface here. Bake new values
+ * by running `shasum -a 256 jbrsdk-<version>-<os>-<arch>-<build>.tar.gz`
+ * against the official archive.
+ */
+const JBR_SHA256: Record<string, string> = {
+  "osx-aarch64": "1501ed8f15c1176abc895d6e3cf2b52562152f9731ec024b552e4bef24f02bf9",
+  "osx-x64": "aeb433aef8bedcd8ba32963857923096a03bd87ca6ebb7a65a79d8b41b97dec3",
+  "linux-aarch64": "b2a7e10c80b9560bee42e2f6f69d4491dc74362a7ca378249ec545a83155eb57",
+  "linux-x64": "a76e8c1ef916f84d3b28e6794d1527d5189f9b0299a323e21ea737bdd93eaddd",
+  "windows-x64": "48bf62ff4d61969066d71012e98ed6ef1292c4709badb099e22ed07195b00527",
+};
 
 interface JbrTarget {
   /** "osx" | "linux" | "windows" — JBR's own naming. */
@@ -96,10 +115,22 @@ export async function ensureJbr(): Promise<string> {
 
   await mkdir(cacheRoot, { recursive: true });
 
+  const expectedSha = expectedShaFor(target);
   const archiveName = jbrArchiveName(target);
   const archivePath = join(cacheRoot, archiveName);
+  if (existsSync(archivePath)) {
+    // A cached archive that doesn't match the pinned hash is rejected — it's
+    // either corrupt or substituted out of band. Drop and redownload.
+    const cachedSha = await sha256OfFile(archivePath);
+    if (cachedSha !== expectedSha) {
+      log.warn(
+        `hotswap: cached JBR archive at ${archivePath} has unexpected sha256 ${cachedSha} (expected ${expectedSha}); re-downloading`,
+      );
+      await rm(archivePath, { force: true });
+    }
+  }
   if (!existsSync(archivePath)) {
-    await downloadArchive(archiveName, archivePath);
+    await downloadArchive(archiveName, archivePath, expectedSha);
   }
 
   await extractInto(archivePath, cacheRoot, extractedRoot);
@@ -112,17 +143,46 @@ export async function ensureJbr(): Promise<string> {
   return javaPath;
 }
 
+function expectedShaFor(target: JbrTarget): string {
+  const key = `${target.os}-${target.arch}`;
+  const sha = JBR_SHA256[key];
+  if (sha === undefined) {
+    throw new Error(
+      `jbr: no pinned SHA-256 for ${key} — refusing to download an unverified runtime. ` +
+        `Add the expected hash to JBR_SHA256 in src/dev/jbr.ts.`,
+    );
+  }
+  return sha;
+}
+
+async function sha256OfFile(path: string): Promise<string> {
+  const { readFile } = await import("node:fs/promises");
+  const bytes = await readFile(path);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
 const JBR_CDN = "https://cache-redirector.jetbrains.com/intellij-jbr";
 
-async function downloadArchive(archiveName: string, destPath: string): Promise<void> {
+async function downloadArchive(
+  archiveName: string,
+  destPath: string,
+  expectedSha: string,
+): Promise<void> {
   const url = `${JBR_CDN}/${archiveName}`;
   log.info(`hotswap: downloading JetBrains Runtime (${archiveName})…`);
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`jbr: download failed (${res.status} ${res.statusText}) — ${url}`);
   }
-  const tmpPath = `${destPath}.partial`;
   const buf = new Uint8Array(await res.arrayBuffer());
+  const actualSha = createHash("sha256").update(buf).digest("hex");
+  if (actualSha !== expectedSha) {
+    throw new Error(
+      `jbr: integrity check failed for ${archiveName} — expected sha256 ${expectedSha}, got ${actualSha}. ` +
+        `Refusing to extract an unverified runtime; please report at https://github.com/ch99q/pluggy/issues.`,
+    );
+  }
+  const tmpPath = `${destPath}.partial`;
   const { writeFile } = await import("node:fs/promises");
   await writeFile(tmpPath, buf);
   await rename(tmpPath, destPath);

--- a/src/platform/spigot/buildtools.ts
+++ b/src/platform/spigot/buildtools.ts
@@ -2,11 +2,20 @@
  * Spigot BuildTools driver. Downloads `BuildTools.jar`, spawns it under
  * Java to compile a CraftBukkit or Spigot server jar, and surfaces the
  * child's live output as an async stream.
+ *
+ * SpigotMC publishes BuildTools.jar without a checksum sidecar, so we
+ * can't bake an upstream-known hash in. Instead we apply trust-on-first-use
+ * (TOFU) — record the SHA-256 of the first download alongside the cached
+ * jar, and refuse to use a cached copy whose bytes drift from the recorded
+ * value on subsequent runs. Catches post-install substitution and partial
+ * download even though the initial download is still trusted on its first
+ * appearance.
  */
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { classMajorToJava } from "../../jar.ts";
@@ -19,13 +28,41 @@ export const VERSIONS_URL = "https://hub.spigotmc.org/versions/";
 /** Download (or reuse a cached copy of) `BuildTools.jar` and return its path. */
 export async function download(ctx: PlatformContext, ignoreCache = false): Promise<string> {
   const BUILDTOOLS_PATH = join(ctx.getCachePath(), "BuildTools.jar");
+  const SHA_PATH = `${BUILDTOOLS_PATH}.sha256`;
+
   if (existsSync(BUILDTOOLS_PATH) && !ignoreCache) {
-    return BUILDTOOLS_PATH;
+    if (existsSync(SHA_PATH)) {
+      const recorded = (await readFile(SHA_PATH, "utf8")).trim();
+      const actual = createHash("sha256")
+        .update(await readFile(BUILDTOOLS_PATH))
+        .digest("hex");
+      if (recorded !== actual) {
+        // Cached jar drifted from the recorded hash: cache poisoning,
+        // partial overwrite, or a bit-flip. Drop both files and re-fetch
+        // so the user gets a fresh jar with a fresh recorded hash.
+        await rm(BUILDTOOLS_PATH, { force: true });
+        await rm(SHA_PATH, { force: true });
+      } else {
+        return BUILDTOOLS_PATH;
+      }
+    } else {
+      // Older install (pre-TOFU) — adopt the existing jar by recording
+      // its current hash. Strictly weaker than a clean download, but the
+      // user has already been running this jar so it's not a regression.
+      const actual = createHash("sha256")
+        .update(await readFile(BUILDTOOLS_PATH))
+        .digest("hex");
+      await writeFile(SHA_PATH, `${actual}\n`);
+      return BUILDTOOLS_PATH;
+    }
   }
+
   const res = await fetch(BUILDTOOLS_URL);
   if (!res.ok) throw new Error(`Failed to download BuildTools: ${res.statusText}`);
   const data = new Uint8Array(await res.arrayBuffer());
+  const sha = createHash("sha256").update(data).digest("hex");
   await writeFile(BUILDTOOLS_PATH, data);
+  await writeFile(SHA_PATH, `${sha}\n`);
   return BUILDTOOLS_PATH;
 }
 

--- a/src/portable.test.ts
+++ b/src/portable.test.ts
@@ -11,6 +11,7 @@ import {
   installShutdownHandler,
   linkOrCopy,
   resolveRelativeToConfig,
+  safeJoin,
   toPosixPath,
   writeFileLF,
 } from "./portable.ts";
@@ -185,6 +186,33 @@ describe("writeFileLF", () => {
 
     const read = await readFile(target, "utf8");
     expect(read).toBe(contents);
+  });
+});
+
+describe("safeJoin", () => {
+  const root = resolve("/tmp/pluggy-safe-root");
+
+  test("joins a clean relative path", () => {
+    expect(safeJoin(root, "files/a/b.txt")).toBe(resolve(root, "files/a/b.txt"));
+  });
+
+  test("rejects parent traversal", () => {
+    expect(() => safeJoin(root, "../etc/passwd")).toThrow(/escapes/);
+    expect(() => safeJoin(root, "files/../../etc/passwd")).toThrow(/escapes/);
+    expect(() => safeJoin(root, "a/b/../../../etc/passwd")).toThrow(/escapes/);
+  });
+
+  test("rejects absolute paths", () => {
+    expect(() => safeJoin(root, resolve("/etc/passwd"))).toThrow(/absolute/);
+  });
+
+  test("rejects backslash-bearing input on every host", () => {
+    expect(() => safeJoin(root, "a\\b\\c")).toThrow(/backslash/);
+    expect(() => safeJoin(root, "..\\etc\\passwd")).toThrow(/backslash/);
+  });
+
+  test("allows nested traversal that doesn't escape root", () => {
+    expect(safeJoin(root, "a/../b.txt")).toBe(resolve(root, "b.txt"));
   });
 });
 

--- a/src/portable.ts
+++ b/src/portable.ts
@@ -174,13 +174,16 @@ export function safeJoin(root: string, relativePath: string): string {
   if (typeof relativePath !== "string") {
     throw new Error(`safeJoin: relativePath must be a string`);
   }
+  // Absolute-path check has to come first: on Windows, `path.resolve("/x")`
+  // returns `C:\x` — `\` is the platform separator, so the backslash check
+  // below would fire before the absolute one and misreport the error.
+  if (isAbsolute(relativePath)) {
+    throw new Error(`safeJoin: refusing absolute path: ${JSON.stringify(relativePath)}`);
+  }
   if (relativePath.includes("\\")) {
     throw new Error(
       `safeJoin: refusing entry containing backslash: ${JSON.stringify(relativePath)}`,
     );
-  }
-  if (isAbsolute(relativePath)) {
-    throw new Error(`safeJoin: refusing absolute path: ${JSON.stringify(relativePath)}`);
   }
   const resolvedRoot = resolve(root);
   const candidate = resolve(resolvedRoot, relativePath);

--- a/src/portable.ts
+++ b/src/portable.ts
@@ -5,7 +5,7 @@
 
 import type { ChildProcess } from "node:child_process";
 import { copyFile, link, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
 
 /**
  * Make `destination` reference the bytes at `source` — hardlink first,
@@ -159,4 +159,33 @@ export function installShutdownHandler(child: ChildProcess, opts: ShutdownOption
 export async function writeFileLF(path: string, contents: string): Promise<void> {
   const normalized = contents.includes("\r\n") ? contents.replace(/\r\n/g, "\n") : contents;
   await writeFile(path, normalized, "utf8");
+}
+
+/**
+ * Join `root` with `relativePath` and assert the result stays under `root`.
+ * Use whenever an archive entry name, downloaded path component, or other
+ * untrusted input is being written under a directory — a malicious `..` or
+ * absolute path otherwise escapes the root (zip-slip). Behaviour is the same
+ * on every host: backslashes in the input are rejected up front so a
+ * Windows-targeted entry doesn't traverse on Windows but write a literal
+ * `\\`-named file on POSIX.
+ */
+export function safeJoin(root: string, relativePath: string): string {
+  if (typeof relativePath !== "string") {
+    throw new Error(`safeJoin: relativePath must be a string`);
+  }
+  if (relativePath.includes("\\")) {
+    throw new Error(
+      `safeJoin: refusing entry containing backslash: ${JSON.stringify(relativePath)}`,
+    );
+  }
+  if (isAbsolute(relativePath)) {
+    throw new Error(`safeJoin: refusing absolute path: ${JSON.stringify(relativePath)}`);
+  }
+  const resolvedRoot = resolve(root);
+  const candidate = resolve(resolvedRoot, relativePath);
+  if (candidate !== resolvedRoot && !candidate.startsWith(resolvedRoot + sep)) {
+    throw new Error(`safeJoin: ${JSON.stringify(relativePath)} escapes ${JSON.stringify(root)}`);
+  }
+  return candidate;
 }

--- a/src/resolver/file.test.ts
+++ b/src/resolver/file.test.ts
@@ -95,6 +95,21 @@ describe("resolveFile", () => {
     );
   });
 
+  test("rejects the resolve when expectedIntegrity disagrees with the file bytes", async () => {
+    const bytes = new Uint8Array([42, 42, 42]);
+    await writeFile(join(workDir, "ours.jar"), bytes);
+
+    const ctx: ResolveContext = {
+      rootDir: workDir,
+      includePrerelease: false,
+      force: false,
+      registries: [],
+      expectedIntegrity: "sha256-pinned",
+    };
+
+    await expect(resolveFile("./ours.jar", "1", ctx)).rejects.toThrow(/integrity check failed/);
+  });
+
   test("byte-identical files from different source paths hash to the same cache entry", async () => {
     const bytes = new Uint8Array([7, 7, 7]);
     await writeFile(join(workDir, "a.jar"), bytes);

--- a/src/resolver/file.ts
+++ b/src/resolver/file.ts
@@ -41,6 +41,14 @@ export async function resolveFile(
   const hex = createHash("sha256").update(bytes).digest("hex");
   const integrity = `sha256-${hex}`;
 
+  if (ctx.expectedIntegrity !== undefined && integrity !== ctx.expectedIntegrity) {
+    throw new Error(
+      `file: integrity check failed for "${path}" — ` +
+        `lockfile expects ${ctx.expectedIntegrity} but the file's bytes hash to ${integrity}. ` +
+        `Re-run with --force to accept the new bytes (this overwrites the lockfile).`,
+    );
+  }
+
   const cacheDir = join(getCachePath(), "dependencies", "file");
   await mkdir(cacheDir, { recursive: true });
   const jarPath = join(cacheDir, `${hex}.jar`);

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -32,6 +32,13 @@ export interface ResolveContext {
   registries: string[];
   /** Required for `workspace:` sources; resolving one without it throws. */
   workspaceContext?: WorkspaceContext;
+  /**
+   * Optional `sha256-<hex>` from the lockfile. When set, resolvers verify
+   * the resolved bytes match it and refuse to overwrite with anything else.
+   * Caller passes this only when it has a recorded integrity to enforce
+   * (i.e. resolving an existing pinned dep, not a fresh install).
+   */
+  expectedIntegrity?: string;
 }
 
 /**

--- a/src/resolver/maven.test.ts
+++ b/src/resolver/maven.test.ts
@@ -183,6 +183,50 @@ describe("resolveMaven", () => {
     expect(got.integrity).toBe(`sha256-${expectedHex}`);
   });
 
+  test("rejects the resolve when the .sha1 sidecar disagrees with the downloaded jar", async () => {
+    const bytes = new Uint8Array([0xab, 0xcd, 0xef]);
+    const fetchMock = vi.fn(async (url: string | URL): Promise<Response> => {
+      const s = String(url);
+      if (s.endsWith(".jar.sha1")) {
+        // Wrong hash on purpose — sha1 of "abcdef" bytes is not all-fs.
+        return new Response("ffffffffffffffffffffffffffffffffffffffff", { status: 200 });
+      }
+      if (s.endsWith(".jar.sha512") || s.endsWith(".jar.sha256")) {
+        return errorResponse(404, "Not Found");
+      }
+      if (s.endsWith(".jar")) return okBinary(bytes);
+      return errorResponse(404, "Not Found");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx: ResolveContext = {
+      ...baseCtx,
+      registries: ["https://repo.example.com"],
+    };
+    await expect(resolveMaven("com.foo", "bar", "1.0.0", ctx)).rejects.toThrow(
+      /sha1 mismatch.*com\.foo:bar:1\.0\.0/s,
+    );
+  });
+
+  test("accepts the resolve when the .sha512 sidecar matches", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const realSha512 = createHash("sha512").update(bytes).digest("hex");
+    const fetchMock = vi.fn(async (url: string | URL): Promise<Response> => {
+      const s = String(url);
+      if (s.endsWith(".jar.sha512")) return new Response(realSha512, { status: 200 });
+      if (s.endsWith(".jar")) return okBinary(bytes);
+      return errorResponse(404, "Not Found");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx: ResolveContext = {
+      ...baseCtx,
+      registries: ["https://repo.example.com"],
+    };
+    const got = await resolveMaven("com.foo", "bar", "1.0.0", ctx);
+    expect(got.integrity).toBe(`sha256-${createHash("sha256").update(bytes).digest("hex")}`);
+  });
+
   test("computes SHA-256 over the downloaded bytes", async () => {
     const bytes = new TextEncoder().encode("hello world");
     const fetchMock = vi.fn(async () => okBinary(bytes));

--- a/src/resolver/maven.ts
+++ b/src/resolver/maven.ts
@@ -80,6 +80,7 @@ async function resolveOne(
   let downloadedFrom: string | undefined;
   let bytes: Uint8Array | undefined;
 
+  let downloadedJarUrl: string | undefined;
   for (const registry of registries) {
     const base = stripTrailingSlash(registry);
     const jarUrl = await resolveJarUrl(base, groupId, artifactId, version, errors);
@@ -90,14 +91,17 @@ async function resolveOne(
 
     bytes = fetched;
     downloadedFrom = base;
+    downloadedJarUrl = jarUrl;
     break;
   }
 
-  if (bytes === undefined || downloadedFrom === undefined) {
+  if (bytes === undefined || downloadedFrom === undefined || downloadedJarUrl === undefined) {
     throw new Error(
       `Maven: could not resolve "${coord}" from any configured registry. Tried:\n  ${errors.join("\n  ")}`,
     );
   }
+
+  await verifyAgainstSidecar(downloadedJarUrl, bytes, coord);
 
   const integrity = `sha256-${createHash("sha256").update(bytes).digest("hex")}`;
   // Only enforce expected-integrity on the top-level resolve (depth 0); a
@@ -455,6 +459,63 @@ async function fetchText(url: string, errors: string[]): Promise<string | undefi
 
 function cachedJarPath(groupId: string, artifactId: string, version: string): string {
   return join(getCachePath(), "dependencies", "maven", groupId, artifactId, `${version}.jar`);
+}
+
+/**
+ * Verify the downloaded jar against the registry-published checksum sidecar
+ * (`<jarUrl>.sha512` / `.sha256` / `.sha1` / `.md5`, in that preference
+ * order). Maven Central and most repos publish at least one of these next
+ * to every artifact; a present-but-mismatching sidecar is a hard fail
+ * because that's the registry telling us the bytes we got aren't the bytes
+ * it intended to serve. A missing sidecar is logged at debug and tolerated
+ * — some smaller mirrors (and snapshot repos for older Spigot artifacts)
+ * skip them.
+ */
+async function verifyAgainstSidecar(
+  jarUrl: string,
+  bytes: Uint8Array,
+  coord: string,
+): Promise<void> {
+  const candidates: { ext: string; algorithm: "sha512" | "sha256" | "sha1" | "md5" }[] = [
+    { ext: "sha512", algorithm: "sha512" },
+    { ext: "sha256", algorithm: "sha256" },
+    { ext: "sha1", algorithm: "sha1" },
+    { ext: "md5", algorithm: "md5" },
+  ];
+  for (const { ext, algorithm } of candidates) {
+    const sidecarUrl = `${jarUrl}.${ext}`;
+    const text = await fetchSidecarText(sidecarUrl);
+    if (text === undefined) continue;
+    const expected = parseSidecarHex(text);
+    if (expected === undefined) continue;
+    const actual = createHash(algorithm).update(bytes).digest("hex");
+    if (actual !== expected) {
+      throw new Error(
+        `maven: ${algorithm} mismatch for "${coord}" — sidecar at ${sidecarUrl} says ${expected}, downloaded bytes hash to ${actual}. ` +
+          `Refusing to use a tampered jar.`,
+      );
+    }
+    return;
+  }
+  log.debug(`maven: no checksum sidecar found for ${coord} (${jarUrl})`);
+}
+
+async function fetchSidecarText(url: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return undefined;
+    return await res.text();
+  } catch {
+    return undefined;
+  }
+}
+
+function parseSidecarHex(text: string): string | undefined {
+  // Maven sidecars are typically just `<hex>` or `<hex>  <filename>`. Tolerate
+  // whitespace and extract the leading hex token.
+  const trimmed = text.trim().split(/\s+/)[0]?.toLowerCase();
+  if (trimmed === undefined || !/^[0-9a-f]+$/.test(trimmed)) return undefined;
+  return trimmed;
 }
 
 function groupPath(groupId: string): string {

--- a/src/resolver/maven.ts
+++ b/src/resolver/maven.ts
@@ -49,7 +49,15 @@ export async function resolveMaven(
   }
 
   const visited = new Set<string>();
-  return resolveOne(groupId, artifactId, version, ctx.registries, visited, 0);
+  return resolveOne(
+    groupId,
+    artifactId,
+    version,
+    ctx.registries,
+    visited,
+    0,
+    ctx.expectedIntegrity,
+  );
 }
 
 async function resolveOne(
@@ -59,6 +67,7 @@ async function resolveOne(
   registries: string[],
   visited: Set<string>,
   depth: number,
+  expectedIntegrity?: string,
 ): Promise<ResolvedDependency> {
   const coord = `${groupId}:${artifactId}:${version}`;
   const key = `${groupId}:${artifactId}`;
@@ -90,8 +99,18 @@ async function resolveOne(
     );
   }
 
-  await writeFile(jarPath, bytes);
   const integrity = `sha256-${createHash("sha256").update(bytes).digest("hex")}`;
+  // Only enforce expected-integrity on the top-level resolve (depth 0); a
+  // mismatch deeper in the tree means upstream advanced a transitive, which
+  // is normal flux and out of scope for the lockfile-pin we're enforcing.
+  if (depth === 0 && expectedIntegrity !== undefined && integrity !== expectedIntegrity) {
+    throw new Error(
+      `maven: integrity check failed for "${coord}" — ` +
+        `lockfile expects ${expectedIntegrity} but resolved bytes are ${integrity}. ` +
+        `Re-run with --force to accept the new bytes (this overwrites the lockfile).`,
+    );
+  }
+  await writeFile(jarPath, bytes);
   const source: ResolvedSource = { kind: "maven", groupId, artifactId, version };
 
   const transitiveDeps =

--- a/src/resolver/modrinth.test.ts
+++ b/src/resolver/modrinth.test.ts
@@ -31,12 +31,13 @@ function mkVersion(
   version_number: string,
   version_type: ModrinthVersion["version_type"],
   url: string,
+  hashes: { sha1?: string; sha512?: string } = {},
 ): ModrinthVersion {
   return {
     id: `id-${version_number}`,
     version_number,
     version_type,
-    files: [{ url, filename: `${version_number}.jar`, primary: true, hashes: {} }],
+    files: [{ url, filename: `${version_number}.jar`, primary: true, hashes }],
   };
 }
 
@@ -202,6 +203,46 @@ describe("resolveModrinth", () => {
       vi.fn(async () => errorResponse(404, "Not Found")),
     );
     await expect(resolveModrinth("nope", "*", ctx)).rejects.toThrow(/Modrinth API.*"nope".*404/s);
+  });
+
+  test("rejects downloads whose bytes don't match Modrinth's published sha512", async () => {
+    const bytes = new Uint8Array([0xaa, 0xbb, 0xcc]);
+    const wrongSha512 = "f".repeat(128);
+    const versions: ModrinthVersion[] = [
+      mkVersion("1.0.0", "release", "https://cdn/1.0.0.jar", { sha512: wrongSha512 }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL): Promise<Response> => {
+        const s = String(url);
+        if (s.includes("/project/")) return okJson(versions);
+        if (s === "https://cdn/1.0.0.jar") return okBinary(bytes);
+        throw new Error(`unexpected url: ${s}`);
+      }),
+    );
+
+    await expect(resolveModrinth("evil", "1.0.0", ctx)).rejects.toThrow(/sha512 mismatch/);
+  });
+
+  test("rejects when expectedIntegrity from the lockfile doesn't match resolved bytes", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const realSha512 = createHash("sha512").update(bytes).digest("hex");
+    const versions: ModrinthVersion[] = [
+      mkVersion("1.0.0", "release", "https://cdn/1.0.0.jar", { sha512: realSha512 }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL): Promise<Response> => {
+        const s = String(url);
+        if (s.includes("/project/")) return okJson(versions);
+        if (s === "https://cdn/1.0.0.jar") return okBinary(bytes);
+        throw new Error(`unexpected url: ${s}`);
+      }),
+    );
+
+    await expect(
+      resolveModrinth("worldedit", "1.0.0", { ...ctx, expectedIntegrity: "sha256-pinned" }),
+    ).rejects.toThrow(/integrity check failed/);
   });
 
   test("skips the download when the cached jar already exists", async () => {

--- a/src/resolver/modrinth.ts
+++ b/src/resolver/modrinth.ts
@@ -2,11 +2,21 @@
  * Modrinth resolver. Fetches the version list for a slug, picks a concrete
  * version (honouring `includePrerelease`), and downloads the primary jar
  * into the user cache.
+ *
+ * Integrity is verified at two levels:
+ *   1. Modrinth's API publishes `hashes.sha512` for every file. Every
+ *      download (fresh or cache-hit) is re-verified against this value, so
+ *      a registry-side substitution or cache poisoning between runs is
+ *      caught before the jar reaches `build` / `dev`.
+ *   2. When the caller passes `ctx.expectedIntegrity` (the lockfile's
+ *      recorded `sha256-<hex>` for this dep), the resolved bytes must
+ *      match it too. Lets `install` refuse silent rolls forward across
+ *      pinned versions.
  */
 
 import { createHash } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { access, mkdir, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -50,11 +60,29 @@ export async function resolveModrinth(
   await mkdir(cacheDir, { recursive: true });
   const jarPath = join(cacheDir, `${picked.version_number}.jar`);
 
-  if (!(await fileExists(jarPath))) {
+  // Cache-hit path: confirm the bytes match Modrinth's published sha512
+  // before reusing them. A poisoned cache (manual write, malicious tooling,
+  // older buggy resolver) is caught here rather than executed at runtime.
+  if (await fileExists(jarPath)) {
+    if (!(await cachedFileMatchesSha512(jarPath, file.hashes.sha512))) {
+      await rm(jarPath, { force: true });
+      await downloadTo(file.url, jarPath, slug, picked.version_number);
+    }
+  } else {
     await downloadTo(file.url, jarPath, slug, picked.version_number);
   }
 
+  await verifyAgainstApiHash(jarPath, slug, picked.version_number, file.hashes);
+
   const integrity = await sha256OfFile(jarPath);
+
+  if (ctx.expectedIntegrity !== undefined && integrity !== ctx.expectedIntegrity) {
+    throw new Error(
+      `modrinth: integrity check failed for "${slug}@${picked.version_number}" — ` +
+        `lockfile expects ${ctx.expectedIntegrity} but resolved bytes are ${integrity}. ` +
+        `Re-run with --force to accept the new bytes (this overwrites the lockfile).`,
+    );
+  }
 
   const source: ResolvedSource = {
     kind: "modrinth",
@@ -192,4 +220,35 @@ async function sha256OfFile(path: string): Promise<string> {
   const bytes = await readFile(path);
   const hash = createHash("sha256").update(bytes).digest("hex");
   return `sha256-${hash}`;
+}
+
+async function cachedFileMatchesSha512(
+  path: string,
+  expectedSha512: string | undefined,
+): Promise<boolean> {
+  // No upstream hash → can't verify; trust the cache. Modrinth always emits
+  // sha512 today, but the type marks it optional so be defensive.
+  if (expectedSha512 === undefined || expectedSha512.length === 0) return true;
+  const bytes = await readFile(path);
+  const actual = createHash("sha512").update(bytes).digest("hex");
+  return actual === expectedSha512.toLowerCase();
+}
+
+async function verifyAgainstApiHash(
+  jarPath: string,
+  slug: string,
+  versionNumber: string,
+  hashes: ModrinthFile["hashes"],
+): Promise<void> {
+  const expected = hashes.sha512;
+  if (expected === undefined || expected.length === 0) return;
+  const bytes = await readFile(jarPath);
+  const actual = createHash("sha512").update(bytes).digest("hex");
+  if (actual !== expected.toLowerCase()) {
+    throw new Error(
+      `modrinth: sha512 mismatch for "${slug}@${versionNumber}" — ` +
+        `Modrinth published ${expected} but downloaded bytes hash to ${actual}. ` +
+        `Refusing to use a tampered jar.`,
+    );
+  }
 }

--- a/src/sdk/cache.test.ts
+++ b/src/sdk/cache.test.ts
@@ -36,6 +36,27 @@ describe("cacheKey", () => {
       "temurin-21-macos-aarch64",
     );
   });
+
+  test("rejects path-traversal in distribution", () => {
+    expect(() =>
+      cacheKey({ distribution: "../../etc", major: 21, os: "linux", arch: "x64" }),
+    ).toThrow(/invalid distribution/);
+  });
+
+  test("rejects path separators in distribution", () => {
+    expect(() =>
+      cacheKey({ distribution: "foo/bar", major: 21, os: "linux", arch: "x64" }),
+    ).toThrow(/invalid distribution/);
+    expect(() =>
+      cacheKey({ distribution: "foo\\bar", major: 21, os: "linux", arch: "x64" }),
+    ).toThrow(/invalid distribution/);
+  });
+
+  test("rejects non-integer major", () => {
+    expect(() =>
+      cacheKey({ distribution: "temurin", major: 21.5, os: "linux", arch: "x64" }),
+    ).toThrow(/major must be a non-negative integer/);
+  });
 });
 
 describe("javaBinaryPath / javaHomePath", () => {

--- a/src/sdk/cache.ts
+++ b/src/sdk/cache.ts
@@ -55,9 +55,28 @@ export interface CacheKeyParts {
   arch: DiscoArch;
 }
 
-/** Build the cache key — stable per (distribution, major, os, arch). */
+/**
+ * Build the cache key — stable per (distribution, major, os, arch). Each
+ * component is checked against a tight allowlist; the key is joined into a
+ * filesystem path under the user cache, so a `..` or path separator here
+ * would let a hostile project.json escape the cache root.
+ */
 export function cacheKey(parts: CacheKeyParts): string {
+  assertSafeKeyPart("distribution", parts.distribution);
+  assertSafeKeyPart("os", parts.os);
+  assertSafeKeyPart("arch", parts.arch);
+  if (!Number.isInteger(parts.major) || parts.major < 0) {
+    throw new Error(`cacheKey: major must be a non-negative integer (got ${parts.major})`);
+  }
   return `${parts.distribution}-${parts.major}-${parts.os}-${parts.arch}`;
+}
+
+const SAFE_KEY_PART_RE = /^[A-Za-z0-9_]+$/;
+
+function assertSafeKeyPart(field: string, value: string): void {
+  if (typeof value !== "string" || !SAFE_KEY_PART_RE.test(value)) {
+    throw new Error(`cacheKey: invalid ${field} ${JSON.stringify(value)}`);
+  }
 }
 
 /** Root directory under the user cache for everything SDK-related. */

--- a/src/sdk/disco.ts
+++ b/src/sdk/disco.ts
@@ -6,11 +6,9 @@
  *
  * Docs: https://github.com/foojayio/discoapi
  *
- * The list response omits checksum fields; those live behind a separate
- * per-package endpoint we currently don't fetch. If a download lands corrupt,
- * archive extraction fails — that's the v1 integrity story. Adding explicit
- * SHA verification means a second `GET /packages/{id}` per install and is
- * tracked as a follow-up.
+ * The package-list response omits checksum fields, so we make a second
+ * `GET /packages/{id}` request after picking a package to retrieve them.
+ * `installJdk` refuses to extract bytes whose hash doesn't match.
  */
 
 import process from "node:process";
@@ -42,6 +40,13 @@ export interface JdkSpec {
   filename: string;
   /** Package size in bytes when Disco knows it; `undefined` otherwise. */
   sizeBytes?: number;
+  /**
+   * Cryptographic hash published by the JDK vendor and surfaced via Disco's
+   * per-package endpoint. `installJdk` verifies the downloaded bytes match
+   * before extraction; `undefined` if the vendor doesn't publish one (rare;
+   * we log a warning but don't block on it for backward compatibility).
+   */
+  checksum?: { algorithm: "sha256" | "sha512" | "sha1" | "md5"; value: string };
 }
 
 export interface ResolveJdkOptions {
@@ -96,6 +101,11 @@ export async function resolveJdk(opts: ResolveJdkOptions): Promise<JdkSpec> {
     throw new Error(`disco: package ${pkg.id ?? "?"} returned no pkg_download_redirect link`);
   }
 
+  const checksum =
+    typeof pkg.id === "string" && pkg.id.length > 0 && typeof pkg.links?.pkg_info_uri === "string"
+      ? await fetchPackageChecksum(pkg.links.pkg_info_uri)
+      : undefined;
+
   return {
     distribution: pkg.distribution,
     major: pkg.major_version,
@@ -106,7 +116,72 @@ export async function resolveJdk(opts: ResolveJdkOptions): Promise<JdkSpec> {
     downloadUrl,
     filename: pkg.filename,
     sizeBytes: typeof pkg.size === "number" ? pkg.size : undefined,
+    checksum,
   };
+}
+
+/**
+ * Fetch the per-package detail endpoint to recover the vendor-published
+ * checksum. Returns `undefined` on any failure (network, missing field,
+ * unsupported algorithm) — `installJdk` logs a warning and proceeds without
+ * verification in that case rather than refusing every install.
+ *
+ * `checksum_uri` (when present) points to a text file containing the digest
+ * value. Some vendors include the hash inline as `checksum`, others only as
+ * a sidecar URL — we handle both.
+ */
+async function fetchPackageChecksum(pkgInfoUri: string): Promise<JdkSpec["checksum"] | undefined> {
+  const data = await fetchJson(new URL(pkgInfoUri)).catch(() => undefined);
+  if (data === undefined) return undefined;
+  const result = (data as DiscoPackageInfoResponse).result;
+  if (!Array.isArray(result) || result.length === 0) return undefined;
+  const info = result[0];
+
+  const rawType = (info.checksum_type ?? "").toLowerCase();
+  if (rawType !== "sha256" && rawType !== "sha512" && rawType !== "sha1" && rawType !== "md5") {
+    return undefined;
+  }
+
+  let value = info.checksum;
+  if ((value === undefined || value.length === 0) && typeof info.checksum_uri === "string") {
+    value = await fetchChecksumSidecar(info.checksum_uri);
+  }
+  if (value === undefined || value.length === 0) return undefined;
+
+  // Sidecar files often look like "<hex>  filename"; take the leading hex
+  // token. Hashes are case-insensitive — normalize to lowercase for compare.
+  const trimmed = value.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+  if (!/^[0-9a-f]+$/.test(trimmed)) return undefined;
+
+  return { algorithm: rawType, value: trimmed };
+}
+
+async function fetchChecksumSidecar(url: string): Promise<string | undefined> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { signal: ctrl.signal });
+      if (!res.ok) return undefined;
+      return await res.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+interface DiscoPackageInfoResponse {
+  result?: DiscoPackageInfo[];
+}
+
+interface DiscoPackageInfo {
+  filename?: string;
+  direct_download_uri?: string;
+  checksum?: string;
+  checksum_type?: string;
+  checksum_uri?: string;
 }
 
 /** Map `process.platform` + `process.arch` to Disco's naming. */

--- a/src/sdk/distributions.ts
+++ b/src/sdk/distributions.ts
@@ -1,0 +1,75 @@
+/**
+ * The curated allowlist of JDK distributions pluggy auto-installs. GraalVM CE
+ * is included for plugins that use Polyglot/Truffle scripting (Oracle's paid
+ * `graalvm` is excluded — auto-installing it would require user license
+ * consent we can't model here). Expanding this list is safe; narrowing it
+ * isn't, so be conservative when adding.
+ *
+ * The allowlist must apply to every source of a distribution slug — CLI
+ * flags, project.json, and any other config — because the slug ends up in a
+ * filesystem path under the user cache.
+ */
+
+import { InvalidArgumentError } from "commander";
+
+export const ALLOWED_DISTRIBUTIONS = [
+  "temurin",
+  "zulu",
+  "liberica",
+  "corretto",
+  "microsoft",
+  "graalvm_community",
+] as const;
+
+export type AllowedDistribution = (typeof ALLOWED_DISTRIBUTIONS)[number];
+
+export const DEFAULT_DISTRIBUTION: AllowedDistribution = "temurin";
+
+/** Java major releases pluggy will provision. Mirrors `parseMajor` in `commands/sdk.ts`. */
+export const MIN_JAVA_MAJOR = 6;
+export const MAX_JAVA_MAJOR = 99;
+
+/** Commander option parser — throws InvalidArgumentError on miss. */
+export function parseDistribution(value: string): AllowedDistribution {
+  if (!ALLOWED_DISTRIBUTIONS.includes(value as AllowedDistribution)) {
+    throw new InvalidArgumentError(
+      `unknown distribution "${value}". Allowed: ${ALLOWED_DISTRIBUTIONS.join(", ")}`,
+    );
+  }
+  return value as AllowedDistribution;
+}
+
+/**
+ * Validate a distribution slug coming from project.json (or any other config
+ * file). Throws a regular Error so the top-level CLI handler treats it as a
+ * config problem, not a CLI usage error.
+ */
+export function validateDistribution(value: unknown): AllowedDistribution {
+  if (typeof value !== "string") {
+    throw new Error(
+      `project.jdk.distribution must be a string. Allowed: ${ALLOWED_DISTRIBUTIONS.join(", ")}`,
+    );
+  }
+  if (!ALLOWED_DISTRIBUTIONS.includes(value as AllowedDistribution)) {
+    throw new Error(
+      `project.jdk.distribution: unknown distribution "${value}". Allowed: ${ALLOWED_DISTRIBUTIONS.join(", ")}`,
+    );
+  }
+  return value as AllowedDistribution;
+}
+
+/**
+ * Validate a Java major release coming from project.json. Throws on values
+ * that aren't a positive integer in `[MIN_JAVA_MAJOR, MAX_JAVA_MAJOR]`.
+ */
+export function validateJavaMajor(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`project.jdk.major must be an integer (got ${JSON.stringify(value)})`);
+  }
+  if (value < MIN_JAVA_MAJOR || value > MAX_JAVA_MAJOR) {
+    throw new Error(
+      `project.jdk.major must be between ${MIN_JAVA_MAJOR} and ${MAX_JAVA_MAJOR} (got ${value})`,
+    );
+  }
+  return value;
+}

--- a/src/sdk/install.ts
+++ b/src/sdk/install.ts
@@ -10,8 +10,9 @@
  */
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import process from "node:process";
@@ -57,6 +58,20 @@ export async function installJdk(spec: JdkSpec): Promise<InstallResult> {
   // Download archive if missing. We deliberately keep archives around in
   // <cacheRoot>/jdk/archives so a re-extract (after manual slot deletion)
   // doesn't redownload — `pluggy sdk gc` is what cleans them up.
+  if (existsSync(archive)) {
+    // A cached archive whose hash drifts from Disco's published value is
+    // either corrupt or a leftover from before the integrity story; drop
+    // and redownload rather than risk extracting tampered bytes.
+    if (spec.checksum !== undefined) {
+      const cachedHash = await hashFile(archive, spec.checksum.algorithm);
+      if (cachedHash !== spec.checksum.value) {
+        log.warn(
+          `sdk: cached archive at ${archive} has unexpected ${spec.checksum.algorithm} ${cachedHash} (expected ${spec.checksum.value}); re-downloading`,
+        );
+        await rm(archive, { force: true });
+      }
+    }
+  }
   if (!existsSync(archive)) {
     await downloadArchive(spec, archive);
   }
@@ -83,6 +98,14 @@ async function downloadArchive(spec: JdkSpec, destPath: string): Promise<void> {
   const sizeNote = spec.sizeBytes !== undefined ? ` (~${formatMb(spec.sizeBytes)})` : "";
   log.info(`sdk: downloading ${spec.distribution} ${spec.fullVersion}${sizeNote}…`);
 
+  // Refuse to follow non-HTTPS Disco redirects — JDK CDNs are HTTPS-only,
+  // a downgrade is an attack signal worth aborting on.
+  if (!spec.downloadUrl.startsWith("https://")) {
+    throw new Error(
+      `sdk: refusing non-https download URL ${JSON.stringify(spec.downloadUrl)} — Disco redirected to a plaintext target`,
+    );
+  }
+
   const res = await fetch(spec.downloadUrl, { redirect: "follow" });
   if (!res.ok) {
     throw new Error(`sdk: download failed (${res.status} ${res.statusText}) — ${spec.downloadUrl}`);
@@ -95,9 +118,33 @@ async function downloadArchive(spec: JdkSpec, destPath: string): Promise<void> {
   // reliable across platforms — and JDK archives are bounded (≈200 MB).
   // Worth revisiting if we ever cache larger artifacts.
   const buf = new Uint8Array(await res.arrayBuffer());
+
+  if (spec.checksum !== undefined) {
+    const actual = createHash(spec.checksum.algorithm).update(buf).digest("hex");
+    if (actual !== spec.checksum.value) {
+      throw new Error(
+        `sdk: integrity check failed for ${spec.distribution} ${spec.fullVersion} (${spec.os}/${spec.arch}) — ` +
+          `Disco published ${spec.checksum.algorithm} ${spec.checksum.value}, downloaded bytes hash to ${actual}. ` +
+          `Refusing to extract a tampered runtime.`,
+      );
+    }
+  } else {
+    log.warn(
+      `sdk: ${spec.distribution} ${spec.fullVersion} (${spec.os}/${spec.arch}) was downloaded without an upstream checksum — Disco didn't publish one for this package`,
+    );
+  }
+
   await writeFile(tmpPath, buf);
   await rename(tmpPath, destPath);
   log.debug(`sdk: cached archive at ${destPath} (${buf.byteLength} bytes)`);
+}
+
+async function hashFile(
+  path: string,
+  algorithm: "sha256" | "sha512" | "sha1" | "md5",
+): Promise<string> {
+  const bytes = await readFile(path);
+  return createHash(algorithm).update(bytes).digest("hex");
 }
 
 /**

--- a/src/sdk/resolve.test.ts
+++ b/src/sdk/resolve.test.ts
@@ -102,4 +102,36 @@ describe("selectJdkForVersion", () => {
     );
     expect(sel).toEqual({ major: 25, distribution: "graalvm_community", source: "project-pin" });
   });
+
+  test("rejects project.jdk.distribution outside the allowlist", async () => {
+    vi.mocked(getJavaRange).mockResolvedValue([21, 25]);
+    await expect(
+      selectJdkForVersion(
+        project({ jdk: { distribution: "../../../tmp/evil" } as never }),
+        "1.21.4",
+      ),
+    ).rejects.toThrow(/unknown distribution/);
+  });
+
+  test("rejects non-allowlisted distribution names", async () => {
+    vi.mocked(getJavaRange).mockResolvedValue([21, 25]);
+    await expect(
+      selectJdkForVersion(project({ jdk: { distribution: "oracle" } as never }), "1.21.4"),
+    ).rejects.toThrow(/unknown distribution/);
+  });
+
+  test("rejects non-integer project.jdk.major", async () => {
+    await expect(
+      selectJdkForVersion(
+        project({ jdk: { major: 21.5 as never, distribution: "temurin" } }),
+        "1.21.4",
+      ),
+    ).rejects.toThrow(/integer/);
+  });
+
+  test("rejects out-of-range project.jdk.major", async () => {
+    await expect(
+      selectJdkForVersion(project({ jdk: { major: 300, distribution: "temurin" } }), "1.21.4"),
+    ).rejects.toThrow(/between/);
+  });
 });

--- a/src/sdk/resolve.ts
+++ b/src/sdk/resolve.ts
@@ -17,6 +17,11 @@
 
 import { getJavaRange } from "../platform/spigot/buildtools.ts";
 import type { ResolvedProject } from "../project.ts";
+import {
+  DEFAULT_DISTRIBUTION as DEFAULT_DISTRIBUTION_SLUG,
+  validateDistribution,
+  validateJavaMajor,
+} from "./distributions.ts";
 
 /**
  * Hardcoded floor by MC release line. Values are conservative — older JDKs
@@ -49,7 +54,7 @@ const MC_VERSION_TO_JAVA_FALLBACK: { prefix: string; major: number }[] = [
 ];
 
 /** Default distribution when neither project.json nor flags say otherwise. */
-export const DEFAULT_DISTRIBUTION = "temurin";
+export const DEFAULT_DISTRIBUTION = DEFAULT_DISTRIBUTION_SLUG;
 
 export interface ProjectJdkSelection {
   /** Java major release, e.g. 21. */
@@ -73,10 +78,13 @@ export async function selectJdkForVersion(
   project: ResolvedProject,
   mcVersion: string | undefined,
 ): Promise<ProjectJdkSelection> {
-  const distribution = project.jdk?.distribution ?? DEFAULT_DISTRIBUTION;
+  const distribution =
+    project.jdk?.distribution !== undefined
+      ? validateDistribution(project.jdk.distribution)
+      : DEFAULT_DISTRIBUTION;
 
   if (project.jdk?.major !== undefined) {
-    return { major: project.jdk.major, distribution, source: "project-pin" };
+    return { major: validateJavaMajor(project.jdk.major), distribution, source: "project-pin" };
   }
 
   if (mcVersion === undefined) {


### PR DESCRIPTION
## Summary

- Add layered integrity verification across every artifact pluggy downloads: JDK (Foojay Disco checksums), JBR + HotswapAgent (pinned SHA-256), BuildTools (TOFU pin), Maven (`.sha1`/`.sha512` sidecars), Modrinth (API `hashes.sha512`), and the pluggy binary itself (`SHA256SUMS.txt` + Sigstore build-provenance attestations from `actions/attest-build-provenance`).
- Enforce `pluggy.lock` integrity at install time (re-hash cached jars, reject silent rolls forward) and at build time (thread `expectedIntegrity` from the lockfile through every resolver).
- Harden path handling: new `safeJoin` helper for archive extraction (templates, shaded jars), allowlist-validation on every lockfile / `project.json` component that becomes a filesystem path, and `project.jdk.distribution` checked against the same allowlist used for CLI flags.
- Update the release workflow to publish `SHA256SUMS.txt` + Sigstore attestations, and extend `SECURITY.md` with the threat model and the codebase's active defenses.

## Test plan

- [x] `vp test` (485 passing, 3 skipped)
- [x] `vp check` (formatter + lint + types green)
- [x] `bun build --compile --outfile=bin/pluggy ./src/index.ts` produces a working binary; smoke-tested `--version`, `--help`, and `sdk list --available`.
- [ ] Manual: cut a tagged pre-release to verify the new workflow steps emit `SHA256SUMS.txt` and `actions/attest-build-provenance` attestations, then run `pluggy upgrade` against it end-to-end.