### PR TITLE
chore: update repository references to pluggy-sh org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [ch99q]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a report. Please search [existing issues](https://github.com/ch99q/pluggy/issues?q=is%3Aissue) before submitting.
+        Thanks for taking the time to file a report. Please search [existing issues](https://github.com/pluggy-sh/pluggy/issues?q=is%3Aissue) before submitting.
 
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please search [existing issues](https://github.com/ch99q/pluggy/issues?q=is%3Aissue) before submitting — feature requests are often already tracked.
+        Please search [existing issues](https://github.com/pluggy-sh/pluggy/issues?q=is%3Aissue) before submitting — feature requests are often already tracked.
 
   - type: textarea
     id: problem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,12 +145,12 @@ jobs:
 
             ### Windows (PowerShell)
             ```
-            irm https://github.com/ch99q/pluggy/releases/download/${{ github.ref_name }}/install.ps1 | iex
+            irm https://github.com/pluggy-sh/pluggy/releases/download/${{ github.ref_name }}/install.ps1 | iex
             ```
 
             ### Unix-like Systems (macOS, Linux)
             ```
-            curl -fsSL https://github.com/ch99q/pluggy/releases/download/${{ github.ref_name }}/install.sh | bash
+            curl -fsSL https://github.com/pluggy-sh/pluggy/releases/download/${{ github.ref_name }}/install.sh | bash
             ```
 
             ## Verification

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Install pluggy with the script for your platform. Both scripts drop the binary o
 On macOS and Linux:
 
 ```bash
-curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
 ```
 
 On Windows (PowerShell):
 
 ```powershell
-irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
+irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
 ```
 
 Open a new terminal and verify:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Report security vulnerabilities privately. Do not open public issues for securit
 
 ## Reporting a vulnerability
 
-File a report through GitHub's [private vulnerability reporting](https://github.com/ch99q/pluggy/security/advisories/new). If you cannot use GitHub, email `64793a1a@gmail.com` with the same content.
+File a report through GitHub's [private vulnerability reporting](https://github.com/pluggy-sh/pluggy/security/advisories/new). If you cannot use GitHub, email `64793a1a@gmail.com` with the same content.
 
 Include in the report:
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -16,7 +16,7 @@ pluggy upgrade [options]
 
 ## What it does
 
-1. Queries `https://api.github.com/repos/ch99q/pluggy/releases/latest`.
+1. Queries `https://api.github.com/repos/pluggy-sh/pluggy/releases/latest`.
 2. Maps `process.platform` × `process.arch` to a release asset name:
 
    | Platform | Arch    | Asset                      |
@@ -42,7 +42,7 @@ install instructions and exits clean.
 ```text
 $ pluggy upgrade
 Upgrading to: v0.2.0
-downloading https://github.com/ch99q/pluggy/releases/download/v0.2.0/pluggy-darwin-arm64
+downloading https://github.com/pluggy-sh/pluggy/releases/download/v0.2.0/pluggy-darwin-arm64
 ✔ pluggy v0.2.0 installed at ~/.pluggy/bin/pluggy (previous binary backed up to ~/.pluggy/bin/pluggy.old)
 ```
 
@@ -51,12 +51,12 @@ With `--print-only`:
 ```text
 Latest release: v0.2.0
 Published:      2026-03-01T12:00:00Z
-URL:            https://github.com/ch99q/pluggy/releases/tag/v0.2.0
+URL:            https://github.com/pluggy-sh/pluggy/releases/tag/v0.2.0
 
 Install manually:
 
-  Unix:    curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
-  Windows: irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
+  Unix:    curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
+  Windows: irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
 ```
 
 ## Permissions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ pluggy itself from source.
 ### macOS and Linux
 
 ```bash
-curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
 ```
 
 The script downloads the binary for your OS and architecture into
@@ -36,7 +36,7 @@ shell profile (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`,
 Override the install location with `PLUGGY_HOME`:
 
 ```bash
-PLUGGY_HOME=/opt/pluggy curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
+PLUGGY_HOME=/opt/pluggy curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
 ```
 
 Open a new shell or `source` the updated profile to pick up the new
@@ -45,7 +45,7 @@ Open a new shell or `source` the updated profile to pick up the new
 ### Windows
 
 ```powershell
-irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
+irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
 ```
 
 The script installs `pluggy.exe` to `%LOCALAPPDATA%\Programs\pluggy` and

--- a/docs/recipes/ci-without-global-pluggy.md
+++ b/docs/recipes/ci-without-global-pluggy.md
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install pluggy
         run: |
-          curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/install.sh | bash
+          curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
 
       - name: Cache pluggy downloads
         uses: actions/cache@v4
@@ -72,7 +72,7 @@ a tag:
 
 ```bash
 VERSION=v0.2.0
-curl -fsSL "https://github.com/ch99q/pluggy/releases/download/${VERSION}/pluggy-linux-amd64" -o /tmp/pluggy
+curl -fsSL "https://github.com/pluggy-sh/pluggy/releases/download/${VERSION}/pluggy-linux-amd64" -o /tmp/pluggy
 chmod +x /tmp/pluggy
 sudo mv /tmp/pluggy /usr/local/bin/pluggy
 ```
@@ -86,7 +86,7 @@ container:
 
 ```dockerfile
 FROM eclipse-temurin:21-jdk
-RUN curl -fsSL https://github.com/ch99q/pluggy/releases/latest/download/pluggy-linux-amd64 \
+RUN curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/pluggy-linux-amd64 \
     -o /usr/local/bin/pluggy \
  && chmod +x /usr/local/bin/pluggy
 ```
@@ -103,7 +103,7 @@ add the directory to `$env:PATH` explicitly:
 - name: Install pluggy
   shell: pwsh
   run: |
-    irm https://github.com/ch99q/pluggy/releases/latest/download/install.ps1 | iex
+    irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
     # Add to PATH for the rest of this job
     echo "$env:LOCALAPPDATA\Programs\pluggy" >> $env:GITHUB_PATH
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@
 # to the user PATH. No administrator privileges required.
 
 param(
-    [string]$Repo = "ch99q/pluggy",
+    [string]$Repo = "pluggy-sh/pluggy",
     [string]$Binary = "pluggy"
 )
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-REPO="ch99q/pluggy"
+REPO="pluggy-sh/pluggy"
 BINARY="pluggy"
 
 PLUGGY_HOME="${PLUGGY_HOME:-$HOME/.pluggy}"

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "pluggy",
   "version": "0.0.0",
   "description": "A CLI for developing Minecraft plugins.",
-  "homepage": "https://github.com/ch99q/pluggy#readme",
+  "homepage": "https://github.com/pluggy-sh/pluggy#readme",
   "bugs": {
-    "url": "https://github.com/ch99q/pluggy/issues"
+    "url": "https://github.com/pluggy-sh/pluggy/issues"
   },
   "license": "MIT",
   "author": "Christian Hansen",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ch99q/pluggy.git"
+    "url": "git+https://github.com/pluggy-sh/pluggy.git"
   },
   "bin": {
     "pluggy": "./bin/pluggy"

--- a/src/dev/hotswap.ts
+++ b/src/dev/hotswap.ts
@@ -76,7 +76,7 @@ export async function ensureAgent(version = HOTSWAP_AGENT_VERSION): Promise<stri
   if (actualSha !== expectedSha) {
     throw new Error(
       `hotswap: integrity check failed for hotswap-agent-${version}.jar — expected sha256 ${expectedSha}, got ${actualSha}. ` +
-        `Refusing to load an unverified javaagent; please report at https://github.com/ch99q/pluggy/issues.`,
+        `Refusing to load an unverified javaagent; please report at https://github.com/pluggy-sh/pluggy/issues.`,
     );
   }
   const tmp = `${dest}.partial`;

--- a/src/dev/jbr.ts
+++ b/src/dev/jbr.ts
@@ -179,7 +179,7 @@ async function downloadArchive(
   if (actualSha !== expectedSha) {
     throw new Error(
       `jbr: integrity check failed for ${archiveName} — expected sha256 ${expectedSha}, got ${actualSha}. ` +
-        `Refusing to extract an unverified runtime; please report at https://github.com/ch99q/pluggy/issues.`,
+        `Refusing to extract an unverified runtime; please report at https://github.com/pluggy-sh/pluggy/issues.`,
     );
   }
   const tmpPath = `${destPath}.partial`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { startUpdateCheck } from "./update-check.ts";
 import "./platform/index.ts";
 
 const CLI_VERSION = "0.0.0";
-const REPOSITORY = "ch99q/pluggy";
+const REPOSITORY = "pluggy-sh/pluggy";
 
 const program = new Command()
   .name("pluggy")

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -25,7 +25,7 @@ import yauzl, { type Entry, type ZipFile } from "yauzl";
 import type { PlatformFamily } from "../platform/index.ts";
 import { replace } from "../template.ts";
 
-const DEFAULT_REPO = "ch99q/pluggy";
+const DEFAULT_REPO = "pluggy-sh/pluggy";
 const DEFAULT_REF = "main";
 
 /** Lightweight entry as listed in `templates/index.json`. */

--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -67,7 +67,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });
@@ -86,7 +86,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });
@@ -102,7 +102,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       json: true,
       stateFile,
@@ -120,7 +120,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });
@@ -137,7 +137,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });
@@ -153,7 +153,7 @@ describe("startUpdateCheck", () => {
     );
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.0.0",
       stateFile,
     });
@@ -168,7 +168,7 @@ describe("startUpdateCheck", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({ tag_name: "v0.2.0" }), { status: 200 }));
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });
@@ -185,7 +185,7 @@ describe("startUpdateCheck", () => {
     );
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
     const handle = await startUpdateCheck({
-      repository: "ch99q/pluggy",
+      repository: "pluggy-sh/pluggy",
       currentVersion: "0.1.0",
       stateFile,
     });


### PR DESCRIPTION
## Summary

- Replaced all `ch99q/pluggy` repo references with `pluggy-sh/pluggy` across source, tests, docs, install scripts, release workflow, and issue templates following the move to the `pluggy-sh` GitHub org.
- Removed per-repo `.github/FUNDING.yml`; sponsorship config now lives globally in `pluggy-sh/.github`.

## Test plan

- [ ] `vp test`
- [ ] `vp lint`
- [ ] Manual: spot-check generated install/upgrade URLs and `package.json` repository fields.