### PR TITLE
feat(cache): add `pluggy cache` and split state from cache directory

### DIFF
--- a/docs/commands/cache.md
+++ b/docs/commands/cache.md
@@ -1,0 +1,142 @@
+# `pluggy cache`
+
+Inspect and manage everything pluggy keeps under its on-disk cache: cached JDKs, platform server jars, BuildTools artifacts, dependency jars, the JetBrains Runtime used for hotswap, and the HotswapAgent. Use this when disk fills up, when you want to reset to a known-clean state, or when you want to script the cache path into shell automation.
+
+For installing or removing a _specific_ JDK toolchain, see [`pluggy sdk`](./sdk.md).
+
+## Background
+
+The cache root is OS-specific:
+
+| OS      | Path                                                     |
+| ------- | -------------------------------------------------------- |
+| macOS   | `~/Library/Caches/pluggy`                                |
+| Windows | `%LOCALAPPDATA%\pluggy\cache`                            |
+| Linux   | `$XDG_CACHE_HOME/pluggy` (defaults to `~/.cache/pluggy`) |
+
+Everything under this directory is reproducible: deleting it forces re-downloads but never loses irreplaceable state. Persistent metadata (e.g. the cached "latest pluggy release" timestamp) lives under a separate state directory and survives `pluggy cache clean`.
+
+Categories pluggy tracks:
+
+| Category       | What it holds                                                              |
+| -------------- | -------------------------------------------------------------------------- |
+| `jdk`          | Cached JDKs (extracted slots + downloaded archives), with an LRU manifest. |
+| `versions`     | Platform server jars (Paper, Velocity, Waterfall, Folia, Travertine, …).   |
+| `buildtools`   | `BuildTools.jar` plus its CraftBukkit/Spigot output cache.                 |
+| `dependencies` | Resolved plugin dependencies — `maven`, `modrinth`, and `file` subkinds.   |
+| `jbr`          | JetBrains Runtime used by `pluggy dev` for hotswap.                        |
+| `hotswap`      | HotswapAgent jars used by `pluggy dev`.                                    |
+
+## Subcommands
+
+Every subcommand supports the global `--json` flag for structured output.
+
+| Subcommand                           | Purpose                                                   |
+| ------------------------------------ | --------------------------------------------------------- |
+| `pluggy cache` / `pluggy cache info` | Show entries and bytes per category. The default action.  |
+| `pluggy cache list [--category]`     | Per-entry listing, newest first.                          |
+| `pluggy cache path`                  | Print the cache root. Scriptable.                         |
+| `pluggy cache clean [--category]`    | Wipe a category — or, with no flag, the entire cache.     |
+| `pluggy cache prune [...]`           | LRU-evict by age and size budget. Safe one-shot defaults. |
+
+## `info`
+
+Default action — running `pluggy cache` with no subcommand is identical.
+
+```text
+$ pluggy cache
+cache /Users/you/Library/Caches/pluggy
+
+  jdk             2.00 GB  4 entries
+  versions        4.50 GB  12 entries
+  buildtools    580.00 MB  3 entries
+  dependencies  312.00 MB  87 entries
+    └ maven       280.00 MB  60 entries
+    └ modrinth     30.00 MB  25 entries
+    └ file          2.00 MB  2 entries
+  jbr           450.00 MB  1 entry
+  hotswap         1.40 MB  1 entry
+
+  total  7.34 GB
+```
+
+## `list`
+
+List individual entries, newest first within each category.
+
+```text
+$ pluggy cache list --category versions
+versions
+  paper-1.21.1-127.jar  450.00 MB  (2h ago)
+  velocity-3.4.0-489.jar  41.00 MB  (3d ago)
+```
+
+`--category` accepts `jdk`, `versions`, `buildtools`, `dependencies`, `jbr`, or `hotswap`. Omit it to list every category at once. With `--json`, the output is `{ status, category, groups: [{ category, entries: [...] }] }`.
+
+## `path`
+
+Print the cache directory. Useful in shell scripts:
+
+```text
+$ pluggy cache path
+/Users/you/Library/Caches/pluggy
+
+$ du -sh "$(pluggy cache path)"
+7.3G    /Users/you/Library/Caches/pluggy
+```
+
+## `clean`
+
+Delete cache entries. With no flag, wipes everything pluggy manages under the cache root. With `--category`, scopes the wipe.
+
+```text
+$ pluggy cache clean --category versions
+? Delete the "versions" category (4.50 GB)? Yes
+✔ Removed 12 entries (4.50 GB).
+```
+
+`clean` is interactive by default. Pass `-y`/`--yes` to skip the confirmation; `--json` skips it implicitly. JDK manifest entries are reconciled automatically so subsequent `cache info` calls don't show ghost numbers.
+
+## `prune`
+
+Budget-driven eviction. Safe to run in a one-shot — defaults are conservative.
+
+```text
+$ pluggy cache prune
+  - versions/paper-1.20.4-450.jar (age, 450.00 MB)
+  - dependencies/net.kyori:adventure-api:4.18.0 (age, 280.00 KB)
+✔ Evicted 2; kept 102. Freed 450.27 MB.
+```
+
+| Flag                   | Default | Effect                                                                                                                               |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--max-age <duration>` | `90d`   | Drop entries older than this. Accepts `s`, `m`, `h`, `d`, `w` suffixes (`90d`, `12h`, `1w`). Use `0` to disable age-based pruning.   |
+| `--max-size <size>`    | (none)  | After age pruning, evict oldest-first until the scoped total is at or below this budget. Accepts `K`, `M`, `G`, `T` suffixes (`5G`). |
+| `--keep-latest <n>`    | `2`     | JDK only: keep the N most-recently-used JDKs per major regardless of age. Set to `0` to opt out.                                     |
+| `--category <name>`    | (all)   | Limit pruning to one category.                                                                                                       |
+| `--dry-run`            | (off)   | Print what would be removed without touching disk.                                                                                   |
+
+For JDKs, "last used" is sourced from the LRU manifest (`ensureJdk` bumps it on every cache hit). For every other category, "last used" is the file's mtime — which is set when the entry was last downloaded.
+
+### Combined budgets
+
+`pluggy cache prune --max-age 30d --max-size 2G` first removes anything not touched in 30 days, then evicts more (oldest first) until the total drops to 2 GB. `--keep-latest` is JDK-specific and applies before either.
+
+## CI usage
+
+In CI you usually want strict, predictable cache behavior. Two patterns:
+
+```yaml
+# Free space mid-pipeline without losing the JDK you just used
+- run: pluggy cache prune --category versions --max-age 0 --max-size 1G
+```
+
+```yaml
+# Wipe everything between matrix rows
+- run: pluggy cache clean --yes
+```
+
+## See also
+
+- [`pluggy sdk`](./sdk.md) — install, list, pin, and remove specific JDK toolchains.
+- [`pluggy doctor`](./doctor.md) — the `Cache reachability` check reports cache root + total size.

--- a/docs/commands/sdk.md
+++ b/docs/commands/sdk.md
@@ -1,6 +1,8 @@
 # `pluggy sdk`
 
-Manage the JDKs pluggy provisions for `build`, `test`, and `dev`. You rarely run these commands directly: `pluggy build` auto-installs the right JDK on first use. Reach for `pluggy sdk` to pre-warm the cache, pin a distribution per project, or evict old slots.
+Manage the JDKs pluggy provisions for `build`, `test`, and `dev`. You rarely run these commands directly: `pluggy build` auto-installs the right JDK on first use. Reach for `pluggy sdk` to pre-warm the cache, pin a distribution per project, or remove a slot.
+
+For cross-cutting cache housekeeping (LRU eviction across all categories, total size, cleaning everything) see [`pluggy cache`](./cache.md).
 
 ## Background
 
@@ -12,15 +14,14 @@ Set `PLUGGY_NO_AUTO_INSTALL=1` to make a cache miss raise instead of downloading
 
 Every subcommand supports the global `--json` flag for structured output.
 
-| Subcommand                          | Purpose                                                  |
-| ----------------------------------- | -------------------------------------------------------- |
-| `pluggy sdk install [<major>]`      | Download and cache a JDK.                                |
-| `pluggy sdk list`                   | Show cached JDKs, with their full versions and last use. |
-| `pluggy sdk list --available`       | Show distributions pluggy can install.                   |
-| `pluggy sdk path <major>`           | Print `JAVA_HOME` for a cached JDK.                      |
-| `pluggy sdk use <major>`            | Pin a JDK in `project.json`.                             |
-| `pluggy sdk remove <major>`         | Delete a cached JDK.                                     |
-| `pluggy sdk gc [--keep-latest <n>]` | Evict cached JDKs by LRU per major.                      |
+| Subcommand                     | Purpose                                                  |
+| ------------------------------ | -------------------------------------------------------- |
+| `pluggy sdk install [<major>]` | Download and cache a JDK.                                |
+| `pluggy sdk list`              | Show cached JDKs, with their full versions and last use. |
+| `pluggy sdk list --available`  | Show distributions pluggy can install.                   |
+| `pluggy sdk path <major>`      | Print `JAVA_HOME` for a cached JDK.                      |
+| `pluggy sdk use <major>`       | Pin a JDK in `project.json`.                             |
+| `pluggy sdk remove <major>`    | Delete a cached JDK.                                     |
 
 ## `install`
 
@@ -48,7 +49,7 @@ Cached JDKs:
   ✓ zulu 17     (17.0.13)     last used 3d ago
 ```
 
-A red `✗` means the manifest still references the slot but the directory is gone — `pluggy sdk gc` cleans those up.
+A red `✗` means the manifest still references the slot but the directory is gone — `pluggy cache prune --category jdk` cleans those up.
 
 `pluggy sdk list --available` switches to the install allowlist.
 
@@ -96,16 +97,6 @@ $ pluggy sdk remove 17 --distribution zulu
 
 `remove` always honors the `--distribution` value, so you can prune one distribution while keeping another.
 
-## `gc`
-
-Evict cached JDKs by LRU per major. Default: keep the two most-recently-used slots per major. Manifest entries whose on-disk slots are missing are dropped automatically.
-
-```text
-$ pluggy sdk gc --keep-latest 1
-  - zulu-17-macos-aarch64 (lru)
-✔ Evicted 1; kept 1.
-```
-
 ## CI escape hatch
 
 CI workflows that don't want pluggy reaching the network mid-build should pre-warm the cache and set `PLUGGY_NO_AUTO_INSTALL=1`:
@@ -122,5 +113,6 @@ The first command resolves the major from `project.json` and downloads the JDK. 
 ## See also
 
 - [`jdk` in the `project.json` reference](../project-json.md#jdk-optional) — the per-project pin.
+- [`pluggy cache`](./cache.md) — cross-category cache housekeeping (`info`, `prune`, `clean`).
 - [`pluggy doctor`](./doctor.md) — the `Project JDK` check reports cache state.
 - [Foojay Disco distributions](https://api.foojay.io/disco/v3.0/distributions) — every distribution Disco knows about.

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -76,8 +76,9 @@ and remove the old system binary so it doesn't shadow the new one.
 
 ## Update notification
 
-When pluggy starts, it reads a small cached state file
-(`<cache>/update-check.json`) and, at most once per 24 hours, fetches
+When pluggy starts, it reads a small state file
+(`<state>/update-check.json`, separate from the cache so `pluggy cache
+clean` doesn't reset it) and, at most once per 24 hours, fetches
 the latest release tag in the background. If the cache shows that you
 are out of date, you'll see a one-line notice on stderr after the
 command finishes:

--- a/src/cache/index.test.ts
+++ b/src/cache/index.test.ts
@@ -275,6 +275,22 @@ describe("pruneCache", () => {
     expect(existsSync(slotPath("liberica-21-linux-x64"))).toBe(false);
   });
 
+  test("keep-latest 0 opts out of the LRU pin so age/size handles JDKs", async () => {
+    const now = Date.now();
+    await writeJdkSlot("temurin-21-linux-x64", "21.0.5+11", now);
+    await writeJdkSlot("zulu-21-linux-x64", "21.0.4", now - 1000);
+    await writeJdkSlot("liberica-21-linux-x64", "21.0.3", now - 2000);
+    const result = await pruneCache({
+      maxAgeMs: 0,
+      keepLatest: 0,
+      category: "jdk",
+    });
+    expect(result.removed.filter((r) => r.reason === "lru")).toHaveLength(0);
+    expect(existsSync(slotPath("temurin-21-linux-x64"))).toBe(true);
+    expect(existsSync(slotPath("zulu-21-linux-x64"))).toBe(true);
+    expect(existsSync(slotPath("liberica-21-linux-x64"))).toBe(true);
+  });
+
   test("dry-run reports what would be removed without touching disk", async () => {
     const stale = await writeFixture("versions/stale.jar", 100, Date.now() - 100 * 86_400_000);
     const result = await pruneCache({

--- a/src/cache/index.test.ts
+++ b/src/cache/index.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for the cache module. Each test redirects `getCachePath` (and where
+ * relevant `getStatePath`) to a tempdir so the user's real pluggy cache is
+ * never touched.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+
+vi.mock("../project.ts", async () => {
+  const actual = await vi.importActual<typeof import("../project.ts")>("../project.ts");
+  return { ...actual, getCachePath: vi.fn() };
+});
+
+import { getCachePath } from "../project.ts";
+import { recordEntry, jdkCacheRoot, slotPath } from "../sdk/cache.ts";
+
+import {
+  cleanCache,
+  formatBytes,
+  isCategoryId,
+  listCacheEntries,
+  parseDurationMs,
+  parseSizeBytes,
+  pruneCache,
+  scanCache,
+} from "./index.ts";
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "pluggy-cache-test-"));
+  vi.mocked(getCachePath).mockReturnValue(tmp);
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+  vi.mocked(getCachePath).mockReset();
+});
+
+async function writeFixture(relPath: string, bytes: number, mtimeMs?: number): Promise<string> {
+  const full = join(tmp, relPath);
+  await mkdir(join(full, ".."), { recursive: true });
+  await writeFile(full, Buffer.alloc(bytes, "x"));
+  if (mtimeMs !== undefined) {
+    const seconds = mtimeMs / 1000;
+    await utimes(full, seconds, seconds);
+  }
+  return full;
+}
+
+async function writeJdkSlot(key: string, fullVersion: string, lastUsed: number): Promise<void> {
+  const root = jdkCacheRoot();
+  await mkdir(slotPath(key), { recursive: true });
+  await writeFile(join(slotPath(key), "marker"), Buffer.alloc(1024, "j"));
+  // Distribution-major-os-arch parse — pretend Linux x64 21.
+  await mkdir(root, { recursive: true });
+  const parts = key.split("-");
+  await recordEntry(
+    key,
+    {
+      distribution: parts[0],
+      major: Number.parseInt(parts[1], 10),
+      os: parts[2] as "linux",
+      arch: parts[3] as "x64",
+    },
+    fullVersion,
+  );
+  // Backdate manifest lastUsed by rewriting it.
+  const manifestPath = join(root, "manifest.json");
+  const raw = await import("node:fs/promises").then((m) => m.readFile(manifestPath, "utf8"));
+  const parsed = JSON.parse(raw);
+  parsed.entries[key].lastUsed = lastUsed;
+  await writeFile(manifestPath, JSON.stringify(parsed, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("formatBytes", () => {
+  test("scales B / KB / MB / GB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toMatch(/^2\.0 KB$/);
+    expect(formatBytes(5 * 1024 * 1024)).toMatch(/^5\.00 MB$/);
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toMatch(/^3\.00 GB$/);
+  });
+});
+
+describe("parseDurationMs", () => {
+  test("parses every supported suffix", () => {
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(5 * 60_000);
+    expect(parseDurationMs("12h")).toBe(12 * 3_600_000);
+    expect(parseDurationMs("90d")).toBe(90 * 86_400_000);
+    expect(parseDurationMs("2w")).toBe(14 * 86_400_000);
+  });
+  test("unsuffixed values are days", () => {
+    expect(parseDurationMs("7")).toBe(7 * 86_400_000);
+  });
+  test("rejects malformed input", () => {
+    expect(() => parseDurationMs("forever")).toThrow();
+    expect(() => parseDurationMs("-1d")).toThrow();
+  });
+});
+
+describe("parseSizeBytes", () => {
+  test("scales K/M/G/T (and *B forms)", () => {
+    expect(parseSizeBytes("1024")).toBe(1024);
+    expect(parseSizeBytes("2K")).toBe(2 * 1024);
+    expect(parseSizeBytes("5M")).toBe(5 * 1024 ** 2);
+    expect(parseSizeBytes("3GB")).toBe(3 * 1024 ** 3);
+    expect(parseSizeBytes("1T")).toBe(1024 ** 4);
+  });
+  test("rejects malformed input", () => {
+    expect(() => parseSizeBytes("big")).toThrow();
+  });
+});
+
+describe("isCategoryId", () => {
+  test("accepts each known id and rejects others", () => {
+    for (const id of ["jdk", "versions", "buildtools", "dependencies", "jbr", "hotswap"]) {
+      expect(isCategoryId(id)).toBe(true);
+    }
+    expect(isCategoryId("update-check")).toBe(false);
+    expect(isCategoryId("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanCache
+// ---------------------------------------------------------------------------
+
+describe("scanCache", () => {
+  test("returns zeroed categories on an empty cache", async () => {
+    const summary = await scanCache();
+    expect(summary.cachePath).toBe(tmp);
+    expect(summary.totalBytes).toBe(0);
+    expect(summary.categories.jdk).toEqual({ entries: 0, bytes: 0 });
+    expect(summary.categories.dependencies.maven).toEqual({ entries: 0, bytes: 0 });
+  });
+
+  test("aggregates sizes across every category", async () => {
+    await writeFixture("versions/paper-1.21.1-127.jar", 1000);
+    await writeFixture("BuildTools.jar", 2000);
+    await writeFixture("BuildTools/spigot-1.21.1.jar", 500);
+    await writeFixture("dependencies/maven/net.kyori/adventure-api/4.18.0.jar", 100);
+    await writeFixture("dependencies/modrinth/worldedit/1.5.0.jar", 200);
+    await writeFixture("dependencies/file/abc123.jar", 50);
+    await writeFixture("agents/hotswap-agent-2.0.3.jar", 300);
+    await writeFixture("jbr/some-archive.tar.gz", 700);
+    await writeJdkSlot("temurin-21-linux-x64", "21.0.5+11", Date.now());
+
+    const summary = await scanCache();
+    expect(summary.categories.versions).toEqual({ entries: 1, bytes: 1000 });
+    expect(summary.categories.buildtools.entries).toBe(2);
+    expect(summary.categories.buildtools.bytes).toBe(2500);
+    expect(summary.categories.dependencies.maven).toEqual({ entries: 1, bytes: 100 });
+    expect(summary.categories.dependencies.modrinth).toEqual({ entries: 1, bytes: 200 });
+    expect(summary.categories.dependencies.file).toEqual({ entries: 1, bytes: 50 });
+    expect(summary.categories.dependencies.entries).toBe(3);
+    expect(summary.categories.dependencies.bytes).toBe(350);
+    expect(summary.categories.hotswap).toEqual({ entries: 1, bytes: 300 });
+    expect(summary.categories.jbr).toEqual({ entries: 1, bytes: 700 });
+    expect(summary.categories.jdk.entries).toBe(1);
+    expect(summary.totalBytes).toBe(1000 + 2500 + 350 + 300 + 700 + summary.categories.jdk.bytes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listCacheEntries
+// ---------------------------------------------------------------------------
+
+describe("listCacheEntries", () => {
+  test("scopes to a single category", async () => {
+    await writeFixture("versions/paper-1.21.1-127.jar", 100);
+    await writeFixture("dependencies/maven/g/a/1.0.0.jar", 200);
+    const groups = await listCacheEntries("versions");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe("versions");
+    expect(groups[0].entries[0].id).toBe("paper-1.21.1-127.jar");
+  });
+
+  test("formats dependency identifiers with subcategory", async () => {
+    await writeFixture("dependencies/maven/net.kyori/adventure-api/4.18.0.jar", 100);
+    const [group] = await listCacheEntries("dependencies");
+    expect(group.entries[0].id).toBe("net.kyori:adventure-api:4.18.0");
+    expect(group.entries[0].subcategory).toBe("maven");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanCache
+// ---------------------------------------------------------------------------
+
+describe("cleanCache", () => {
+  test("scoped clean removes only the requested category", async () => {
+    const versionPath = await writeFixture("versions/paper.jar", 100);
+    const depPath = await writeFixture("dependencies/maven/g/a/1.0.jar", 200);
+    const result = await cleanCache("versions");
+    expect(result.removed).toHaveLength(1);
+    expect(result.freedBytes).toBe(100);
+    expect(existsSync(versionPath)).toBe(false);
+    expect(existsSync(depPath)).toBe(true);
+  });
+
+  test("category=all wipes everything pluggy tracks", async () => {
+    await writeFixture("versions/paper.jar", 100);
+    await writeFixture("dependencies/maven/g/a/1.0.jar", 200);
+    await writeFixture("agents/hotswap-agent-2.0.3.jar", 50);
+    await writeJdkSlot("temurin-21-linux-x64", "21.0.5+11", Date.now());
+    const result = await cleanCache("all");
+    expect(result.removed.length).toBeGreaterThanOrEqual(4);
+    expect(result.freedBytes).toBeGreaterThan(350);
+    // JDK manifest entry should be reconciled away too.
+    const summary = await scanCache();
+    expect(summary.categories.jdk.entries).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneCache
+// ---------------------------------------------------------------------------
+
+describe("pruneCache", () => {
+  test("max-age removes anything older than the cutoff", async () => {
+    const fresh = await writeFixture("versions/fresh.jar", 100, Date.now());
+    const stale = await writeFixture("versions/stale.jar", 100, Date.now() - 100 * 86_400_000);
+    const result = await pruneCache({ maxAgeMs: 90 * 86_400_000 });
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0].path).toBe(stale);
+    expect(result.removed[0].reason).toBe("age");
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  test("max-size evicts oldest until under budget", async () => {
+    const now = Date.now();
+    await writeFixture("versions/a.jar", 1000, now - 3 * 86_400_000);
+    await writeFixture("versions/b.jar", 1000, now - 2 * 86_400_000);
+    await writeFixture("versions/c.jar", 1000, now - 1 * 86_400_000);
+    const result = await pruneCache({
+      maxAgeMs: 0,
+      maxBytes: 1500,
+      category: "versions",
+    });
+    // Should evict the two oldest (a, then b) leaving 1000 bytes.
+    const removedNames = result.removed.map((r) => r.id).sort();
+    expect(removedNames).toEqual(["a.jar", "b.jar"]);
+    for (const r of result.removed) expect(r.reason).toBe("size");
+  });
+
+  test("keep-latest pins the N most-recent JDKs per major", async () => {
+    const now = Date.now();
+    await writeJdkSlot("temurin-21-linux-x64", "21.0.5+11", now);
+    await writeJdkSlot("zulu-21-linux-x64", "21.0.4", now - 1000);
+    await writeJdkSlot("liberica-21-linux-x64", "21.0.3", now - 2000);
+    const result = await pruneCache({
+      maxAgeMs: 0,
+      keepLatest: 2,
+      category: "jdk",
+    });
+    const evicted = result.removed
+      .filter((r) => r.reason !== "dangling")
+      .map((r) => r.id)
+      .sort();
+    expect(evicted).toEqual(["liberica-21-linux-x64"]);
+    expect(existsSync(slotPath("temurin-21-linux-x64"))).toBe(true);
+    expect(existsSync(slotPath("zulu-21-linux-x64"))).toBe(true);
+    expect(existsSync(slotPath("liberica-21-linux-x64"))).toBe(false);
+  });
+
+  test("dry-run reports what would be removed without touching disk", async () => {
+    const stale = await writeFixture("versions/stale.jar", 100, Date.now() - 100 * 86_400_000);
+    const result = await pruneCache({
+      maxAgeMs: 90 * 86_400_000,
+      dryRun: true,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(result.removed).toHaveLength(1);
+    expect(existsSync(stale)).toBe(true);
+  });
+});

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,676 @@
+/**
+ * `pluggy cache` core. Pure scan/clean/prune logic; the CLI surface in
+ * `src/commands/cache.ts` is a thin wrapper. Other modules own how they
+ * *populate* the cache (resolvers, platform providers, the SDK installer,
+ * the dev runner); this module knows how to *introspect and reclaim* it.
+ *
+ * On-disk layout under `getCachePath()`:
+ *
+ *   jdk/                              -- managed JDKs (LRU manifest)
+ *     manifest.json
+ *     archives/                       -- downloaded tarballs/zips
+ *     <distribution>-<major>-<os>-<arch>/
+ *   versions/                         -- platform server jars
+ *     paper-1.21.1-127.jar
+ *   BuildTools.jar                    -- Spigot BuildTools driver
+ *   BuildTools/                       -- BuildTools output cache
+ *     spigot-1.21.1.jar
+ *   dependencies/
+ *     maven/<groupId>/<artifactId>/<version>.jar
+ *     modrinth/<slug>/<version>.jar
+ *     file/<sha256>.jar
+ *   jbr/                              -- JetBrains Runtime for hotswap
+ *     <key>/                          -- extracted slot
+ *     jbr_*.tar.gz                    -- archive
+ *   agents/                           -- HotswapAgent jars
+ *     hotswap-agent-<version>.jar
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getCachePath } from "../project.ts";
+import { forgetEntry, jdkCacheRoot, readManifest, slotPath } from "../sdk/cache.ts";
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+export type CategoryId = "jdk" | "versions" | "buildtools" | "dependencies" | "jbr" | "hotswap";
+
+export const CATEGORY_IDS: readonly CategoryId[] = [
+  "jdk",
+  "versions",
+  "buildtools",
+  "dependencies",
+  "jbr",
+  "hotswap",
+] as const;
+
+export interface CategorySummary {
+  entries: number;
+  bytes: number;
+}
+
+export interface DependencySummary {
+  entries: number;
+  bytes: number;
+  maven: CategorySummary;
+  modrinth: CategorySummary;
+  file: CategorySummary;
+}
+
+export interface CacheSummary {
+  cachePath: string;
+  totalBytes: number;
+  categories: {
+    jdk: CategorySummary;
+    versions: CategorySummary;
+    buildtools: CategorySummary;
+    dependencies: DependencySummary;
+    jbr: CategorySummary;
+    hotswap: CategorySummary;
+  };
+}
+
+export interface CacheEntry {
+  /** Stable identifier used in CLI output and JSON. Unique within its category. */
+  id: string;
+  /** Absolute path on disk — may be a file or a directory. */
+  path: string;
+  /** Total bytes, recursive for directories. */
+  bytes: number;
+  /** Epoch ms of most recent activity. JDKs use manifest `lastUsed`; everything else uses mtime. */
+  lastUsedMs: number;
+  /** Sub-bucket key (e.g. `"maven"` for dependencies). Optional. */
+  subcategory?: string;
+}
+
+export interface CategoryEntries {
+  category: CategoryId;
+  entries: CacheEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the cache and aggregate sizes by category. Cheap to call: it
+ * `stat`s every file but never reads contents.
+ */
+export async function scanCache(): Promise<CacheSummary> {
+  const root = getCachePath();
+  const all = await Promise.all([
+    listJdkEntries(),
+    listVersionsEntries(),
+    listBuildtoolsEntries(),
+    listDependenciesEntries(),
+    listJbrEntries(),
+    listHotswapEntries(),
+  ]);
+  const [jdk, versions, buildtools, deps, jbr, hotswap] = all;
+
+  const summarize = (entries: CacheEntry[]): CategorySummary => ({
+    entries: entries.length,
+    bytes: entries.reduce((acc, e) => acc + e.bytes, 0),
+  });
+
+  const summarizeBy = (entries: CacheEntry[], sub: string): CategorySummary =>
+    summarize(entries.filter((e) => e.subcategory === sub));
+
+  const dependencies: DependencySummary = {
+    ...summarize(deps),
+    maven: summarizeBy(deps, "maven"),
+    modrinth: summarizeBy(deps, "modrinth"),
+    file: summarizeBy(deps, "file"),
+  };
+
+  const totalBytes =
+    summarize(jdk).bytes +
+    summarize(versions).bytes +
+    summarize(buildtools).bytes +
+    dependencies.bytes +
+    summarize(jbr).bytes +
+    summarize(hotswap).bytes;
+
+  return {
+    cachePath: root,
+    totalBytes,
+    categories: {
+      jdk: summarize(jdk),
+      versions: summarize(versions),
+      buildtools: summarize(buildtools),
+      dependencies,
+      jbr: summarize(jbr),
+      hotswap: summarize(hotswap),
+    },
+  };
+}
+
+/** Per-entry listing for `pluggy cache list`. Empty array for a category that has no on-disk presence. */
+export async function listCacheEntries(category: CategoryId | "all"): Promise<CategoryEntries[]> {
+  const wanted: CategoryId[] = category === "all" ? [...CATEGORY_IDS] : [category];
+  const out: CategoryEntries[] = [];
+  for (const id of wanted) {
+    const entries = await loadCategory(id);
+    out.push({ category: id, entries });
+  }
+  return out;
+}
+
+async function loadCategory(id: CategoryId): Promise<CacheEntry[]> {
+  switch (id) {
+    case "jdk":
+      return listJdkEntries();
+    case "versions":
+      return listVersionsEntries();
+    case "buildtools":
+      return listBuildtoolsEntries();
+    case "dependencies":
+      return listDependenciesEntries();
+    case "jbr":
+      return listJbrEntries();
+    case "hotswap":
+      return listHotswapEntries();
+  }
+}
+
+async function listJdkEntries(): Promise<CacheEntry[]> {
+  const out: CacheEntry[] = [];
+  const manifest = await readManifest();
+  for (const [key, entry] of Object.entries(manifest.entries)) {
+    const slot = slotPath(key);
+    if (!existsSync(slot)) continue;
+    out.push({
+      id: key,
+      path: slot,
+      bytes: await dirSize(slot),
+      lastUsedMs: entry.lastUsed,
+    });
+  }
+  // Archives staged for re-extract sit beside the slots; bill them to the JDK total.
+  const archivesDir = join(jdkCacheRoot(), "archives");
+  if (existsSync(archivesDir)) {
+    for (const file of await listFiles(archivesDir)) {
+      out.push({
+        id: `archives/${file.name}`,
+        path: file.path,
+        bytes: file.bytes,
+        lastUsedMs: file.mtimeMs,
+      });
+    }
+  }
+  return out;
+}
+
+async function listVersionsEntries(): Promise<CacheEntry[]> {
+  const dir = join(getCachePath(), "versions");
+  if (!existsSync(dir)) return [];
+  const files = await listFiles(dir);
+  return files.map((f) => ({
+    id: f.name,
+    path: f.path,
+    bytes: f.bytes,
+    lastUsedMs: f.mtimeMs,
+  }));
+}
+
+async function listBuildtoolsEntries(): Promise<CacheEntry[]> {
+  const out: CacheEntry[] = [];
+  const root = getCachePath();
+  const driverPath = join(root, "BuildTools.jar");
+  if (existsSync(driverPath)) {
+    const s = await stat(driverPath);
+    out.push({
+      id: "BuildTools.jar",
+      path: driverPath,
+      bytes: s.size,
+      lastUsedMs: s.mtimeMs,
+    });
+  }
+  const outputDir = join(root, "BuildTools");
+  if (existsSync(outputDir)) {
+    // The output dir is large (work tree + jars). Bill it as one entry — users
+    // who want a finer view can drop into the directory themselves.
+    const s = await stat(outputDir);
+    out.push({
+      id: "BuildTools/",
+      path: outputDir,
+      bytes: await dirSize(outputDir),
+      lastUsedMs: s.mtimeMs,
+    });
+  }
+  return out;
+}
+
+async function listDependenciesEntries(): Promise<CacheEntry[]> {
+  const out: CacheEntry[] = [];
+  const base = join(getCachePath(), "dependencies");
+  if (!existsSync(base)) return out;
+
+  // maven: <base>/maven/<groupId>/<artifactId>/<version>.jar
+  const mavenRoot = join(base, "maven");
+  if (existsSync(mavenRoot)) {
+    for (const groupId of await safeReaddir(mavenRoot)) {
+      const groupDir = join(mavenRoot, groupId);
+      for (const artifactId of await safeReaddir(groupDir)) {
+        const artifactDir = join(groupDir, artifactId);
+        for (const file of await listFiles(artifactDir)) {
+          if (!file.name.endsWith(".jar")) continue;
+          out.push({
+            id: `${groupId}:${artifactId}:${file.name.slice(0, -".jar".length)}`,
+            path: file.path,
+            bytes: file.bytes,
+            lastUsedMs: file.mtimeMs,
+            subcategory: "maven",
+          });
+        }
+      }
+    }
+  }
+
+  // modrinth: <base>/modrinth/<slug>/<version>.jar
+  const modrinthRoot = join(base, "modrinth");
+  if (existsSync(modrinthRoot)) {
+    for (const slug of await safeReaddir(modrinthRoot)) {
+      const slugDir = join(modrinthRoot, slug);
+      for (const file of await listFiles(slugDir)) {
+        if (!file.name.endsWith(".jar")) continue;
+        out.push({
+          id: `${slug}@${file.name.slice(0, -".jar".length)}`,
+          path: file.path,
+          bytes: file.bytes,
+          lastUsedMs: file.mtimeMs,
+          subcategory: "modrinth",
+        });
+      }
+    }
+  }
+
+  // file: <base>/file/<sha256>.jar
+  const fileRoot = join(base, "file");
+  if (existsSync(fileRoot)) {
+    for (const file of await listFiles(fileRoot)) {
+      if (!file.name.endsWith(".jar")) continue;
+      out.push({
+        id: file.name,
+        path: file.path,
+        bytes: file.bytes,
+        lastUsedMs: file.mtimeMs,
+        subcategory: "file",
+      });
+    }
+  }
+
+  return out;
+}
+
+async function listJbrEntries(): Promise<CacheEntry[]> {
+  const root = join(getCachePath(), "jbr");
+  if (!existsSync(root)) return [];
+  const out: CacheEntry[] = [];
+  for (const name of await safeReaddir(root)) {
+    const path = join(root, name);
+    const s = await stat(path).catch(() => undefined);
+    if (s === undefined) continue;
+    out.push({
+      id: name,
+      path,
+      bytes: s.isDirectory() ? await dirSize(path) : s.size,
+      lastUsedMs: s.mtimeMs,
+    });
+  }
+  return out;
+}
+
+async function listHotswapEntries(): Promise<CacheEntry[]> {
+  const dir = join(getCachePath(), "agents");
+  if (!existsSync(dir)) return [];
+  const files = await listFiles(dir);
+  return files.map((f) => ({
+    id: f.name,
+    path: f.path,
+    bytes: f.bytes,
+    lastUsedMs: f.mtimeMs,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Clean (delete a whole category, or everything)
+// ---------------------------------------------------------------------------
+
+export interface CleanResult {
+  removed: { id: string; path: string; bytes: number; category: CategoryId }[];
+  freedBytes: number;
+}
+
+/**
+ * Wholesale wipe of a category — delete every entry pluggy knows about under it.
+ * `all` wipes every category. JDKs are removed via the manifest so dangling
+ * entries don't get left behind.
+ */
+export async function cleanCache(category: CategoryId | "all"): Promise<CleanResult> {
+  const wanted: CategoryId[] = category === "all" ? [...CATEGORY_IDS] : [category];
+  const removed: CleanResult["removed"] = [];
+  for (const id of wanted) {
+    const entries = await loadCategory(id);
+    for (const entry of entries) {
+      await deleteEntry(id, entry);
+      removed.push({ id: entry.id, path: entry.path, bytes: entry.bytes, category: id });
+    }
+    // After removing all JDK slots, drop their manifest entries so subsequent
+    // `cache info` calls don't show ghost numbers from a stale manifest.
+    if (id === "jdk") {
+      const manifest = await readManifest();
+      for (const key of Object.keys(manifest.entries)) await forgetEntry(key);
+    }
+  }
+  return {
+    removed,
+    freedBytes: removed.reduce((acc, r) => acc + r.bytes, 0),
+  };
+}
+
+async function deleteEntry(category: CategoryId, entry: CacheEntry): Promise<void> {
+  // Match the on-disk shape: JDK slots and BuildTools/ are directories, the
+  // rest are files. `rm` with `recursive: true` handles both safely.
+  await rm(entry.path, { recursive: true, force: true });
+  if (category === "jdk" && !entry.id.startsWith("archives/")) {
+    await forgetEntry(entry.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prune (budget-driven LRU eviction)
+// ---------------------------------------------------------------------------
+
+export interface PruneOptions {
+  /**
+   * Drop entries whose `lastUsedMs` (JDKs) or mtime (everything else) is
+   * older than `now - maxAgeMs`. `0` disables age-based pruning.
+   */
+  maxAgeMs?: number;
+  /**
+   * After age-based pruning, evict additional entries oldest-first until the
+   * scoped total is at or below this byte budget. `undefined` disables the
+   * size cap.
+   */
+  maxBytes?: number;
+  /**
+   * JDK-only hard cap: keep the N most-recently-used JDKs per major; evict
+   * anything beyond that with reason `"lru"`, regardless of age. Defaults
+   * to 2 (a current and a previous slot per major).
+   */
+  keepLatest?: number;
+  /** Limit pruning to a single category. Default: every category. */
+  category?: CategoryId | "all";
+  /** When true, compute what would be removed but don't touch disk. */
+  dryRun?: boolean;
+  /** Override `Date.now()` for tests. */
+  now?: () => number;
+}
+
+export interface PruneResult {
+  removed: {
+    id: string;
+    path: string;
+    bytes: number;
+    category: CategoryId;
+    reason: "age" | "size" | "lru" | "dangling";
+  }[];
+  kept: { id: string; category: CategoryId }[];
+  freedBytes: number;
+  dryRun: boolean;
+}
+
+/**
+ * Evict cache entries by per-major LRU (JDKs), age, then size budget.
+ * Order of operations per category:
+ *   1. JDKs only: reconcile manifests (drop dangling entries) and apply
+ *      `keepLatest` as a hard cap — anything beyond the top N per major
+ *      is evicted with reason `"lru"`.
+ *   2. Apply `maxAgeMs` to whatever survived step 1.
+ *   3. Apply `maxBytes` (oldest-first) to whatever's left.
+ */
+export async function pruneCache(opts: PruneOptions = {}): Promise<PruneResult> {
+  const now = opts.now ?? (() => Date.now());
+  const dryRun = opts.dryRun === true;
+  const keepLatest = Math.max(0, opts.keepLatest ?? 2);
+  const maxAgeMs = opts.maxAgeMs ?? 0;
+  const maxBytes = opts.maxBytes;
+  const wanted: CategoryId[] =
+    opts.category === undefined || opts.category === "all" ? [...CATEGORY_IDS] : [opts.category];
+
+  const result: PruneResult = { removed: [], kept: [], freedBytes: 0, dryRun };
+
+  for (const id of wanted) {
+    const entries = await loadCategory(id);
+    let survivors: CacheEntry[] = entries;
+
+    if (id === "jdk") {
+      // Drop manifest entries whose slot vanished out-of-band.
+      const manifest = await readManifest();
+      for (const [key] of Object.entries(manifest.entries)) {
+        if (!existsSync(slotPath(key))) {
+          if (!dryRun) await forgetEntry(key);
+          result.removed.push({
+            id: key,
+            path: slotPath(key),
+            bytes: 0,
+            category: id,
+            reason: "dangling",
+          });
+        }
+      }
+      // Hard cap: keep only the N most-recently-used slots per major.
+      // Archive tarballs (`archives/...`) aren't slot-keyed; they age out
+      // through `maxAgeMs` / `maxBytes` instead.
+      const byMajor = new Map<number, CacheEntry[]>();
+      const unmajored: CacheEntry[] = [];
+      for (const entry of entries) {
+        const major = parseMajorFromKey(entry.id);
+        if (major === undefined) {
+          unmajored.push(entry);
+          continue;
+        }
+        const list = byMajor.get(major) ?? [];
+        list.push(entry);
+        byMajor.set(major, list);
+      }
+      const kept: CacheEntry[] = [...unmajored];
+      for (const list of byMajor.values()) {
+        list.sort((a, b) => b.lastUsedMs - a.lastUsedMs);
+        for (let i = 0; i < list.length; i++) {
+          if (i < keepLatest) {
+            kept.push(list[i]);
+          } else {
+            if (!dryRun) await deleteEntry(id, list[i]);
+            result.removed.push({
+              id: list[i].id,
+              path: list[i].path,
+              bytes: list[i].bytes,
+              category: id,
+              reason: "lru",
+            });
+          }
+        }
+      }
+      survivors = kept;
+    }
+
+    const ageCutoff = maxAgeMs > 0 ? now() - maxAgeMs : -Infinity;
+    const afterAge: CacheEntry[] = [];
+
+    for (const entry of survivors) {
+      if (entry.lastUsedMs < ageCutoff) {
+        if (!dryRun) await deleteEntry(id, entry);
+        result.removed.push({
+          id: entry.id,
+          path: entry.path,
+          bytes: entry.bytes,
+          category: id,
+          reason: "age",
+        });
+        continue;
+      }
+      afterAge.push(entry);
+    }
+
+    if (maxBytes !== undefined) {
+      afterAge.sort((a, b) => a.lastUsedMs - b.lastUsedMs);
+      let total = afterAge.reduce((acc, e) => acc + e.bytes, 0);
+      while (total > maxBytes && afterAge.length > 0) {
+        const victim = afterAge.shift();
+        if (victim === undefined) break;
+        if (!dryRun) await deleteEntry(id, victim);
+        result.removed.push({
+          id: victim.id,
+          path: victim.path,
+          bytes: victim.bytes,
+          category: id,
+          reason: "size",
+        });
+        total -= victim.bytes;
+      }
+    }
+
+    for (const survivor of afterAge) {
+      result.kept.push({ id: survivor.id, category: id });
+    }
+  }
+
+  result.freedBytes = result.removed.reduce((acc, r) => acc + r.bytes, 0);
+  return result;
+}
+
+/**
+ * Pull the major release number out of a JDK cache key like
+ * `temurin-21-macos-aarch64`. Returns `undefined` for archive entries
+ * (e.g. `archives/temurin-21-macos-aarch64.tar.gz`) or unrecognized shapes.
+ */
+function parseMajorFromKey(key: string): number | undefined {
+  if (key.includes("/")) return undefined;
+  const parts = key.split("-");
+  if (parts.length < 4) return undefined;
+  const n = Number.parseInt(parts[1], 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FileInfo {
+  name: string;
+  path: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+async function listFiles(dir: string): Promise<FileInfo[]> {
+  const out: FileInfo[] = [];
+  for (const name of await safeReaddir(dir)) {
+    const path = join(dir, name);
+    const s = await stat(path).catch(() => undefined);
+    if (s === undefined || !s.isFile()) continue;
+    out.push({ name, path, bytes: s.size, mtimeMs: s.mtimeMs });
+  }
+  return out;
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+/** Recursive directory size in bytes. Skips unreadable entries silently. */
+export async function dirSize(path: string): Promise<number> {
+  let total = 0;
+  async function walk(current: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        try {
+          const s = await stat(full);
+          total += s.size;
+        } catch {
+          // unreadable entry — ignore
+        }
+      }
+    }
+  }
+  await walk(path);
+  return total;
+}
+
+/** Format bytes as a short human string. Mirrors the doctor command's format. */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * Parse a duration string like `90d`, `12h`, `30m`, `7w` into milliseconds.
+ * Unsuffixed integers are read as days. Throws on negative or malformed input.
+ */
+export function parseDurationMs(value: string): number {
+  const m = value.trim().match(/^(\d+)\s*(s|m|h|d|w)?$/);
+  if (m === null) throw new Error(`invalid duration "${value}" (expected e.g. 90d, 12h, 30m, 1w)`);
+  const n = Number.parseInt(m[1], 10);
+  const unit = m[2] ?? "d";
+  const ms =
+    unit === "s"
+      ? 1_000
+      : unit === "m"
+        ? 60_000
+        : unit === "h"
+          ? 3_600_000
+          : unit === "w"
+            ? 7 * 86_400_000
+            : 86_400_000;
+  return n * ms;
+}
+
+/**
+ * Parse a size string like `5G`, `500M`, `1024K`, `2048` into bytes.
+ * Unsuffixed integers are bytes. Accepts both `G` and `GB` style suffixes.
+ */
+export function parseSizeBytes(value: string): number {
+  const m = value
+    .trim()
+    .toUpperCase()
+    .match(/^(\d+)\s*(B|K|KB|M|MB|G|GB|T|TB)?$/);
+  if (m === null) throw new Error(`invalid size "${value}" (expected e.g. 5G, 500M, 1024K)`);
+  const n = Number.parseInt(m[1], 10);
+  const unit = m[2] ?? "B";
+  const factor =
+    unit === "B"
+      ? 1
+      : unit === "K" || unit === "KB"
+        ? 1024
+        : unit === "M" || unit === "MB"
+          ? 1024 ** 2
+          : unit === "G" || unit === "GB"
+            ? 1024 ** 3
+            : 1024 ** 4;
+  return n * factor;
+}
+
+export function isCategoryId(value: string): value is CategoryId {
+  return (CATEGORY_IDS as readonly string[]).includes(value);
+}

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -467,37 +467,41 @@ export async function pruneCache(opts: PruneOptions = {}): Promise<PruneResult> 
       // Hard cap: keep only the N most-recently-used slots per major.
       // Archive tarballs (`archives/...`) aren't slot-keyed; they age out
       // through `maxAgeMs` / `maxBytes` instead.
-      const byMajor = new Map<number, CacheEntry[]>();
-      const unmajored: CacheEntry[] = [];
-      for (const entry of entries) {
-        const major = parseMajorFromKey(entry.id);
-        if (major === undefined) {
-          unmajored.push(entry);
-          continue;
+      // `keepLatest === 0` opts out of the per-major LRU pin entirely —
+      // every slot flows through to age/size pruning unmolested.
+      if (keepLatest > 0) {
+        const byMajor = new Map<number, CacheEntry[]>();
+        const unmajored: CacheEntry[] = [];
+        for (const entry of entries) {
+          const major = parseMajorFromKey(entry.id);
+          if (major === undefined) {
+            unmajored.push(entry);
+            continue;
+          }
+          const list = byMajor.get(major) ?? [];
+          list.push(entry);
+          byMajor.set(major, list);
         }
-        const list = byMajor.get(major) ?? [];
-        list.push(entry);
-        byMajor.set(major, list);
-      }
-      const kept: CacheEntry[] = [...unmajored];
-      for (const list of byMajor.values()) {
-        list.sort((a, b) => b.lastUsedMs - a.lastUsedMs);
-        for (let i = 0; i < list.length; i++) {
-          if (i < keepLatest) {
-            kept.push(list[i]);
-          } else {
-            if (!dryRun) await deleteEntry(id, list[i]);
-            result.removed.push({
-              id: list[i].id,
-              path: list[i].path,
-              bytes: list[i].bytes,
-              category: id,
-              reason: "lru",
-            });
+        const kept: CacheEntry[] = [...unmajored];
+        for (const list of byMajor.values()) {
+          list.sort((a, b) => b.lastUsedMs - a.lastUsedMs);
+          for (let i = 0; i < list.length; i++) {
+            if (i < keepLatest) {
+              kept.push(list[i]);
+            } else {
+              if (!dryRun) await deleteEntry(id, list[i]);
+              result.removed.push({
+                id: list[i].id,
+                path: list[i].path,
+                bytes: list[i].bytes,
+                category: id,
+                reason: "lru",
+              });
+            }
           }
         }
+        survivors = kept;
       }
-      survivors = kept;
     }
 
     const ageCutoff = maxAgeMs > 0 ? now() - maxAgeMs : -Infinity;

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -31,6 +31,7 @@ import {
   scanCache,
 } from "../cache/index.ts";
 import { bold, dim, log, yellow } from "../logging.ts";
+import { getCachePath } from "../project.ts";
 
 interface CacheGlobalOpts {
   json?: boolean;
@@ -161,12 +162,12 @@ function pathSubcommand(): Command {
     .description("Print the cache directory path. Useful in shell scripts.")
     .action(async function action(this: Command) {
       const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
-      const summary = await scanCache();
+      const cachePath = getCachePath();
       if (globalOpts.json === true) {
-        emitJson({ status: "success", cachePath: summary.cachePath });
+        emitJson({ status: "success", cachePath });
         return;
       }
-      process.stdout.write(`${summary.cachePath}\n`);
+      process.stdout.write(`${cachePath}\n`);
     });
 }
 

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -1,0 +1,338 @@
+/**
+ * `pluggy cache` — introspect and manage everything pluggy keeps under
+ * `getCachePath()`. JDK toolchain commands (`pluggy sdk install/list/...`)
+ * stay where they are; this surface exists for the cross-cutting "what is
+ * eating my disk and how do I clean it up" question.
+ *
+ * Subcommands:
+ *   info (default)       Summary table — entries + bytes per category.
+ *   list [--category]    Per-entry listing.
+ *   path                 Print the cache root (scriptable: `cd "$(pluggy cache path)"`).
+ *   clean [--category]   Wipe a category (or everything).
+ *   prune [--max-age]    Budget-driven LRU eviction. Safe one-shot defaults.
+ */
+
+import process from "node:process";
+
+import { Command, InvalidArgumentError } from "commander";
+import { confirm } from "@inquirer/prompts";
+
+import {
+  CATEGORY_IDS,
+  type CacheSummary,
+  type CategoryId,
+  cleanCache,
+  formatBytes,
+  isCategoryId,
+  listCacheEntries,
+  parseDurationMs,
+  parseSizeBytes,
+  pruneCache,
+  scanCache,
+} from "../cache/index.ts";
+import { bold, dim, log, yellow } from "../logging.ts";
+
+interface CacheGlobalOpts {
+  json?: boolean;
+}
+
+const DEFAULT_MAX_AGE = "90d";
+
+/** Top-level `cache` command. Subcommands attached below. */
+export function cacheCommand(): Command {
+  const cmd = new Command("cache").description(
+    "Inspect and manage pluggy's on-disk cache (JDKs, server jars, dependencies, BuildTools).",
+  );
+
+  // No-arg invocation (`pluggy cache`) prints the same summary as `cache info`.
+  cmd.action(async function action(this: Command) {
+    const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+    await runInfo(globalOpts);
+  });
+
+  cmd.addCommand(infoSubcommand());
+  cmd.addCommand(listSubcommand());
+  cmd.addCommand(pathSubcommand());
+  cmd.addCommand(cleanSubcommand());
+  cmd.addCommand(pruneSubcommand());
+
+  return cmd;
+}
+
+// ---------------------------------------------------------------------------
+// info
+// ---------------------------------------------------------------------------
+
+function infoSubcommand(): Command {
+  return new Command("info")
+    .description("Show cache size by category. Default if no subcommand is given.")
+    .action(async function action(this: Command) {
+      const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+      await runInfo(globalOpts);
+    });
+}
+
+async function runInfo(globalOpts: CacheGlobalOpts): Promise<void> {
+  const summary = await scanCache();
+
+  if (globalOpts.json === true) {
+    emitJson({ status: "success", ...summary });
+    return;
+  }
+
+  log.info(`${bold("cache")} ${dim(summary.cachePath)}`);
+  log.info("");
+
+  printCategoryRow("jdk", summary.categories.jdk);
+  printCategoryRow("versions", summary.categories.versions);
+  printCategoryRow("buildtools", summary.categories.buildtools);
+  printCategoryRow("dependencies", summary.categories.dependencies);
+  if (summary.categories.dependencies.entries > 0) {
+    printSubRow("maven", summary.categories.dependencies.maven);
+    printSubRow("modrinth", summary.categories.dependencies.modrinth);
+    printSubRow("file", summary.categories.dependencies.file);
+  }
+  printCategoryRow("jbr", summary.categories.jbr);
+  printCategoryRow("hotswap", summary.categories.hotswap);
+
+  log.info("");
+  log.info(`  ${bold("total")}  ${formatBytes(summary.totalBytes)}`);
+}
+
+function printCategoryRow(name: string, c: { entries: number; bytes: number }): void {
+  const label = name.padEnd(14);
+  const entries = c.entries === 1 ? "1 entry" : `${c.entries} entries`;
+  const size = formatBytes(c.bytes);
+  log.info(`  ${label} ${size.padStart(10)}  ${dim(entries)}`);
+}
+
+function printSubRow(name: string, c: { entries: number; bytes: number }): void {
+  const label = `  └ ${name}`.padEnd(14);
+  const entries = c.entries === 1 ? "1 entry" : `${c.entries} entries`;
+  const size = formatBytes(c.bytes);
+  log.info(`  ${dim(label)} ${dim(size.padStart(10))}  ${dim(entries)}`);
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+function listSubcommand(): Command {
+  return new Command("list")
+    .alias("ls")
+    .description("List individual cache entries.")
+    .option("--category <name>", "Limit to one category.", parseCategoryArg)
+    .action(async function action(this: Command, options) {
+      const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+      const category: CategoryId | "all" = (options.category as CategoryId | undefined) ?? "all";
+      const groups = await listCacheEntries(category);
+
+      if (globalOpts.json === true) {
+        emitJson({ status: "success", category, groups });
+        return;
+      }
+
+      let printed = 0;
+      for (const group of groups) {
+        if (group.entries.length === 0) continue;
+        log.info(bold(group.category));
+        // Newest first so the top of the listing is what the user just touched.
+        const sorted = [...group.entries].sort((a, b) => b.lastUsedMs - a.lastUsedMs);
+        for (const entry of sorted) {
+          const sub = entry.subcategory === undefined ? "" : `${dim(`[${entry.subcategory}]`)} `;
+          const used = formatRelative(entry.lastUsedMs);
+          log.info(`  ${sub}${entry.id}  ${dim(formatBytes(entry.bytes))}  ${dim(`(${used})`)}`);
+        }
+        log.info("");
+        printed += group.entries.length;
+      }
+      if (printed === 0) {
+        log.info(`Cache is empty${category !== "all" ? ` in category "${category}"` : ""}.`);
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// path
+// ---------------------------------------------------------------------------
+
+function pathSubcommand(): Command {
+  return new Command("path")
+    .description("Print the cache directory path. Useful in shell scripts.")
+    .action(async function action(this: Command) {
+      const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+      const summary = await scanCache();
+      if (globalOpts.json === true) {
+        emitJson({ status: "success", cachePath: summary.cachePath });
+        return;
+      }
+      process.stdout.write(`${summary.cachePath}\n`);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// clean
+// ---------------------------------------------------------------------------
+
+function cleanSubcommand(): Command {
+  return new Command("clean")
+    .description("Delete all cached entries (or just one category).")
+    .option("--category <name>", "Limit cleaning to one category.", parseCategoryArg)
+    .option("-y, --yes", "Skip the confirmation prompt.")
+    .action(async function action(this: Command, options) {
+      const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+      const category: CategoryId | "all" = (options.category as CategoryId | undefined) ?? "all";
+      const skipPrompt = options.yes === true || globalOpts.json === true;
+
+      const summary = await scanCache();
+      const target = describeTarget(category, summary);
+      if (target.bytes === 0) {
+        if (globalOpts.json === true) {
+          emitJson({ status: "success", action: "clean", category, removed: [], freedBytes: 0 });
+          return;
+        }
+        log.info(`Nothing to clean${category !== "all" ? ` in "${category}"` : ""}.`);
+        return;
+      }
+
+      if (!skipPrompt) {
+        const ok = await confirm({
+          message: `Delete ${target.label} (${formatBytes(target.bytes)})?`,
+          default: false,
+        });
+        if (!ok) {
+          log.info("Aborted.");
+          return;
+        }
+      }
+
+      const result = await cleanCache(category);
+      if (globalOpts.json === true) {
+        emitJson({ status: "success", action: "clean", category, ...result });
+        return;
+      }
+      log.success(
+        `Removed ${result.removed.length} entr${result.removed.length === 1 ? "y" : "ies"} (${formatBytes(result.freedBytes)}).`,
+      );
+    });
+}
+
+function describeTarget(
+  category: CategoryId | "all",
+  summary: CacheSummary,
+): { label: string; bytes: number } {
+  if (category === "all") {
+    return { label: "the entire cache", bytes: summary.totalBytes };
+  }
+  const c = summary.categories[category];
+  const bytes = "bytes" in c ? c.bytes : 0;
+  return { label: `the "${category}" category`, bytes };
+}
+
+// ---------------------------------------------------------------------------
+// prune
+// ---------------------------------------------------------------------------
+
+function pruneSubcommand(): Command {
+  return new Command("prune")
+    .description(
+      "Evict stale cache entries. Defaults: drop anything not used in 90 days; keep the 2 most-recent JDKs per major.",
+    )
+    .option(
+      "--max-age <duration>",
+      `Drop entries older than this (e.g. 90d, 12h, 30m, 1w). Default: ${DEFAULT_MAX_AGE}. Use 0 to disable.`,
+      DEFAULT_MAX_AGE,
+    )
+    .option(
+      "--max-size <size>",
+      "After age pruning, evict oldest entries until total is at or below this budget (e.g. 5G, 500M).",
+    )
+    .option(
+      "--keep-latest <n>",
+      "JDK-only: keep the N most-recently-used JDKs per major regardless of age. Default: 2.",
+      parseKeepLatest,
+      2,
+    )
+    .option("--category <name>", "Limit pruning to one category.", parseCategoryArg)
+    .option("--dry-run", "Print what would be removed without touching disk.")
+    .action(async function action(this: Command, options) {
+      const globalOpts = this.optsWithGlobals() as CacheGlobalOpts;
+      const maxAgeMs = parseDurationOrZero(options.maxAge as string);
+      const maxBytes =
+        options.maxSize === undefined ? undefined : parseSizeArg(options.maxSize as string);
+      const keepLatest = options.keepLatest as number;
+      const category: CategoryId | "all" = (options.category as CategoryId | undefined) ?? "all";
+      const dryRun = options.dryRun === true;
+
+      const result = await pruneCache({ maxAgeMs, maxBytes, keepLatest, category, dryRun });
+
+      if (globalOpts.json === true) {
+        emitJson({ status: "success", action: "prune", ...result });
+        return;
+      }
+
+      if (result.removed.length === 0) {
+        log.info(`Nothing to prune (${result.kept.length} kept).`);
+        return;
+      }
+      for (const r of result.removed) {
+        log.info(
+          `  ${yellow("-")} ${r.category}/${r.id} ${dim(`(${r.reason}, ${formatBytes(r.bytes)})`)}`,
+        );
+      }
+      const verb = dryRun ? "Would evict" : "Evicted";
+      log.success(
+        `${verb} ${result.removed.length}; kept ${result.kept.length}. Freed ${formatBytes(result.freedBytes)}.`,
+      );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseCategoryArg(value: string): CategoryId {
+  if (!isCategoryId(value)) {
+    throw new InvalidArgumentError(
+      `unknown category "${value}". Allowed: ${CATEGORY_IDS.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+function parseKeepLatest(value: string): number {
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n) || n < 0) {
+    throw new InvalidArgumentError(`--keep-latest must be a non-negative integer (got "${value}")`);
+  }
+  return n;
+}
+
+function parseDurationOrZero(value: string): number {
+  if (value === "0") return 0;
+  try {
+    return parseDurationMs(value);
+  } catch (err) {
+    throw new InvalidArgumentError((err as Error).message);
+  }
+}
+
+function parseSizeArg(value: string): number {
+  try {
+    return parseSizeBytes(value);
+  } catch (err) {
+    throw new InvalidArgumentError((err as Error).message);
+  }
+}
+
+function emitJson(payload: unknown): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function formatRelative(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -1,5 +1,7 @@
 /**
- * `pluggy sdk` — manage cached JDKs.
+ * `pluggy sdk` — the JDK *toolchain* surface. For cross-cutting cache
+ * housekeeping (LRU eviction, total size, cleaning everything) see
+ * `pluggy cache prune` / `cache info` / `cache clean --category jdk`.
  *
  * Subcommands:
  *   install [<major>]         Download + cache a JDK. With no arg, derives
@@ -9,7 +11,6 @@
  *   path <major>              Print the absolute javaHome for a cached JDK.
  *   use <major>               Pin a JDK in the current project.json.
  *   remove <major>            Delete a cached JDK.
- *   gc [--keep-latest <N>]    LRU-evict cached JDKs.
  *
  * `--distribution` is an opt-in override; defaults to Temurin. Only the
  * curated allowlist is accepted — see `ALLOWED_DISTRIBUTIONS`. Adding
@@ -28,9 +29,9 @@ import {
   type Project,
   type ResolvedProject,
 } from "../project.ts";
-import { bold, dim, green, log, red, yellow } from "../logging.ts";
+import { bold, dim, green, log, red } from "../logging.ts";
 
-import { ensureJdk, getCachedJdk, gc, listInstalled, removeJdk } from "../sdk/index.ts";
+import { ensureJdk, getCachedJdk, listInstalled, removeJdk } from "../sdk/index.ts";
 import { selectJdkForProject } from "../sdk/resolve.ts";
 
 /**
@@ -58,14 +59,13 @@ interface SdkGlobalOpts {
 
 /** Top-level `sdk` command. Subcommands attached below. */
 export function sdkCommand(): Command {
-  const cmd = new Command("sdk").description("Manage cached JDKs (install, list, pin, gc).");
+  const cmd = new Command("sdk").description("Manage JDK toolchains (install, list, pin, remove).");
 
   cmd.addCommand(installSubcommand());
   cmd.addCommand(listSubcommand());
   cmd.addCommand(pathSubcommand());
   cmd.addCommand(useSubcommand());
   cmd.addCommand(removeSubcommand());
-  cmd.addCommand(gcSubcommand());
 
   return cmd;
 }
@@ -271,33 +271,6 @@ function removeSubcommand(): Command {
 }
 
 // ---------------------------------------------------------------------------
-// gc
-// ---------------------------------------------------------------------------
-
-function gcSubcommand(): Command {
-  return new Command("gc")
-    .description("Evict cached JDKs by LRU per major.")
-    .option("--keep-latest <n>", "Keep the N most-recently-used JDKs per major.", parseKeep, 2)
-    .action(async function action(this: Command, options) {
-      const globalOpts = this.optsWithGlobals() as SdkGlobalOpts;
-      const result = await gc({ keepLatest: options.keepLatest as number });
-
-      if (globalOpts.json === true) {
-        emitJson({ status: "success", action: "gc", ...result });
-        return;
-      }
-      if (result.removed.length === 0) {
-        log.info(`Nothing to evict (${result.kept.length} kept).`);
-        return;
-      }
-      for (const r of result.removed) {
-        log.info(`  ${yellow("-")} ${r.key} ${dim(`(${r.reason})`)}`);
-      }
-      log.success(`Evicted ${result.removed.length}; kept ${result.kept.length}.`);
-    });
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -316,14 +289,6 @@ function parseDistribution(value: string): AllowedDistribution {
     );
   }
   return value as AllowedDistribution;
-}
-
-function parseKeep(value: string): number {
-  const n = Number.parseInt(value, 10);
-  if (Number.isNaN(n) || n < 1) {
-    throw new InvalidArgumentError(`--keep-latest must be a positive integer (got "${value}")`);
-  }
-  return n;
 }
 
 function loadProject(globalOpts: SdkGlobalOpts): ResolvedProject {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { Command, InvalidArgumentError } from "commander";
 
 import { buildCommand } from "./commands/build.ts";
+import { cacheCommand } from "./commands/cache.ts";
 import { completionsCommand } from "./commands/completions.ts";
 import { devCommand } from "./commands/dev.ts";
 import { docsCommand } from "./commands/docs.ts";
@@ -48,6 +49,7 @@ program.addCommand(docsCommand());
 program.addCommand(doctorCommand({ pluggyVersion: CLI_VERSION, repository: REPOSITORY }));
 program.addCommand(devCommand());
 program.addCommand(sdkCommand());
+program.addCommand(cacheCommand());
 program.addCommand(upgradeCommand({ repository: REPOSITORY }));
 program.addCommand(completionsCommand(program));
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -90,6 +90,10 @@ export interface HotswapConfig {
  * macOS: `~/Library/Caches/pluggy`.
  * Windows: `%LOCALAPPDATA%/pluggy/cache`.
  * Linux/other: `$XDG_CACHE_HOME/pluggy` (defaulting to `~/.cache/pluggy`).
+ *
+ * Cache contents are *reproducible* — wiping this directory only forces
+ * re-downloads. State that must survive `pluggy cache clean` (e.g. the
+ * update-check timestamp) belongs under `getStatePath` instead.
  */
 export function getCachePath(): string {
   const home = homedir();
@@ -100,6 +104,27 @@ export function getCachePath(): string {
     return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), "pluggy", "cache");
   }
   return join(process.env.XDG_CACHE_HOME || join(home, ".cache"), "pluggy");
+}
+
+/**
+ * OS-appropriate user *state* directory for pluggy. Distinct from the
+ * cache: state is small, non-regenerable metadata (e.g. the cached
+ * latest-release tag from the update checker) that must survive
+ * `pluggy cache clean`.
+ *
+ * macOS: `~/Library/Application Support/pluggy`.
+ * Windows: `%APPDATA%/pluggy`.
+ * Linux/other: `$XDG_STATE_HOME/pluggy` (defaulting to `~/.local/state/pluggy`).
+ */
+export function getStatePath(): string {
+  const home = homedir();
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "pluggy");
+  }
+  if (process.platform === "win32") {
+    return join(process.env.APPDATA || join(home, "AppData", "Roaming"), "pluggy");
+  }
+  return join(process.env.XDG_STATE_HOME || join(home, ".local", "state"), "pluggy");
 }
 
 const PROJECT_FILE_NAME = "project.json";

--- a/src/sdk/cache.ts
+++ b/src/sdk/cache.ts
@@ -1,5 +1,5 @@
 /**
- * On-disk layout for cached JDKs and the LRU manifest used by `pluggy sdk gc`.
+ * On-disk layout for cached JDKs and the LRU manifest used by `pluggy cache prune`.
  *
  *   <cachePath>/jdk/
  *     manifest.json                     -- {entries: {<key>: {lastUsed, fullVersion, installedAt}}}
@@ -30,7 +30,7 @@ const MANIFEST_FILE = "manifest.json";
 const ARCHIVES_DIR = "archives";
 
 export interface ManifestEntry {
-  /** epoch ms — `ensureJdk` updates this on every cache hit for LRU gc. */
+  /** epoch ms — `ensureJdk` updates this on every cache hit for LRU prune. */
   lastUsed: number;
   /** epoch ms — set when the slot is first populated. */
   installedAt: number;

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -7,7 +7,8 @@
  *     `ensureJdk`. The one call build/test/dev care about.
  *   * `getCachedJdk(major, distribution?)` — look up a cached JDK without
  *     installing. Returns `undefined` on miss.
- *   * `listInstalled()` / `gc(opts)` — used by `pluggy sdk list`/`gc`.
+ *   * `listInstalled()` — used by `pluggy sdk list`. Eviction lives in
+ *     `pluggy cache prune` (see `src/cache/index.ts`).
  *
  * Auto-install is on by default. Set `PLUGGY_NO_AUTO_INSTALL=1` to make a
  * cache miss raise instead — CI escape hatch. The error points at the
@@ -38,7 +39,6 @@ import {
   slotPath,
   touchEntry,
   type CacheKeyParts,
-  type ManifestEntry,
 } from "./cache.ts";
 import { resolveJdk, targetForHost, type DiscoArch, type DiscoOs } from "./disco.ts";
 import { installJdk } from "./install.ts";
@@ -200,66 +200,6 @@ export async function listInstalled(): Promise<InstalledJdkInfo[]> {
   }
   out.sort((a, b) => a.key.localeCompare(b.key));
   return out;
-}
-
-export interface GcOptions {
-  /**
-   * Keep the N most-recently-used JDKs per major version. Default 2 — gives
-   * users a current and a previous slot per major to roll back between.
-   */
-  keepLatest?: number;
-  /** When true, also remove slots that exist on disk but aren't in the manifest. */
-  pruneOrphans?: boolean;
-}
-
-export interface GcResult {
-  removed: { key: string; reason: "lru" | "orphan" | "dangling" }[];
-  kept: string[];
-}
-
-/**
- * Evict cached JDKs by LRU per major. Also reconciles manifest vs filesystem:
- *   - `dangling`: manifest entry whose on-disk slot is gone → drop from manifest.
- *   - `orphan`: on-disk slot with no manifest entry → optionally `rm -r`.
- */
-export async function gc(opts: GcOptions = {}): Promise<GcResult> {
-  const keepLatest = Math.max(1, opts.keepLatest ?? 2);
-  const result: GcResult = { removed: [], kept: [] };
-  const manifest = await readManifest();
-
-  // Group by major; sort each group by lastUsed desc; keep first N.
-  const byMajor = new Map<number, [string, ManifestEntry][]>();
-  for (const [key, entry] of Object.entries(manifest.entries)) {
-    const slot = slotPath(key);
-    if (!existsSync(slot)) {
-      await forgetEntry(key);
-      result.removed.push({ key, reason: "dangling" });
-      continue;
-    }
-    const list = byMajor.get(entry.major) ?? [];
-    list.push([key, entry]);
-    byMajor.set(entry.major, list);
-  }
-
-  for (const list of byMajor.values()) {
-    list.sort((a, b) => b[1].lastUsed - a[1].lastUsed);
-    for (let i = 0; i < list.length; i++) {
-      const [key] = list[i];
-      if (i < keepLatest) {
-        result.kept.push(key);
-      } else {
-        await rm(slotPath(key), { recursive: true, force: true });
-        await forgetEntry(key);
-        result.removed.push({ key, reason: "lru" });
-      }
-    }
-  }
-
-  if (opts.pruneOrphans === true) {
-    // Optional second pass — left for a future PR to keep this one bounded.
-  }
-
-  return result;
 }
 
 /**

--- a/src/sdk/install.ts
+++ b/src/sdk/install.ts
@@ -39,7 +39,7 @@ export interface InstallResult {
 /**
  * Download (if needed) and extract `spec` into the cache. Atomic: a partial
  * extract on crash leaves no slot behind. Records the install in the
- * manifest so `pluggy sdk gc` can LRU-evict later.
+ * manifest so `pluggy cache prune` can LRU-evict later.
  */
 export async function installJdk(spec: JdkSpec): Promise<InstallResult> {
   await ensureCacheDirs();
@@ -56,7 +56,7 @@ export async function installJdk(spec: JdkSpec): Promise<InstallResult> {
 
   // Download archive if missing. We deliberately keep archives around in
   // <cacheRoot>/jdk/archives so a re-extract (after manual slot deletion)
-  // doesn't redownload — `pluggy sdk gc` is what cleans them up.
+  // doesn't redownload — `pluggy cache prune --category jdk` is what cleans them up.
   if (!existsSync(archive)) {
     await downloadArchive(spec, archive);
   }

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -9,12 +9,13 @@
  * `PLUGGY_NO_UPDATE_CHECK=1`.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import process from "node:process";
 
 import { bold, brightBlue, dim } from "./logging.ts";
-import { getCachePath } from "./project.ts";
+import { getCachePath, getStatePath } from "./project.ts";
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 2000;
@@ -44,9 +45,26 @@ export interface UpdateCheckHandle {
   dispose: () => void;
 }
 
-/** Default location of the cached state file. */
+/** Default location of the state file. */
 export function getStateFilePath(): string {
-  return join(getCachePath(), "update-check.json");
+  return join(getStatePath(), "update-check.json");
+}
+
+/**
+ * One-shot migration: pluggy <= 0.x kept `update-check.json` inside the
+ * cache directory, where it would have been wiped by `pluggy cache clean`.
+ * On first read after upgrade, move it under the state directory.
+ */
+async function migrateLegacyState(stateFile: string): Promise<void> {
+  const legacy = join(getCachePath(), "update-check.json");
+  if (!existsSync(legacy) || existsSync(stateFile)) return;
+  try {
+    await mkdir(dirname(stateFile), { recursive: true });
+    await rename(legacy, stateFile);
+  } catch {
+    // Best-effort: a failed migration just means the next fetch repopulates
+    // the new path. Don't block the user's command on this.
+  }
 }
 
 /**
@@ -126,6 +144,7 @@ export async function startUpdateCheck(opts: UpdateCheckOptions): Promise<Update
 
   const now = opts.now ?? (() => new Date());
   const stateFile = opts.stateFile ?? getStateFilePath();
+  if (opts.stateFile === undefined) await migrateLegacyState(stateFile);
   const cached = await readState(stateFile);
 
   const stale =


### PR DESCRIPTION
## Summary

- New top-level `pluggy cache` surface for cross-cutting cache management: `info` (default), `list`, `path`, `clean`, `prune`. Covers every category pluggy writes — `jdk`, `versions`, `buildtools`, `dependencies` (nested `maven`/`modrinth`/`file`), `jbr`, `hotswap` — with locked JSON shape using `bytes` consistently.
- `cache prune` ships with safe one-shot defaults (`--max-age 90d`, `--keep-latest 2`) and supports `--max-size`, `--category`, and `--dry-run`. `cache clean` is interactive by default; `-y`/`--yes` or `--json` skips the prompt.
- Folded `pluggy sdk gc` into `pluggy cache prune --category jdk` — `sdk` is now purely the JDK *toolchain* surface (install/list/path/use/remove). Dead `gc()`/`GcOptions`/`GcResult` exports removed.
- Moved `update-check.json` out of the cache directory into a new state directory via `getStatePath()` (`~/Library/Application Support/pluggy` on macOS, `$XDG_STATE_HOME/pluggy` on Linux, `%APPDATA%\pluggy` on Windows). One-shot rename migrates the legacy file on first read, so `pluggy cache clean` no longer wipes the update-check timestamp.
- Docs added for `pluggy cache`; `pluggy sdk` and `pluggy upgrade` docs updated to reflect the new split.

## Test plan

- [x] `vp test` (479 passed, 3 skipped)
- [x] `vp check` (197 files formatted, 136 type-checked, no warnings)
- [x] `bun build --compile --outfile=bin/pluggy ./src/index.ts` produces a working binary
- [x] Manual smoke test against the real cache: `pluggy cache`, `pluggy cache --json`, `pluggy cache path`, `pluggy cache prune --dry-run`, `pluggy sdk` (verified `gc` is gone, `cache` appears in top-level help)