### PR TITLE
feat(install): point install one-liners at pluggy.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,12 +145,12 @@ jobs:
 
             ### Windows (PowerShell)
             ```
-            irm https://github.com/pluggy-sh/pluggy/releases/download/${{ github.ref_name }}/install.ps1 | iex
+            irm https://pluggy.sh/install.ps1 | iex
             ```
 
             ### Unix-like Systems (macOS, Linux)
             ```
-            curl -fsSL https://github.com/pluggy-sh/pluggy/releases/download/${{ github.ref_name }}/install.sh | bash
+            curl -fsSL https://pluggy.sh/install.sh | sh
             ```
 
             ## Verification
@@ -166,3 +166,17 @@ jobs:
             ---
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Requires WEBSITE_DISPATCH_TOKEN: a fine-grained PAT scoped to
+      # pluggy-sh/pluggy.sh with `actions: write`. The default GITHUB_TOKEN
+      # cannot dispatch across repos.
+      - name: Trigger pluggy.sh docs rebuild
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            repos/pluggy-sh/pluggy.sh/dispatches \
+            -f event_type=pluggy-release \
+            -f "client_payload[tag]=${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Pick the script for your operating system. Both scripts drop the binary on your 
 On macOS and Linux:
 
 ```bash
-curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
+curl -fsSL https://pluggy.sh/install.sh | sh
 ```
 
 On Windows (PowerShell):
 
 ```powershell
-irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
+irm https://pluggy.sh/install.ps1 | iex
 ```
 
 Open a new terminal and verify:

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -55,8 +55,8 @@ URL:            https://github.com/pluggy-sh/pluggy/releases/tag/v0.2.0
 
 Install manually:
 
-  Unix:    curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
-  Windows: irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
+  Unix:    curl -fsSL https://pluggy.sh/install.sh | sh
+  Windows: irm https://pluggy.sh/install.ps1 | iex
 ```
 
 ## Permissions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Manage it later with [`pluggy cache`](./commands/cache.md) or [`pluggy sdk`](./c
 Run the install script:
 
 ```bash
-curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
+curl -fsSL https://pluggy.sh/install.sh | sh
 ```
 
 The script downloads the binary for your operating system into `~/.pluggy/bin/pluggy` and adds that directory to your `PATH` by appending an `export` line to your shell profile (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`, or `~/.config/fish/config.fish`, whichever exist). It does not need `sudo`.
@@ -37,7 +37,7 @@ The script downloads the binary for your operating system into `~/.pluggy/bin/pl
 To put pluggy somewhere else, set `PLUGGY_HOME`:
 
 ```bash
-PLUGGY_HOME=/opt/pluggy curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
+PLUGGY_HOME=/opt/pluggy curl -fsSL https://pluggy.sh/install.sh | sh
 ```
 
 Open a new terminal, or run `source` on the profile that was updated, to pick up the new `PATH` in your current session.
@@ -47,7 +47,7 @@ Open a new terminal, or run `source` on the profile that was updated, to pick up
 Open PowerShell and run:
 
 ```powershell
-irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
+irm https://pluggy.sh/install.ps1 | iex
 ```
 
 The script puts `pluggy.exe` at `%LOCALAPPDATA%\Programs\pluggy` and appends that directory to your user `PATH`. It does not need administrator rights. Restart your terminal before using `pluggy`.

--- a/docs/recipes/ci-without-global-pluggy.md
+++ b/docs/recipes/ci-without-global-pluggy.md
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pluggy
         run: |
-          curl -fsSL https://github.com/pluggy-sh/pluggy/releases/latest/download/install.sh | bash
+          curl -fsSL https://pluggy.sh/install.sh | sh
 
       - name: Cache pluggy downloads
         uses: actions/cache@v4
@@ -94,7 +94,7 @@ The PowerShell install script adds the binary to your user `PATH`, which doesn't
 - name: Install pluggy
   shell: pwsh
   run: |
-    irm https://github.com/pluggy-sh/pluggy/releases/latest/download/install.ps1 | iex
+    irm https://pluggy.sh/install.ps1 | iex
     # Add to PATH for the rest of this job
     echo "$env:LOCALAPPDATA\Programs\pluggy" >> $env:GITHUB_PATH
 ```


### PR DESCRIPTION
## Summary

- Replaces \`github.com/pluggy-sh/pluggy/releases/.../install.{sh,ps1}\` with \`https://pluggy.sh/install.{sh,ps1}\` in the README, getting-started, upgrade docs, ci recipe, and the release-notes body emitted by \`release.yml\`.
- The new URLs are served by [pluggy-sh/pluggy.sh](https://github.com/pluggy-sh/pluggy.sh) (a fresh Astro + Starlight site deployed to https://pluggy.sh) which proxies \`/install.sh\` and \`/install.ps1\` straight to \`raw.githubusercontent.com\` on this repo's \`main\`, so the script content stays here unchanged.
- Adds a \`Trigger pluggy.sh docs rebuild\` step at the end of \`release.yml\` that fires a \`repository_dispatch\` event of type \`pluggy-release\` at \`pluggy-sh/pluggy.sh\` after a tag is published, so a freshly tagged \`docs/\` snapshot lands on the site as soon as it's added to that repo's \`versions.config.ts\`.
- Requires a new \`WEBSITE_DISPATCH_TOKEN\` repo secret (fine-grained PAT scoped to \`pluggy-sh/pluggy.sh\` with \`Actions: write\`); the default \`GITHUB_TOKEN\` cannot dispatch across repos, so the step will fail loudly until the secret is set.

## Test plan

- [x] \`vp test\`
- [x] \`vp lint\`
- [x] Manual: \`curl -sI https://pluggy.sh/install.sh\` returns \`200 text/plain\` and matches \`install.sh\` on \`main\`; same for \`install.ps1\`.
- [ ] On next release tag: confirm the \`Trigger pluggy.sh docs rebuild\` step succeeds (after \`WEBSITE_DISPATCH_TOKEN\` is added) and the docs site rebuild runs.