### PR TITLE
feat(platform): add sponge as a first-class platform

### DIFF
--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -74,9 +74,10 @@ at a time below.
 ### `name` (required)
 
 String matching `^[a-zA-Z0-9_]+$`. Becomes the plugin's name in the
-generated descriptor (`plugin.yml` / `bungee.yml` / `velocity-plugin.json`)
-and the output jar stem (`<name>-<version>.jar`). `doctor` enforces the
-regex; `init` rejects other characters.
+generated descriptor (`plugin.yml` / `bungee.yml` / `velocity-plugin.json` /
+`META-INF/sponge_plugins.json`) and the output jar stem
+(`<name>-<version>.jar`). `doctor` enforces the regex; `init` rejects other
+characters.
 
 ### `version` (required)
 
@@ -142,21 +143,22 @@ the array by hand to add or remove editors later.
   latest stable Velocity release.
 - `platforms` — non-empty array. The first entry is the primary platform.
   Every platform in the array must share the same descriptor family (same
-  `plugin.yml` vs `bungee.yml` vs `velocity-plugin.json` target) — mixing
-  families fails early with "Split them into separate workspaces — one per
-  family."
+  `plugin.yml` vs `bungee.yml` vs `velocity-plugin.json` vs
+  `META-INF/sponge_plugins.json` target) — mixing families fails early with
+  "Split them into separate workspaces — one per family."
 
 The full platform roster ships with the binary:
 
-| id           | descriptor             | Maven coordinate                           |
-| ------------ | ---------------------- | ------------------------------------------ |
-| `paper`      | `plugin.yml`           | `io.papermc.paper:paper-api`               |
-| `folia`      | `plugin.yml`           | `dev.folia:folia-api`                      |
-| `spigot`     | `plugin.yml`           | `org.spigotmc:spigot-api` (SNAPSHOT)       |
-| `bukkit`     | `plugin.yml`           | `org.spigotmc:spigot-api` (SNAPSHOT)       |
-| `velocity`   | `velocity-plugin.json` | `com.velocitypowered:velocity-api`         |
-| `waterfall`  | `bungee.yml`           | `io.github.waterfallmc:waterfall-api`      |
-| `travertine` | `bungee.yml`           | (no Maven API — compile against waterfall) |
+| id           | descriptor                     | Maven coordinate                           |
+| ------------ | ------------------------------ | ------------------------------------------ |
+| `paper`      | `plugin.yml`                   | `io.papermc.paper:paper-api`               |
+| `folia`      | `plugin.yml`                   | `dev.folia:folia-api`                      |
+| `spigot`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)       |
+| `bukkit`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)       |
+| `velocity`   | `velocity-plugin.json`         | `com.velocitypowered:velocity-api`         |
+| `waterfall`  | `bungee.yml`                   | `io.github.waterfallmc:waterfall-api`      |
+| `travertine` | `bungee.yml`                   | (no Maven API — compile against waterfall) |
+| `sponge`     | `META-INF/sponge_plugins.json` | `org.spongepowered:spongeapi`              |
 
 Paper handles version strings in two formats. For 1.17 – 1.21.x the artifact
 is `<version>-R0.1-SNAPSHOT`; for 26.x and later (Mojang's calendar scheme —
@@ -170,6 +172,12 @@ require different Java versions (MC 1.21.x allows Java 21 – 26; MC
 26.1.x requires Java 25 – 26). pluggy provisions a matching JDK from the
 [Foojay Disco API](./commands/sdk.md) on first build, so the version
 you pick at `init` time isn't constrained by your host Java.
+
+Sponge surfaces Minecraft versions in the same shape as `velocity` — pluggy
+fetches the SpongeVanilla artifact list and resolves the matching SpongeAPI
+Maven coordinate internally. Modding-specific variants (SpongeForge,
+SpongeNeo) aren't modelled; only the standalone SpongeVanilla server is
+supported.
 
 ### `registries` (optional)
 

--- a/src/build/descriptor.test.ts
+++ b/src/build/descriptor.test.ts
@@ -22,6 +22,7 @@ createPlatform(() => ({
   getVersionInfo: () => Promise.resolve({ version: "1.0.0", build: 0 }),
   download: () => Promise.reject(new Error("not used")),
   api: () => Promise.resolve({ repositories: [], dependencies: [] }),
+  runtime: { pluginsDir: "plugins", serverArgs: [], vanillaServerFiles: false },
 }));
 
 createPlatform(() => ({
@@ -37,6 +38,7 @@ createPlatform(() => ({
   getVersionInfo: () => Promise.resolve({ version: "1.0.0", build: 0 }),
   download: () => Promise.reject(new Error("not used")),
   api: () => Promise.resolve({ repositories: [], dependencies: [] }),
+  runtime: { pluginsDir: "plugins", serverArgs: [], vanillaServerFiles: false },
 }));
 
 createPlatform(() => ({
@@ -52,6 +54,7 @@ createPlatform(() => ({
   getVersionInfo: () => Promise.resolve({ version: "1.0.0", build: 0 }),
   download: () => Promise.reject(new Error("not used")),
   api: () => Promise.resolve({ repositories: [], dependencies: [] }),
+  runtime: { pluginsDir: "plugins", serverArgs: [], vanillaServerFiles: false },
 }));
 
 function makeProject(platforms: string[]): ResolvedProject {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,10 +10,12 @@ import defaultConfig from "../defaults/config.yml" with { type: "text" };
 import bukkitPackage from "../defaults/bukkit-package.java" with { type: "text" };
 import velocityPackage from "../defaults/velocity-package.java" with { type: "text" };
 import bungeePackage from "../defaults/bungee-package.java" with { type: "text" };
+import spongePackage from "../defaults/sponge-package.java" with { type: "text" };
 
 import { writeIntellijStub } from "../build/intellij.ts";
 import { getPlatform, getRegisteredPlatforms, type PlatformFamily } from "../platform/index.ts";
 import { deriveVelocityId } from "../platform/descriptor/velocity.ts";
+import { deriveSpongeId } from "../platform/descriptor/sponge.ts";
 import { bold, dim, log } from "../logging.ts";
 import { writeFileLF } from "../portable.ts";
 import { getCurrentProject, type Project, resolveProjectFile } from "../project.ts";
@@ -98,6 +100,7 @@ export async function generateProject(
         className: main.split(".").pop() || "Main",
         packageName: main.split(".").slice(0, -1).join("."),
         velocityId: deriveVelocityId(project.name),
+        spongeId: deriveSpongeId(project.name),
       },
     };
 
@@ -159,6 +162,7 @@ function stubForFamily(family: PlatformFamily): string {
   if (family === "bukkit") return bukkitPackage;
   if (family === "velocity") return velocityPackage;
   if (family === "bungee") return bungeePackage;
+  if (family === "sponge") return spongePackage;
   // exhaustiveness: TS narrowed `family` to `never` if all branches handled.
   const _exhaustive: never = family;
   throw new Error(`No stub for platform family: ${String(_exhaustive)}`);
@@ -429,6 +433,7 @@ export function initCommand(): Command {
               className,
               packageName,
               velocityId: deriveVelocityId(INITIAL_PROJECT.name),
+              spongeId: deriveSpongeId(INITIAL_PROJECT.name),
               ...(apiVersion ? { apiVersion } : {}),
             },
           },

--- a/src/defaults/sponge-package.java
+++ b/src/defaults/sponge-package.java
@@ -1,0 +1,36 @@
+package ${project.packageName};
+
+import com.google.inject.Inject;
+
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+
+/**
+ * Main plugin class for ${project.name}
+ *
+ * Sponge constructs this class via Guice — the constructor's parameters are
+ * dependency-injected. {@code @Listener} methods on the plugin class are
+ * auto-registered against the plugin container. {@link ConstructPluginEvent}
+ * is the canonical startup hook; later lifecycle events
+ * ({@code StartedEngineEvent}, {@code StoppingEngineEvent}) hook engine
+ * start/stop.
+ */
+@Plugin("${project.spongeId}")
+public class ${project.className} {
+
+    private final Logger logger;
+
+    @Inject
+    public ${project.className}(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Listener
+    public void onConstructPlugin(final ConstructPluginEvent event) {
+        logger.info("${project.name} has been enabled!");
+
+        // TODO: register listeners and commands here
+    }
+}

--- a/src/dev/index.test.ts
+++ b/src/dev/index.test.ts
@@ -107,6 +107,7 @@ function fakePlatform(id = "paper"): PlatformProvider {
   return {
     id,
     descriptor: fakeDescriptor(),
+    runtime: { pluginsDir: "plugins", serverArgs: ["nogui"], vanillaServerFiles: true },
     getVersions: vi.fn(async () => ["1.21.8"]),
     getLatestVersion: vi.fn(async () => ({ version: "1.21.8", build: 42 }) as Version),
     getVersionInfo: vi.fn(async (v: string) => ({ version: v, build: 42 }) as Version),
@@ -191,8 +192,10 @@ describe("runDev", () => {
     expect(stageOptsArg.port).toBeUndefined();
 
     expect(stagePlugins).toHaveBeenCalledTimes(1);
-    const [devDirArg, ownJarArg, runtimeDepsArg, extrasArg] = vi.mocked(stagePlugins).mock.calls[0];
+    const [devDirArg, pluginsDirArg, ownJarArg, runtimeDepsArg, extrasArg] =
+      vi.mocked(stagePlugins).mock.calls[0];
     expect(devDirArg).toBe(devDirPath);
+    expect(pluginsDirArg).toBe("plugins");
     expect(ownJarArg).toBe(join(workDir, "bin", "testplugin-1.0.0.jar"));
     expect(runtimeDepsArg).toEqual([]);
     expect(extrasArg).toEqual([]);
@@ -281,7 +284,7 @@ describe("runDev", () => {
     });
     await runDev(project, { watch: false });
 
-    const runtimeDepsArg = vi.mocked(stagePlugins).mock.calls[0][2];
+    const runtimeDepsArg = vi.mocked(stagePlugins).mock.calls[0][3];
     expect(runtimeDepsArg).toHaveLength(1);
     expect(runtimeDepsArg[0].source.kind).toBe("modrinth");
   });
@@ -308,7 +311,7 @@ describe("runDev", () => {
     });
     await runDev(project, { watch: false });
 
-    const extras = vi.mocked(stagePlugins).mock.calls[0][3];
+    const extras = vi.mocked(stagePlugins).mock.calls[0][4];
     expect(extras).toEqual([
       join(workDir, "dev-plugins", "debug.jar"),
       join(workDir, "dev-plugins", "tools.jar"),

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -125,12 +125,19 @@ export async function runDev(project: ResolvedProject, opts: DevOptions): Promis
     freshWorld: opts.freshWorld,
     port: opts.port,
     onlineMode: opts.offline === true ? false : project.dev?.onlineMode,
+    vanillaServerFiles: platform.runtime.vanillaServerFiles,
   });
 
   const extraPluginsAbsolute = (project.dev?.extraPlugins ?? []).map((p) =>
     resolve(project.rootDir, p),
   );
-  await stagePlugins(devDir, buildResult.outputPath, runtimePluginDeps, extraPluginsAbsolute);
+  await stagePlugins(
+    devDir,
+    platform.runtime.pluginsDir,
+    buildResult.outputPath,
+    runtimePluginDeps,
+    extraPluginsAbsolute,
+  );
 
   const memory = opts.memory ?? project.dev?.memory ?? "2G";
   const userJvmArgs = opts.args ?? project.dev?.jvmArgs ?? [];
@@ -156,6 +163,7 @@ export async function runDev(project: ResolvedProject, opts: DevOptions): Promis
     serverJarName: "server.jar",
     memory,
     jvmArgs,
+    serverArgs: platform.runtime.serverArgs,
     javaPath,
   });
 
@@ -165,7 +173,7 @@ export async function runDev(project: ResolvedProject, opts: DevOptions): Promis
     hotswap.enabled === true ? startHotswap({ child }) : undefined;
 
   const pluginJarName = basename(buildResult.outputPath);
-  const pluginDest = join(devDir, "plugins", pluginJarName);
+  const pluginDest = join(devDir, ...platform.runtime.pluginsDir.split("/"), pluginJarName);
 
   let stopWatching: (() => void) | undefined;
 
@@ -193,6 +201,7 @@ export async function runDev(project: ResolvedProject, opts: DevOptions): Promis
         serverJarName: "server.jar",
         memory,
         jvmArgs,
+        serverArgs: platform.runtime.serverArgs,
         javaPath,
       });
       log.debug(`dev: server respawned (pid=${child.pid ?? "?"})`);

--- a/src/dev/plugins.test.ts
+++ b/src/dev/plugins.test.ts
@@ -130,7 +130,7 @@ describe("stagePlugins", () => {
       },
     ];
 
-    await stagePlugins(devDir, ownJar, runtimeDeps, [extra]);
+    await stagePlugins(devDir, "plugins", ownJar, runtimeDeps, [extra]);
 
     const names = (await readdir(join(devDir, "plugins"))).sort();
     expect(names).toEqual([
@@ -149,7 +149,7 @@ describe("stagePlugins", () => {
     const ownJar = join(workDir, "plugin.jar");
     await writeFile(ownJar, "OWN");
 
-    await stagePlugins(devDir, ownJar, [], []);
+    await stagePlugins(devDir, "plugins", ownJar, [], []);
 
     const names = await readdir(join(devDir, "plugins"));
     expect(names).toEqual(["plugin.jar"]);
@@ -164,7 +164,20 @@ describe("stagePlugins", () => {
     await mkdir(join(devDir, "plugins"), { recursive: true });
     await writeFile(join(devDir, "plugins", "plugin.jar"), "OLD");
 
-    await stagePlugins(devDir, ownJar, [], []);
+    await stagePlugins(devDir, "plugins", ownJar, [], []);
     expect(await readFile(join(devDir, "plugins", "plugin.jar"), "utf8")).toBe("NEW-OWN");
+  });
+
+  test("stages into a nested pluginsDir (sponge mods/plugins) and creates parents", async () => {
+    const ownJar = join(workDir, "sponge-plugin.jar");
+    await writeFile(ownJar, "SPONGE");
+
+    await stagePlugins(devDir, "mods/plugins", ownJar, [], []);
+
+    const names = await readdir(join(devDir, "mods", "plugins"));
+    expect(names).toEqual(["sponge-plugin.jar"]);
+    expect(await readFile(join(devDir, "mods", "plugins", "sponge-plugin.jar"), "utf8")).toBe(
+      "SPONGE",
+    );
   });
 });

--- a/src/dev/plugins.ts
+++ b/src/dev/plugins.ts
@@ -55,26 +55,30 @@ export function isRuntimePlugin(jarPath: string, descriptor: DescriptorSpec): Pr
 }
 
 /**
- * Populate `<devDir>/plugins/` with the user's plugin jar, every runtime-
- * plugin dep, and the `extraPlugins` jars. Each is hardlinked (copy
- * fallback) under its basename — callers must ensure unique names.
+ * Populate `<devDir>/<pluginsDir>/` with the user's plugin jar, every
+ * runtime-plugin dep, and the `extraPlugins` jars. `pluginsDir` is the
+ * platform's `runtime.pluginsDir` (e.g. `"plugins"` for bukkit,
+ * `"mods/plugins"` for sponge) — forward-slashed and resolved relative to
+ * `devDir`. Each jar is hardlinked (copy fallback) under its basename;
+ * callers must ensure unique names.
  */
 export async function stagePlugins(
   devDir: string,
+  pluginsDir: string,
   ownJarPath: string,
   runtimeDeps: ResolvedDependency[],
   extraPlugins: string[],
 ): Promise<void> {
-  const pluginsDir = join(devDir, "plugins");
-  await mkdir(pluginsDir, { recursive: true });
+  const dest = join(devDir, ...pluginsDir.split("/"));
+  await mkdir(dest, { recursive: true });
 
-  await linkOrCopy(ownJarPath, join(pluginsDir, basename(ownJarPath)));
+  await linkOrCopy(ownJarPath, join(dest, basename(ownJarPath)));
 
   for (const dep of runtimeDeps) {
-    await linkOrCopy(dep.jarPath, join(pluginsDir, basename(dep.jarPath)));
+    await linkOrCopy(dep.jarPath, join(dest, basename(dep.jarPath)));
   }
 
   for (const extra of extraPlugins) {
-    await linkOrCopy(extra, join(pluginsDir, basename(extra)));
+    await linkOrCopy(extra, join(dest, basename(extra)));
   }
 }

--- a/src/dev/spawn.test.ts
+++ b/src/dev/spawn.test.ts
@@ -57,7 +57,7 @@ describe("spawnServer", () => {
     vi.restoreAllMocks();
   });
 
-  test("invokes `java -Xmx… jvmArgs -jar server.jar nogui` with cwd=devDir, stdin piped", () => {
+  test("invokes `java -Xmx… jvmArgs -jar server.jar <serverArgs>` with cwd=devDir, stdin piped", () => {
     const fake = makeFakeChild();
     vi.mocked(spawn).mockReturnValue(fake as unknown as ReturnType<typeof spawn>);
 
@@ -66,6 +66,7 @@ describe("spawnServer", () => {
       serverJarName: "server.jar",
       memory: "2G",
       jvmArgs: ["-XX:+UseG1GC", "-XX:+ParallelRefProcEnabled"],
+      serverArgs: ["nogui"],
     });
 
     expect(spawn).toHaveBeenCalledTimes(1);
@@ -96,6 +97,7 @@ describe("spawnServer", () => {
       serverJarName: "server.jar",
       memory: "1G",
       jvmArgs: [],
+      serverArgs: ["nogui"],
     });
 
     expect(installShutdownHandler).toHaveBeenCalledTimes(1);
@@ -117,6 +119,7 @@ describe("spawnServer", () => {
       serverJarName: "server.jar",
       memory: "1G",
       jvmArgs: [],
+      serverArgs: ["nogui"],
     });
 
     expect(dispose).not.toHaveBeenCalled();
@@ -133,13 +136,14 @@ describe("spawnServer", () => {
       serverJarName: "server.jar",
       memory: "512M",
       jvmArgs: [],
+      serverArgs: ["nogui"],
     });
 
     const args = vi.mocked(spawn).mock.calls[0][1] as string[];
     expect(args[0]).toBe("-Xmx512M");
   });
 
-  test("serverJarName sits between -jar and the trailing `nogui`", () => {
+  test("serverJarName sits between -jar and the trailing serverArgs", () => {
     const fake = makeFakeChild();
     vi.mocked(spawn).mockReturnValue(fake as unknown as ReturnType<typeof spawn>);
 
@@ -148,11 +152,44 @@ describe("spawnServer", () => {
       serverJarName: "paperclip-1.21.8.jar",
       memory: "4G",
       jvmArgs: ["-Dfoo=bar"],
+      serverArgs: ["nogui"],
     });
 
     const args = vi.mocked(spawn).mock.calls[0][1] as string[];
     expect(args[args.length - 3]).toBe("-jar");
     expect(args[args.length - 2]).toBe("paperclip-1.21.8.jar");
     expect(args[args.length - 1]).toBe("nogui");
+  });
+
+  test("serverArgs are appended verbatim — empty array means no trailing args (proxies)", () => {
+    const fake = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(fake as unknown as ReturnType<typeof spawn>);
+
+    spawnServer({
+      devDir: "/tmp/dev",
+      serverJarName: "velocity.jar",
+      memory: "1G",
+      jvmArgs: [],
+      serverArgs: [],
+    });
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(args).toEqual(["-Xmx1G", "-jar", "velocity.jar"]);
+  });
+
+  test("serverArgs supports multi-value lists (e.g. sponge --nogui)", () => {
+    const fake = makeFakeChild();
+    vi.mocked(spawn).mockReturnValue(fake as unknown as ReturnType<typeof spawn>);
+
+    spawnServer({
+      devDir: "/tmp/dev",
+      serverJarName: "spongevanilla.jar",
+      memory: "2G",
+      jvmArgs: [],
+      serverArgs: ["--nogui"],
+    });
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[];
+    expect(args).toEqual(["-Xmx2G", "-jar", "spongevanilla.jar", "--nogui"]);
   });
 });

--- a/src/dev/spawn.ts
+++ b/src/dev/spawn.ts
@@ -17,6 +17,12 @@ export interface SpawnServerOptions {
   /** Caller-supplied JVM flags. `-javaagent:` etc. go here. */
   jvmArgs: string[];
   /**
+   * Args appended after `-jar <serverJar>`. Comes from the platform's
+   * `runtime.serverArgs` — `["nogui"]` for bukkit-family, `["--nogui"]`
+   * for sponge (ModLauncher), `[]` for velocity/bungee proxies.
+   */
+  serverArgs: string[];
+  /**
    * Absolute path to the `java` binary to launch. Defaults to "java" on
    * PATH; the dev loop overrides this with a JBR-resolved path when hotswap
    * is enabled.
@@ -25,12 +31,18 @@ export interface SpawnServerOptions {
 }
 
 /**
- * Spawn `<javaPath> -Xmx<memory> <jvmArgs> -jar <serverJar> nogui` inside
- * `devDir`. `nogui` suppresses Bukkit's AWT console window on desktop JVMs.
- * Installs a SIGINT handler that is disposed automatically on child exit.
+ * Spawn `<javaPath> -Xmx<memory> <jvmArgs> -jar <serverJar> <serverArgs>`
+ * inside `devDir`. Installs a SIGINT handler that is disposed automatically
+ * on child exit.
  */
 export function spawnServer(opts: SpawnServerOptions): ChildProcess {
-  const argv = [`-Xmx${opts.memory}`, ...opts.jvmArgs, "-jar", opts.serverJarName, "nogui"];
+  const argv = [
+    `-Xmx${opts.memory}`,
+    ...opts.jvmArgs,
+    "-jar",
+    opts.serverJarName,
+    ...opts.serverArgs,
+  ];
 
   const child = spawn(opts.javaPath ?? "java", argv, {
     cwd: opts.devDir,

--- a/src/dev/stage.test.ts
+++ b/src/dev/stage.test.ts
@@ -48,7 +48,7 @@ describe("stageDev", () => {
   test("creates dev/ with server.jar, eula.txt, server.properties", async () => {
     const project = makeProject(workDir);
 
-    const devDir = await stageDev(project, serverJar, {});
+    const devDir = await stageDev(project, serverJar, { vanillaServerFiles: true });
     expect(devDir).toBe(join(workDir, "dev"));
 
     const linkedBytes = await readFile(join(devDir, "server.jar"), "utf8");
@@ -69,7 +69,7 @@ describe("stageDev", () => {
   test("PLUGGY_DEV_NO_EULA=1 skips writing eula.txt", async () => {
     process.env.PLUGGY_DEV_NO_EULA = "1";
     const project = makeProject(workDir);
-    const devDir = await stageDev(project, serverJar, {});
+    const devDir = await stageDev(project, serverJar, { vanillaServerFiles: true });
 
     await stat(join(devDir, "server.properties"));
     await expect(stat(join(devDir, "eula.txt"))).rejects.toThrow();
@@ -78,7 +78,7 @@ describe("stageDev", () => {
   test("opts.port overrides project.dev.port and the default", async () => {
     const project = makeProject(workDir, { dev: { port: 30000 } });
 
-    const devDir = await stageDev(project, serverJar, { port: 25570 });
+    const devDir = await stageDev(project, serverJar, { port: 25570, vanillaServerFiles: true });
     const props = await readFile(join(devDir, "server.properties"), "utf8");
     expect(props).toContain("server-port=25570");
     expect(props).not.toContain("server-port=30000");
@@ -96,7 +96,7 @@ describe("stageDev", () => {
       },
     });
 
-    const devDir = await stageDev(project, serverJar, {});
+    const devDir = await stageDev(project, serverJar, { vanillaServerFiles: true });
     const props = await readFile(join(devDir, "server.properties"), "utf8");
     expect(props).toContain("motd=custom");
     expect(props).not.toContain("motd=testplugin dev");
@@ -111,7 +111,7 @@ describe("stageDev", () => {
     await writeFile(join(devDir, "leftover.txt"), "bye");
 
     const project = makeProject(workDir);
-    await stageDev(project, serverJar, { clean: true });
+    await stageDev(project, serverJar, { clean: true, vanillaServerFiles: true });
 
     await expect(stat(join(devDir, "world"))).rejects.toThrow();
     await expect(stat(join(devDir, "leftover.txt"))).rejects.toThrow();
@@ -129,7 +129,7 @@ describe("stageDev", () => {
     await writeFile(join(devDir, "logs.txt"), "keep-me");
 
     const project = makeProject(workDir);
-    await stageDev(project, serverJar, { freshWorld: true });
+    await stageDev(project, serverJar, { freshWorld: true, vanillaServerFiles: true });
 
     await expect(stat(join(devDir, "world"))).rejects.toThrow();
     await expect(stat(join(devDir, "world_nether"))).rejects.toThrow();
@@ -142,15 +142,27 @@ describe("stageDev", () => {
 
   test("onlineMode option overrides project.dev.onlineMode", async () => {
     const project = makeProject(workDir, { dev: { onlineMode: true } });
-    const devDir = await stageDev(project, serverJar, { onlineMode: false });
+    const devDir = await stageDev(project, serverJar, {
+      onlineMode: false,
+      vanillaServerFiles: true,
+    });
     const props = await readFile(join(devDir, "server.properties"), "utf8");
     expect(props).toContain("online-mode=false");
   });
 
   test("server.properties is LF only", async () => {
     const project = makeProject(workDir);
-    const devDir = await stageDev(project, serverJar, {});
+    const devDir = await stageDev(project, serverJar, { vanillaServerFiles: true });
     const raw = await readFile(join(devDir, "server.properties"));
     expect(raw.includes(Buffer.from("\r\n"))).toBe(false);
+  });
+
+  test("vanillaServerFiles=false skips eula.txt and server.properties (proxies)", async () => {
+    const project = makeProject(workDir);
+    const devDir = await stageDev(project, serverJar, { vanillaServerFiles: false });
+
+    await stat(join(devDir, "server.jar"));
+    await expect(stat(join(devDir, "eula.txt"))).rejects.toThrow();
+    await expect(stat(join(devDir, "server.properties"))).rejects.toThrow();
   });
 });

--- a/src/dev/stage.ts
+++ b/src/dev/stage.ts
@@ -24,6 +24,13 @@ export interface StageDevOptions {
   port?: number;
   /** Force online mode one way or another. Overrides `project.dev.onlineMode`. */
   onlineMode?: boolean;
+  /**
+   * Whether the platform runtime expects vanilla MC server files. When
+   * `true` (paper/folia/spigot/bukkit/sponge) `eula.txt` and
+   * `server.properties` are written; when `false` (velocity/bungee) both
+   * are skipped — proxies don't read them.
+   */
+  vanillaServerFiles: boolean;
 }
 
 const EULA_HEADER =
@@ -57,12 +64,14 @@ export async function stageDev(
   const serverJar = join(devDir, "server.jar");
   await linkOrCopy(platformJarPath, serverJar);
 
-  if (process.env.PLUGGY_DEV_NO_EULA !== "1") {
-    await writeFileLF(join(devDir, "eula.txt"), `${EULA_HEADER}eula=true\n`);
-  }
+  if (opts.vanillaServerFiles) {
+    if (process.env.PLUGGY_DEV_NO_EULA !== "1") {
+      await writeFileLF(join(devDir, "eula.txt"), `${EULA_HEADER}eula=true\n`);
+    }
 
-  const serverProperties = renderServerProperties(project, opts);
-  await writeFileLF(join(devDir, "server.properties"), serverProperties);
+    const serverProperties = renderServerProperties(project, opts);
+    await writeFileLF(join(devDir, "server.properties"), serverProperties);
+  }
 
   return devDir;
 }

--- a/src/platform/descriptor/sponge.test.ts
+++ b/src/platform/descriptor/sponge.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Contract tests for the Sponge Plugin Metadata generator. Output is JSON,
+ * so tests parse with `JSON.parse` and assert on shape.
+ */
+
+import { describe, expect, test } from "vite-plus/test";
+
+import type { ResolvedProject } from "../../project.ts";
+
+import { deriveSpongeId, spongeDescriptor } from "./sponge.ts";
+
+function project(overrides: Partial<ResolvedProject> = {}): ResolvedProject {
+  return {
+    name: "myplugin",
+    version: "1.0.0",
+    main: "com.example.MyPlugin",
+    compatibility: { versions: ["1.21.8"], platforms: ["sponge"] },
+    rootDir: "/tmp/project",
+    projectFile: "/tmp/project/project.json",
+    ...overrides,
+  };
+}
+
+describe("spongeDescriptor.generate", () => {
+  test("emits required fields for a minimal project", () => {
+    const output = spongeDescriptor.generate(project());
+    const parsed = JSON.parse(output);
+
+    expect(parsed.loader).toEqual({ name: "java_plain", version: "1.0" });
+    expect(parsed.license).toBe("All Rights Reserved");
+    expect(parsed.global).toEqual({ version: "1.0.0" });
+    expect(parsed.plugins).toHaveLength(1);
+    expect(parsed.plugins[0]).toMatchObject({
+      id: "myplugin",
+      name: "myplugin",
+      entrypoint: "com.example.MyPlugin",
+    });
+    expect(parsed.plugins[0].description).toBeUndefined();
+    expect(parsed.plugins[0].contributors).toBeUndefined();
+    expect(output.endsWith("\n")).toBe(true);
+  });
+
+  test("emits description and contributors when present", () => {
+    const output = spongeDescriptor.generate(
+      project({ description: "A sponge plugin.", authors: ["Alice", "Bob"] }),
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.plugins[0].description).toBe("A sponge plugin.");
+    expect(parsed.plugins[0].contributors).toEqual([{ name: "Alice" }, { name: "Bob" }]);
+  });
+
+  test("throws when main is missing", () => {
+    expect(() => spongeDescriptor.generate(project({ main: undefined }))).toThrow(
+      "Sponge descriptor requires project.main",
+    );
+  });
+
+  test("descriptor path is META-INF/sponge_plugins.json", () => {
+    expect(spongeDescriptor.path).toBe("META-INF/sponge_plugins.json");
+  });
+
+  test("uses LF line endings only", () => {
+    const output = spongeDescriptor.generate(project({ description: "x", authors: ["A"] }));
+    expect(output.split("\r\n").length).toBe(1);
+  });
+
+  test("output is valid JSON", () => {
+    const output = spongeDescriptor.generate(project({ authors: ["A"] }));
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+});
+
+describe("deriveSpongeId", () => {
+  test("lowercases a plain name", () => {
+    expect(deriveSpongeId("MyPlugin")).toBe("myplugin");
+  });
+
+  test("replaces disallowed characters with hyphens", () => {
+    expect(deriveSpongeId("My Plugin!")).toBe("my-plugin-");
+  });
+
+  test("keeps hyphens and underscores as-is", () => {
+    expect(deriveSpongeId("my_cool-plugin")).toBe("my_cool-plugin");
+  });
+
+  test("prefixes with 'p-' when the result starts with a digit", () => {
+    expect(deriveSpongeId("1plugin")).toBe("p-1plugin");
+  });
+
+  test("truncates to 64 characters", () => {
+    const long = "a".repeat(100);
+    expect(deriveSpongeId(long).length).toBeLessThanOrEqual(64);
+  });
+
+  test("pads single-character names so id is at least 2 characters", () => {
+    expect(deriveSpongeId("x").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/platform/descriptor/sponge.ts
+++ b/src/platform/descriptor/sponge.ts
@@ -1,0 +1,64 @@
+import type { DescriptorSpec } from "../platform.ts";
+
+/**
+ * Sponge plugin metadata descriptor → `META-INF/sponge_plugins.json`.
+ *
+ * Targets the modern SpongeAPI 8+ Plugin Metadata format with the built-in
+ * `java_plain` loader: one entry under `plugins[]`, `entrypoint` set to the
+ * fully-qualified main class. Annotation-driven discovery isn't required
+ * with `java_plain`, so the user can ship without the Sponge AP on their
+ * compile classpath.
+ *
+ * See: https://docs.spongepowered.org/stable/en/plugin/plugin-meta.html
+ */
+export const spongeDescriptor: DescriptorSpec = {
+  path: "META-INF/sponge_plugins.json",
+  format: "json",
+  family: "sponge",
+  generate(project) {
+    if (!project.main) {
+      throw new Error("Sponge descriptor requires project.main");
+    }
+
+    const plugin: Record<string, unknown> = {
+      id: deriveSpongeId(project.name),
+      name: project.name,
+      entrypoint: project.main,
+    };
+
+    if (project.description && project.description.length > 0) {
+      plugin.description = project.description;
+    }
+
+    if (project.authors && project.authors.length > 0) {
+      plugin.contributors = project.authors.map((name) => ({ name }));
+    }
+
+    const descriptor = {
+      loader: { name: "java_plain", version: "1.0" },
+      license: "All Rights Reserved",
+      global: { version: project.version },
+      plugins: [plugin],
+    };
+
+    return `${JSON.stringify(descriptor, null, 2)}\n`;
+  },
+};
+
+/**
+ * Derive a Sponge plugin `id` from `project.name`. Sponge ids must match
+ * `^[a-z][a-z0-9-_]{1,63}$` (start with a letter, 2 – 64 chars). We
+ * lowercase, substitute disallowed characters with `-`, prefix `p-` if the
+ * result doesn't start with a letter, and truncate to 64 chars.
+ */
+export function deriveSpongeId(name: string): string {
+  const lowered = name.toLowerCase();
+  let normalized = lowered.replace(/[^a-z0-9_-]/g, "-");
+  if (!/^[a-z]/.test(normalized)) {
+    normalized = `p-${normalized}`;
+  }
+  if (normalized.length < 2) {
+    normalized = `${normalized}-plugin`;
+  }
+  return normalized.slice(0, 64);
+}

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -8,3 +8,4 @@ import "./papermc/folia.ts";
 import "./papermc/travertine.ts";
 import "./papermc/velocity.ts";
 import "./papermc/waterfall.ts";
+import "./sponge/sponge.ts";

--- a/src/platform/papermc/folia.ts
+++ b/src/platform/papermc/folia.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 
 import { bukkitDescriptor } from "../descriptor/bukkit.ts";
 import { createPlatform, type Version } from "../platform.ts";
+import { BUKKIT_RUNTIME } from "../runtime.ts";
 import * as papermc from "./papermc.ts";
 
 export default createPlatform((ctx) => ({
   id: "folia",
   descriptor: bukkitDescriptor,
+  runtime: BUKKIT_RUNTIME,
 
   async getVersionInfo(version: string): Promise<Version> {
     const versionsList = await papermc.versions("folia");

--- a/src/platform/papermc/paper.ts
+++ b/src/platform/papermc/paper.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { bukkitDescriptor } from "../descriptor/bukkit.ts";
 import { createPlatform, type Version } from "../platform.ts";
+import { BUKKIT_RUNTIME } from "../runtime.ts";
 import * as papermc from "./papermc.ts";
 
 const PAPER_MAVEN_METADATA =
@@ -47,6 +48,7 @@ function buildNumber(versionString: string): number {
 export default createPlatform((ctx) => ({
   id: "paper",
   descriptor: bukkitDescriptor,
+  runtime: BUKKIT_RUNTIME,
 
   async getVersionInfo(version: string): Promise<Version> {
     const versionsList = await papermc.versions("paper");

--- a/src/platform/papermc/travertine.ts
+++ b/src/platform/papermc/travertine.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 
 import { bungeeDescriptor } from "../descriptor/bungee.ts";
 import { createPlatform, type Version } from "../platform.ts";
+import { BUNGEE_RUNTIME } from "../runtime.ts";
 import * as papermc from "./papermc.ts";
 
 export default createPlatform((ctx) => ({
   id: "travertine",
   descriptor: bungeeDescriptor,
+  runtime: BUNGEE_RUNTIME,
 
   async getVersionInfo(version: string): Promise<Version> {
     const versionsList = await papermc.versions("travertine");

--- a/src/platform/papermc/velocity.ts
+++ b/src/platform/papermc/velocity.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { velocityDescriptor } from "../descriptor/velocity.ts";
 import { createPlatform, type Version } from "../platform.ts";
+import { VELOCITY_RUNTIME } from "../runtime.ts";
 import * as papermc from "./papermc.ts";
 
 /**
@@ -25,6 +26,7 @@ async function latestVelocityRelease(): Promise<{ id: string; build: number }> {
 export default createPlatform((ctx) => ({
   id: "velocity",
   descriptor: velocityDescriptor,
+  runtime: VELOCITY_RUNTIME,
 
   async getVersions(): Promise<string[]> {
     const mc = await papermc.versions("paper");

--- a/src/platform/papermc/waterfall.ts
+++ b/src/platform/papermc/waterfall.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 
 import { bungeeDescriptor } from "../descriptor/bungee.ts";
 import { createPlatform, type Version } from "../platform.ts";
+import { BUNGEE_RUNTIME } from "../runtime.ts";
 import * as papermc from "./papermc.ts";
 
 export default createPlatform((ctx) => ({
   id: "waterfall",
   descriptor: bungeeDescriptor,
+  runtime: BUNGEE_RUNTIME,
 
   async getVersionInfo(version: string): Promise<Version> {
     const versionsList = await papermc.versions("waterfall");

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -21,11 +21,11 @@ export interface MavenAPI {
 
 /**
  * Family of plugin platforms that share a runtime API: bukkit-derivatives
- * (paper/folia/spigot/bukkit), velocity proxies, or bungee proxies. Used by
- * the scaffolder + template selector to pick a stub class that actually
- * compiles against the chosen platform.
+ * (paper/folia/spigot/bukkit), velocity proxies, bungee proxies, or sponge
+ * (SpongeVanilla + SpongeAPI). Used by the scaffolder + template selector to
+ * pick a stub class that actually compiles against the chosen platform.
  */
-export type PlatformFamily = "bukkit" | "velocity" | "bungee";
+export type PlatformFamily = "bukkit" | "velocity" | "bungee" | "sponge";
 
 /** How a plugin descriptor is serialized into the final jar. */
 export interface DescriptorSpec {
@@ -37,10 +37,39 @@ export interface DescriptorSpec {
   generate(project: ResolvedProject): string;
 }
 
+/**
+ * Per-platform runtime layout. Tells `pluggy dev` how to stage the working
+ * directory and how to invoke the server jar — without it, dev would have
+ * to special-case every family.
+ */
+export interface RuntimeLayout {
+  /**
+   * Path under `dev/` where plugin jars are dropped. Forward-slashed,
+   * relative to the dev directory. Bukkit-family servers use `"plugins"`,
+   * SpongeVanilla 8+ uses `"mods/plugins"` (its launcher's default
+   * `additional-plugins-directory`), proxies use `"plugins"`.
+   */
+  pluginsDir: string;
+  /**
+   * Arguments appended after `-jar server.jar`. The Mojang vanilla server
+   * jar accepts the positional `nogui`; SpongeVanilla goes through
+   * ModLauncher and expects `--nogui`; Velocity and Bungee accept neither.
+   */
+  serverArgs: string[];
+  /**
+   * Whether the server reads `eula.txt` and `server.properties` from its
+   * working directory. Vanilla MC wrappers (paper/folia/spigot/bukkit/sponge)
+   * do; standalone proxies (velocity/bungee) ignore both.
+   */
+  vanillaServerFiles: boolean;
+}
+
 /** Contract each platform (paper, spigot, ...) implements. */
 export interface PlatformProvider {
   id: string;
   descriptor: DescriptorSpec;
+  /** Layout + invocation hints used by `pluggy dev`. */
+  runtime: RuntimeLayout;
 
   getVersions(): Promise<string[]>;
   getLatestVersion(): Promise<Version>;

--- a/src/platform/runtime.ts
+++ b/src/platform/runtime.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-family runtime layouts. Centralising these keeps the eight platform
+ * providers consistent — every bukkit-derived server stages plugins the
+ * same way, every proxy skips the vanilla server files, and so on.
+ *
+ * Override at the provider level if a specific platform needs different
+ * values (none do today).
+ */
+
+import type { RuntimeLayout } from "./platform.ts";
+
+/** Vanilla MC + bukkit-style descriptor: paper, folia, spigot, bukkit. */
+export const BUKKIT_RUNTIME: RuntimeLayout = {
+  pluginsDir: "plugins",
+  serverArgs: ["nogui"],
+  vanillaServerFiles: true,
+};
+
+/** Standalone proxy, no MC server: velocity. */
+export const VELOCITY_RUNTIME: RuntimeLayout = {
+  pluginsDir: "plugins",
+  serverArgs: [],
+  vanillaServerFiles: false,
+};
+
+/** Standalone proxy, no MC server: waterfall, travertine. */
+export const BUNGEE_RUNTIME: RuntimeLayout = {
+  pluginsDir: "plugins",
+  serverArgs: [],
+  vanillaServerFiles: false,
+};
+
+/**
+ * SpongeVanilla wraps the Mojang server jar through ModLauncher: vanilla
+ * server files apply, but plugins go in `mods/plugins` (Sponge's launcher
+ * default `additional-plugins-directory`) and the launcher expects the
+ * `--nogui` long form rather than the bukkit positional `nogui`.
+ */
+export const SPONGE_RUNTIME: RuntimeLayout = {
+  pluginsDir: "mods/plugins",
+  serverArgs: ["--nogui"],
+  vanillaServerFiles: true,
+};

--- a/src/platform/spigot/bukkit.ts
+++ b/src/platform/spigot/bukkit.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 
 import { bukkitDescriptor } from "../descriptor/bukkit.ts";
 import { createPlatform } from "../platform.ts";
+import { BUKKIT_RUNTIME } from "../runtime.ts";
 import { compile, versions, VERSIONS_URL } from "./buildtools.ts";
 
 export default createPlatform((ctx) => ({
   id: "bukkit",
   descriptor: bukkitDescriptor,
+  runtime: BUKKIT_RUNTIME,
 
   async getVersionInfo(version: string) {
     const res = await fetch(`${VERSIONS_URL}${version}.json`);

--- a/src/platform/spigot/spigot.ts
+++ b/src/platform/spigot/spigot.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 
 import { bukkitDescriptor } from "../descriptor/bukkit.ts";
 import { createPlatform } from "../platform.ts";
+import { BUKKIT_RUNTIME } from "../runtime.ts";
 import { compile, versions, VERSIONS_URL } from "./buildtools.ts";
 
 export default createPlatform((ctx) => ({
   id: "spigot",
   descriptor: bukkitDescriptor,
+  runtime: BUKKIT_RUNTIME,
 
   async getVersionInfo(version: string) {
     const res = await fetch(`${VERSIONS_URL}${version}.json`);

--- a/src/platform/sponge/sponge.test.ts
+++ b/src/platform/sponge/sponge.test.ts
@@ -1,0 +1,52 @@
+import process from "node:process";
+
+import { expect, test } from "vite-plus/test";
+
+import { getPlatform } from "../index.ts";
+
+// sponge.download streams the SpongeVanilla universal jar (~30 MB+) over the
+// network. Gated behind PLUGGY_INTEGRATION=1 to keep CI fast.
+const integration = process.env.PLUGGY_INTEGRATION === "1";
+
+test("sponge platform exists", () => {
+  expect(getPlatform("sponge").id).toBe("sponge");
+  expect(getPlatform("Sponge").id).toBe("sponge");
+  expect(() => getPlatform("@Sponge")).toThrow("Platform with id '@Sponge' not found");
+});
+
+test("sponge platform versions surface stable MC versions", async () => {
+  const sponge = getPlatform("sponge");
+  const versions = await sponge.getVersions();
+  expect(Array.isArray(versions)).toBe(true);
+  expect(versions.length).toBeGreaterThan(0);
+  expect(versions.every((v) => /^\d+(\.\d+)+/.test(v))).toBe(true);
+  expect(versions.some((v) => v.includes("snapshot"))).toBe(false);
+  expect(versions.some((v) => v.includes("pre"))).toBe(false);
+});
+
+test("sponge api coordinate resolves to a SpongeAPI release, not the MC input", async () => {
+  const sponge = getPlatform("sponge");
+  const latest = await sponge.getLatestVersion();
+  const api = await sponge.api(latest.version);
+
+  expect(api.repositories).toEqual(
+    expect.arrayContaining(["https://repo.spongepowered.org/repository/maven-public/"]),
+  );
+  expect(api.dependencies).toHaveLength(1);
+  const [dep] = api.dependencies;
+  expect(dep.groupId).toBe("org.spongepowered");
+  expect(dep.artifactId).toBe("spongeapi");
+  expect(dep.version).not.toBe(latest.version);
+  expect(dep.version).toMatch(/^\d+\.\d+\.\d+/);
+});
+
+test.runIf(integration)("sponge platform download latest version", async () => {
+  const sponge = getPlatform("sponge");
+  const latestVersion = await sponge.getLatestVersion();
+  const result = await sponge.download(latestVersion, true);
+
+  expect(result?.version).toBe(latestVersion.version);
+  expect(result?.build).toBe(latestVersion.build);
+  expect(result?.output instanceof Uint8Array).toBe(true);
+  expect(result?.output.length).toBeGreaterThan(0);
+});

--- a/src/platform/sponge/sponge.ts
+++ b/src/platform/sponge/sponge.ts
@@ -1,0 +1,218 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { spongeDescriptor } from "../descriptor/sponge.ts";
+import { createPlatform, type Version } from "../platform.ts";
+import { SPONGE_RUNTIME } from "../runtime.ts";
+
+/**
+ * SpongeVanilla — the standalone server flavour of Sponge. (SpongeForge and
+ * SpongeNeo are mod-loader variants and live on top of Forge/NeoForge; pluggy
+ * doesn't model modding, so they're intentionally out of scope.)
+ *
+ * Versioning is two-axis: every SpongeVanilla artifact carries both a
+ * Minecraft version and a SpongeAPI version. The artifact key encodes both
+ * (`<mc>-<api>-RC<n>`), and the dl-api exposes them via `tagValues`. Pluggy's
+ * `compatibility.versions` is always Minecraft, so this provider surfaces
+ * MC versions and resolves the matching SpongeAPI/SpongeVanilla artifact
+ * internally — same pattern as the velocity provider.
+ */
+
+const ARTIFACT_BASE =
+  "https://dl-api.spongepowered.org/v2/groups/org.spongepowered/artifacts/spongevanilla";
+const SPONGE_REPO = "https://repo.spongepowered.org/repository/maven-public/";
+
+interface ArtifactSummary {
+  recommended: boolean;
+  tagValues: { api: string; minecraft: string };
+}
+
+interface VersionsResponse {
+  artifacts: Record<string, ArtifactSummary>;
+  offset: number;
+  limit: number;
+  size: number;
+}
+
+interface ArtifactMetadata {
+  tags?: { minecraft?: string[]; api?: string[] };
+}
+
+interface Asset {
+  classifier?: string;
+  extension: string;
+  downloadUrl: string;
+}
+
+interface VersionDetail {
+  assets: Asset[];
+}
+
+/** Version key produced by the Sponge dl-api, e.g. `1.21.8-12.0.0-RC2627`. */
+interface ResolvedArtifact {
+  key: string;
+  api: string;
+  minecraft: string;
+  build: number;
+}
+
+/** Pull `RC<n>` off the end of a version key. Stable releases have no RC. */
+function buildOf(key: string): number {
+  const match = key.match(/-RC(\d+)$/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+function isStableMc(mc: string): boolean {
+  return !mc.includes("snapshot") && !mc.includes("pre") && /^\d+(\.\d+)+/.test(mc);
+}
+
+/**
+ * Walk the dl-api versions endpoint newest-first and yield artifacts that
+ * pass `predicate`, stopping once `limit` matches are collected or the
+ * dataset is exhausted. The artifact list runs into the thousands, so the
+ * scanner pages and bails early — never fetching more than it needs.
+ */
+async function findArtifacts(
+  predicate: (a: ResolvedArtifact) => boolean,
+  limit: number,
+): Promise<ResolvedArtifact[]> {
+  const results: ResolvedArtifact[] = [];
+  const PAGE = 100;
+  let offset = 0;
+  let total = Infinity;
+
+  while (results.length < limit && offset < total) {
+    const res = await fetch(`${ARTIFACT_BASE}/versions?limit=${PAGE}&offset=${offset}`);
+    if (!res.ok) {
+      throw new Error(`Failed to list spongevanilla versions: ${res.statusText}`);
+    }
+    const data = (await res.json()) as VersionsResponse;
+    total = data.size;
+
+    for (const [key, summary] of Object.entries(data.artifacts)) {
+      const artifact: ResolvedArtifact = {
+        key,
+        api: summary.tagValues.api,
+        minecraft: summary.tagValues.minecraft,
+        build: buildOf(key),
+      };
+      if (predicate(artifact)) {
+        results.push(artifact);
+        if (results.length >= limit) break;
+      }
+    }
+
+    offset += PAGE;
+  }
+
+  return results;
+}
+
+async function findArtifactByMcAndBuild(
+  mcVersion: string,
+  build: number,
+): Promise<ResolvedArtifact> {
+  const matches = await findArtifacts((a) => a.minecraft === mcVersion && a.build === build, 1);
+  if (matches.length === 0) {
+    throw new Error(`No SpongeVanilla artifact for MC ${mcVersion} build ${build}`);
+  }
+  return matches[0];
+}
+
+async function findLatestArtifactForMc(mcVersion: string): Promise<ResolvedArtifact> {
+  const matches = await findArtifacts(
+    (a) => a.minecraft === mcVersion && isStableMc(a.minecraft),
+    1,
+  );
+  if (matches.length === 0) {
+    throw new Error(`No SpongeVanilla artifact found for MC ${mcVersion}`);
+  }
+  return matches[0];
+}
+
+export default createPlatform((ctx) => ({
+  id: "sponge",
+  descriptor: spongeDescriptor,
+  runtime: SPONGE_RUNTIME,
+
+  async getVersions(): Promise<string[]> {
+    const res = await fetch(ARTIFACT_BASE);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch spongevanilla metadata: ${res.statusText}`);
+    }
+    const data = (await res.json()) as ArtifactMetadata;
+    const mcs = data.tags?.minecraft ?? [];
+    return mcs.filter(isStableMc);
+  },
+
+  async getVersionInfo(mcVersion: string): Promise<Version> {
+    const artifact = await findLatestArtifactForMc(mcVersion);
+    return { version: artifact.minecraft, build: artifact.build };
+  },
+
+  async getLatestVersion(): Promise<Version> {
+    const matches = await findArtifacts((a) => isStableMc(a.minecraft), 1);
+    if (matches.length === 0) {
+      throw new Error("No SpongeVanilla artifacts available");
+    }
+    return { version: matches[0].minecraft, build: matches[0].build };
+  },
+
+  async api(mcVersion: string) {
+    const artifact = await findLatestArtifactForMc(mcVersion);
+    return {
+      repositories: [SPONGE_REPO],
+      dependencies: [
+        {
+          groupId: "org.spongepowered",
+          artifactId: "spongeapi",
+          version: artifact.api,
+        },
+      ],
+    };
+  },
+
+  async download(version: Version, ignoreCache = false) {
+    const CACHE_PATH = ctx.getCachePath();
+    const JAR_PATH = join(CACHE_PATH, "versions", `sponge-${version.version}-${version.build}.jar`);
+
+    if (existsSync(JAR_PATH) && !ignoreCache) {
+      return {
+        version: version.version,
+        build: version.build,
+        output: new Uint8Array(readFileSync(JAR_PATH)),
+      };
+    }
+
+    const artifact =
+      version.build > 0
+        ? await findArtifactByMcAndBuild(version.version, version.build)
+        : await findLatestArtifactForMc(version.version);
+
+    const detailRes = await fetch(`${ARTIFACT_BASE}/versions/${artifact.key}`);
+    if (!detailRes.ok) {
+      throw new Error(
+        `Failed to fetch SpongeVanilla version ${artifact.key}: ${detailRes.statusText}`,
+      );
+    }
+    const detail = (await detailRes.json()) as VersionDetail;
+    const universal = detail.assets.find(
+      (a) => a.classifier === "universal" && a.extension === "jar",
+    );
+    if (!universal) {
+      throw new Error(`No universal jar published for SpongeVanilla ${artifact.key}`);
+    }
+
+    const jarRes = await fetch(universal.downloadUrl);
+    if (!jarRes.ok) {
+      throw new Error(`Failed to download SpongeVanilla ${artifact.key}: ${jarRes.statusText}`);
+    }
+    const output = new Uint8Array(await jarRes.arrayBuffer());
+
+    await mkdir(join(CACHE_PATH, "versions"), { recursive: true });
+    await writeFile(JAR_PATH, output);
+
+    return { version: artifact.minecraft, build: artifact.build, output };
+  },
+}));

--- a/templates/index.json
+++ b/templates/index.json
@@ -36,6 +36,12 @@
       "name": "BungeeCord proxy plugin",
       "description": "BungeeCord plugin with a `PostLoginEvent` listener and a registered Command — the Bungee equivalent of the velocity-proxy template.",
       "family": "bungee"
+    },
+    {
+      "id": "sponge-basic",
+      "name": "Sponge plugin (basic)",
+      "description": "SpongeVanilla plugin with `@Plugin` lifecycle, a join listener, and a Brigadier-parameterized `/hello` command.",
+      "family": "sponge"
     }
   ]
 }

--- a/templates/sponge-basic/files/src/__packagePath__/__className__.java
+++ b/templates/sponge-basic/files/src/__packagePath__/__className__.java
@@ -1,0 +1,47 @@
+package ${project.packageName};
+
+import com.google.inject.Inject;
+
+import ${project.packageName}.commands.CommandRegistrar;
+import ${project.packageName}.listeners.JoinListener;
+
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+
+/**
+ * Main plugin class for ${project.name}.
+ *
+ * Sponge constructs the class through Guice — the {@link PluginContainer}
+ * + {@link Logger} parameters are injected by the engine.
+ *
+ * Listeners live in their own classes and are registered against the
+ * container from {@link ConstructPluginEvent}. We deliberately avoid
+ * declaring generic-typed {@code @Listener} methods on the plugin class
+ * itself — Sponge's plugin-class scanner doesn't always recover generic
+ * parameter types from the bytecode signature, but
+ * {@code Sponge.eventManager().registerListeners(...)} uses reflection
+ * which works correctly.
+ */
+@Plugin("${project.spongeId}")
+public class ${project.className} {
+
+    private final PluginContainer container;
+    private final Logger logger;
+
+    @Inject
+    public ${project.className}(final PluginContainer container, final Logger logger) {
+        this.container = container;
+        this.logger = logger;
+    }
+
+    @Listener
+    public void onConstructPlugin(final ConstructPluginEvent event) {
+        Sponge.eventManager().registerListeners(this.container, new JoinListener(this.logger));
+        CommandRegistrar.register(this.container);
+        this.logger.info("${project.name} has been enabled!");
+    }
+}

--- a/templates/sponge-basic/files/src/__packagePath__/commands/CommandRegistrar.java
+++ b/templates/sponge-basic/files/src/__packagePath__/commands/CommandRegistrar.java
@@ -1,0 +1,38 @@
+package ${project.packageName}.commands;
+
+import io.leangen.geantyref.TypeToken;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.event.EventListenerRegistration;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.plugin.PluginContainer;
+
+/**
+ * Registers Sponge commands.
+ *
+ * Sponge's {@code @Listener} scanner has a known issue resolving generic
+ * event types (e.g. {@code RegisterCommandEvent<Command.Parameterized>}):
+ * its ASM-based visitor sometimes drops the type argument and throws
+ * {@code IllegalArgumentException: Incorrect number of type arguments…}.
+ * The explicit {@link EventListenerRegistration} path uses a captured
+ * {@link TypeToken} instead and bypasses the broken scanner.
+ */
+public final class CommandRegistrar {
+
+    private static final TypeToken<RegisterCommandEvent<Command.Parameterized>> COMMAND_EVENT =
+        new TypeToken<RegisterCommandEvent<Command.Parameterized>>() {};
+
+    private CommandRegistrar() {}
+
+    public static void register(final PluginContainer container) {
+        Sponge.eventManager().registerListener(
+            EventListenerRegistration.builder(COMMAND_EVENT)
+                .plugin(container)
+                .order(Order.DEFAULT)
+                .listener(event -> event.register(container, HelloCommand.build(), "hello"))
+                .build()
+        );
+    }
+}

--- a/templates/sponge-basic/files/src/__packagePath__/commands/HelloCommand.java
+++ b/templates/sponge-basic/files/src/__packagePath__/commands/HelloCommand.java
@@ -1,0 +1,33 @@
+package ${project.packageName}.commands;
+
+import net.kyori.adventure.text.Component;
+
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.parameter.Parameter;
+
+/**
+ * {@code /hello [name]} — replies with a greeting.
+ *
+ * Sponge exposes its own parameterised {@link Command} API on top of
+ * Brigadier; that's the recommended way to declare commands since API 8.
+ * The command builder is registered against the plugin container in the
+ * main class's {@code RegisterCommandEvent} listener.
+ */
+public final class HelloCommand {
+
+    private HelloCommand() {}
+
+    public static Command.Parameterized build() {
+        final Parameter.Value<String> name = Parameter.string().key("name").optional().build();
+
+        return Command.builder()
+            .addParameter(name)
+            .executor(ctx -> {
+                final String who = ctx.one(name).orElse("world");
+                ctx.sendMessage(Component.text("Hello, " + who + "!"));
+                return CommandResult.success();
+            })
+            .build();
+    }
+}

--- a/templates/sponge-basic/files/src/__packagePath__/listeners/JoinListener.java
+++ b/templates/sponge-basic/files/src/__packagePath__/listeners/JoinListener.java
@@ -1,0 +1,24 @@
+package ${project.packageName}.listeners;
+
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.network.ServerSideConnectionEvent;
+
+/**
+ * Logs every successful player login. {@link ServerSideConnectionEvent.Join}
+ * fires after the player has been added to the world, so {@code event.player()}
+ * is always present.
+ */
+public class JoinListener {
+
+    private final Logger logger;
+
+    public JoinListener(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Listener
+    public void onJoin(final ServerSideConnectionEvent.Join event) {
+        this.logger.info("{} joined", event.player().name());
+    }
+}

--- a/templates/sponge-basic/template.json
+++ b/templates/sponge-basic/template.json
@@ -1,0 +1,6 @@
+{
+  "id": "sponge-basic",
+  "name": "Sponge plugin (basic)",
+  "description": "SpongeVanilla plugin with `@Plugin` lifecycle, a join listener, and a Brigadier-parameterized `/hello` command.",
+  "family": "sponge"
+}


### PR DESCRIPTION
## Summary

- Adds **SpongeVanilla** support alongside paper/folia/spigot/bukkit/velocity/waterfall/travertine. New descriptor (`META-INF/sponge_plugins.json`, java_plain loader), provider hitting Sponge's dl-api, init scaffolder + curated `sponge-basic` template (lifecycle listener + join listener + Brigadier `/hello`), and docs.
- Introduces **`RuntimeLayout`** on `PlatformProvider` (`pluginsDir`, `serverArgs`, `vanillaServerFiles`) so every platform is first-class in `pluggy dev`. Sponge stages plugins into `mods/plugins/` and uses `--nogui`; bukkit-family keep `plugins/` + positional `nogui`; velocity/bungee no longer write spurious `eula.txt` / `server.properties`.
- Modding-only Sponge variants (SpongeForge, SpongeNeo) are intentionally out of scope — pluggy doesn't model modding.

## Test plan

- [x] `vp test` — 481 passed | 4 skipped (pre-existing integration gates)
- [x] `vp lint` (via `vp check`) — clean
- [x] Manual: `bun build --compile`, `pluggy init --platform paper --yes` → `pluggy dev` → boot → plugin enabled → `Done!` → SIGINT clean shutdown
- [x] Manual: `pluggy init --platform sponge --template sponge-basic --mc-version 1.21.7 --yes` → `pluggy dev` → SpongeVanilla downloads, plugin loads, `sponge_e2e has been enabled!`, `Done (6.386s)!`, SIGINT clean shutdown