### PR TITLE
feat(cli): detect package-manager installs, guard pluggy upgrade

### DIFF
--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -24,7 +24,7 @@ Doctor groups its output into four blocks. Run with `--report` to get the same d
 
 ### Environment
 
-Always shown. Lists pluggy version, OS plus release plus arch, runtime (`bun` or `node`), terminal info (TTY, columns, locale), the names (not values) of pluggy-relevant env vars that are set, and the cache and state directory paths.
+Always shown. Lists pluggy version, OS plus release plus arch, runtime (`bun` or `node`), terminal info (TTY, columns, locale), the names (not values) of pluggy-relevant env vars that are set, the cache and state directory paths, and the install method (`Homebrew`, `Scoop`, `install script`, or `unknown`) plus the resolved binary path. When PATH contains additional pluggy binaries that shadow each other, doctor warns and lists them.
 
 ### Project
 
@@ -72,6 +72,7 @@ Environment
   › env vars set: JAVA_HOME
   › cache: /Users/you/Library/Caches/pluggy
   › state: /Users/you/Library/Application Support/pluggy
+  › install: install script (/Users/you/.pluggy/bin/pluggy)
 
 Project
   › name: my_plugin@1.0.0
@@ -123,6 +124,7 @@ $ pluggy doctor --report
 - env vars set: JAVA_HOME
 - cache: /Users/you/Library/Caches/pluggy
 - state: /Users/you/Library/Application Support/pluggy
+- install: install script (/Users/you/.pluggy/bin/pluggy)
 
 ### Project
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -10,9 +10,10 @@ pluggy upgrade [options]
 
 ## Flags
 
-| Flag           | Default | Notes                                                            |
-| -------------- | ------- | ---------------------------------------------------------------- |
-| `--print-only` | off     | Skip the download and print manual install instructions instead. |
+| Flag           | Default | Notes                                                                                                                       |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `--print-only` | off     | Skip the download and print manual install instructions instead.                                                            |
+| `--force`      | off     | Self-update even when pluggy was installed via Homebrew or Scoop. Not recommended; corrupts the package manager's tracking. |
 
 ## What it does
 
@@ -58,6 +59,36 @@ Install manually:
   Unix:    curl -fsSL https://pluggy.sh/install.sh | sh
   Windows: irm https://pluggy.sh/install.ps1 | iex
 ```
+
+## Managed installs (Homebrew, Scoop)
+
+`pluggy upgrade` refuses to run when it detects that the binary is owned
+by a package manager — overwriting it would leave the package manager's
+manifest pointing at a file it didn't install. Run the package manager's
+own upgrade instead:
+
+```text
+$ pluggy upgrade
+✖ pluggy was installed via Homebrew; don't self-update — that would corrupt the package manager's tracking.
+
+Run this instead:
+
+  $ brew upgrade pluggy
+```
+
+The same guard fires for Scoop, suggesting `scoop update pluggy`.
+Pass `--force` to override (the upgrade will succeed but leave the
+package manager confused).
+
+Detection looks at `process.execPath`:
+
+| Install method | Detected by path containing            |
+| -------------- | -------------------------------------- |
+| Homebrew       | `/Cellar/pluggy/`                      |
+| Scoop          | `/scoop/apps/pluggy/`                  |
+| Install script | `/.pluggy/bin/` or `/Programs/pluggy/` |
+
+Unrecognised paths are treated as self-updateable.
 
 ## Permissions
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -12,6 +12,12 @@ import { HOTSWAP_AGENT_VERSION } from "../dev/hotswap.ts";
 import { JBR_VERSION, jbrCacheKey, jbrJavaPath, jbrTarget } from "../dev/jbr.ts";
 import { classMajorToJava, readJarClassMajor, readManifestAttribute } from "../jar.ts";
 import { type LockfileEntry, pruneOrphans, readLock } from "../lockfile.ts";
+import {
+  type InstallMethod,
+  describeInstallMethod,
+  detectInstallMethod,
+  findOtherInstalls,
+} from "../install-method.ts";
 import { bold, emit, emitErr, green, isJsonMode, log, red, yellow } from "../logging.ts";
 import { platforms } from "../platform/index.ts";
 import {
@@ -45,6 +51,12 @@ export interface EnvironmentInfo {
   locale?: string;
   envVarsSet: string[];
   paths: { cache: string; state: string };
+  install: {
+    method: InstallMethod;
+    label: string;
+    binaryPath: string;
+    otherInstalls: string[];
+  };
   project?: {
     name: string;
     version: string;
@@ -295,6 +307,7 @@ function collectEnvVarsSet(): string[] {
  * context for the bug report.
  */
 function collectEnvironmentInfo(pluggyVersion?: string): EnvironmentInfo {
+  const installInfo = detectInstallMethod();
   const env: EnvironmentInfo = {
     pluggy: { version: pluggyVersion ?? "0.0.0" },
     os: { platform: platform(), release: release(), arch: arch() },
@@ -302,6 +315,12 @@ function collectEnvironmentInfo(pluggyVersion?: string): EnvironmentInfo {
     terminal: { isTTY: process.stdout.isTTY === true },
     envVarsSet: collectEnvVarsSet(),
     paths: { cache: getCachePath(), state: getStatePath() },
+    install: {
+      method: installInfo.method,
+      label: describeInstallMethod(installInfo.method),
+      binaryPath: installInfo.resolvedPath,
+      otherInstalls: findOtherInstalls(installInfo.resolvedPath),
+    },
   };
   if (typeof process.stdout.columns === "number" && process.stdout.columns > 0) {
     env.terminal.columns = process.stdout.columns;
@@ -1192,6 +1211,12 @@ function printHumanReport(result: DoctorCommandResult): void {
   );
   log.step(`cache: ${env.paths.cache}`);
   log.step(`state: ${env.paths.state}`);
+  log.step(`install: ${env.install.label} (${env.install.binaryPath})`);
+  if (env.install.otherInstalls.length > 0) {
+    log.step(
+      `${yellow("⚠")} other pluggy binaries on PATH: ${env.install.otherInstalls.join(", ")}`,
+    );
+  }
 
   if (env.project !== undefined) {
     log.heading("Project");

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -7,6 +7,12 @@ import process from "node:process";
 
 import { Command } from "commander";
 
+import {
+  type InstallInfo,
+  describeInstallMethod,
+  detectInstallMethod,
+  upgradeCommandFor,
+} from "../install-method.ts";
 import { bold, brightBlue, dim, log, red, yellow } from "../logging.ts";
 
 interface GithubReleaseAsset {
@@ -333,6 +339,21 @@ function extractLeafCertificatePem(bundle: Record<string, unknown>): string | un
   return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----\n`;
 }
 
+function printManagedInstallGuidance(install: InstallInfo, upgradeCmd: string): void {
+  const label = describeInstallMethod(install.method);
+  log.error(
+    `${red("✖")} pluggy was installed via ${label}; ${bold("don't")} self-update — that would corrupt the package manager's tracking.`,
+  );
+  log.info("");
+  log.info(`${bold("Run this instead:")}`);
+  log.info("");
+  log.info(`  ${dim("$")} ${upgradeCmd}`);
+  log.info("");
+  log.info(
+    `${dim(`(detected install path: ${install.resolvedPath}. Override with --force if you really mean it.)`)}`,
+  );
+}
+
 function printPermissionGuidance(repository: string, currentBinaryPath: string): void {
   log.error(
     `cannot write to ${currentBinaryPath}: pluggy was installed to a system path and upgrades from there require root.`,
@@ -368,12 +389,27 @@ export function upgradeCommand(options: UpgradeOptions): Command {
       "--print-only",
       "Don't download; just print the latest release info and install commands.",
     )
+    .option(
+      "--force",
+      "Self-update even when pluggy was installed via a package manager. Not recommended; use the package manager's upgrade command instead.",
+    )
     .action(async function action(this: Command, cmdOptions) {
       const release = await fetchLatestRelease(options.repository, options.token);
 
       if (cmdOptions.printOnly === true) {
         printManualInstructions(options.repository, release);
         return;
+      }
+
+      const installInfo = detectInstallMethod();
+      const managedUpgrade = upgradeCommandFor(installInfo.method);
+      if (managedUpgrade !== undefined && cmdOptions.force !== true) {
+        printManagedInstallGuidance(installInfo, managedUpgrade);
+        const err = new Error(
+          `upgrade aborted: pluggy was installed via ${describeInstallMethod(installInfo.method)}; run \`${managedUpgrade}\` instead`,
+        ) as Error & { exitCode?: number };
+        err.exitCode = 1;
+        throw err;
       }
 
       const assetName = currentAssetName();

--- a/src/install-method.test.ts
+++ b/src/install-method.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  type InstallMethod,
+  describeInstallMethod,
+  detectInstallMethod,
+  upgradeCommandFor,
+} from "./install-method.ts";
+
+describe("detectInstallMethod", () => {
+  const cases: Array<{ path: string; expected: InstallMethod }> = [
+    // Homebrew layouts across prefixes.
+    { path: "/opt/homebrew/Cellar/pluggy/0.4.0/bin/pluggy", expected: "homebrew" },
+    { path: "/usr/local/Cellar/pluggy/0.4.0/bin/pluggy", expected: "homebrew" },
+    {
+      path: "/home/linuxbrew/.linuxbrew/Cellar/pluggy/0.4.0/bin/pluggy",
+      expected: "homebrew",
+    },
+
+    // Scoop layout.
+    {
+      path: "C:\\Users\\christian\\scoop\\apps\\pluggy\\current\\pluggy.exe",
+      expected: "scoop",
+    },
+    {
+      path: "C:\\Users\\christian\\scoop\\apps\\pluggy\\0.4.0\\pluggy.exe",
+      expected: "scoop",
+    },
+
+    // Install script defaults.
+    { path: "/Users/christian/.pluggy/bin/pluggy", expected: "manual" },
+    { path: "/home/x/.pluggy/bin/pluggy", expected: "manual" },
+    {
+      path: "C:\\Users\\christian\\AppData\\Local\\Programs\\pluggy\\pluggy.exe",
+      expected: "manual",
+    },
+
+    // Unrecognised — anything else (e.g. dropped into /tmp by hand).
+    { path: "/tmp/pluggy", expected: "unknown" },
+    { path: "/some/random/place/pluggy", expected: "unknown" },
+  ];
+
+  for (const { path, expected } of cases) {
+    test(`classifies ${path} as ${expected}`, () => {
+      const info = detectInstallMethod(path);
+      expect(info.method).toBe(expected);
+      expect(info.rawPath).toBe(path);
+    });
+  }
+});
+
+describe("describeInstallMethod", () => {
+  test("returns human-friendly labels", () => {
+    expect(describeInstallMethod("homebrew")).toBe("Homebrew");
+    expect(describeInstallMethod("scoop")).toBe("Scoop");
+    expect(describeInstallMethod("manual")).toBe("install script");
+    expect(describeInstallMethod("unknown")).toBe("unknown");
+  });
+});
+
+describe("upgradeCommandFor", () => {
+  test("returns the package-manager command for managed installs", () => {
+    expect(upgradeCommandFor("homebrew")).toBe("brew upgrade pluggy");
+    expect(upgradeCommandFor("scoop")).toBe("scoop update pluggy");
+  });
+
+  test("returns undefined for self-updateable installs", () => {
+    expect(upgradeCommandFor("manual")).toBeUndefined();
+    expect(upgradeCommandFor("unknown")).toBeUndefined();
+  });
+});

--- a/src/install-method.ts
+++ b/src/install-method.ts
@@ -1,0 +1,123 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { delimiter, join, sep } from "node:path";
+
+/**
+ * How the running pluggy binary got onto the user's machine. Drives
+ * `pluggy upgrade`'s self-update guard and is surfaced in `pluggy doctor`
+ * so bug reports identify the install path without the user having to dig.
+ */
+export type InstallMethod = "homebrew" | "scoop" | "manual" | "unknown";
+
+export interface InstallInfo {
+  method: InstallMethod;
+  /** Path after symlink/junction resolution. */
+  resolvedPath: string;
+  /** Original `process.execPath`, before resolution. */
+  rawPath: string;
+}
+
+/** Lower-case, forward-slashed copy of `path` for cross-platform pattern matching. */
+function normalize(path: string): string {
+  return path.replace(/\\/g, "/").toLowerCase();
+}
+
+function safeRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Inspect a binary path and classify how it was installed. Falls back to
+ * `unknown` when no rule matches; callers should treat `unknown` as
+ * non-managed (i.e. allow self-update) since the install script's default
+ * locations are the `manual` rules below.
+ */
+export function detectInstallMethod(execPath: string = process.execPath): InstallInfo {
+  const resolved = safeRealpath(execPath);
+  const norm = normalize(resolved);
+
+  // Homebrew binaries always live under a Cellar/<name>/ subtree, regardless
+  // of prefix (/opt/homebrew on Apple Silicon, /usr/local on Intel macOS,
+  // /home/linuxbrew/.linuxbrew on Linuxbrew).
+  if (/\/cellar\/pluggy\//.test(norm)) {
+    return { method: "homebrew", resolvedPath: resolved, rawPath: execPath };
+  }
+
+  // Scoop installs under <userprofile>/scoop/apps/<name>/<version>/.
+  if (/\/scoop\/apps\/pluggy\//.test(norm)) {
+    return { method: "scoop", resolvedPath: resolved, rawPath: execPath };
+  }
+
+  // Curl/iwr install script default locations.
+  if (/\/\.pluggy\/bin\//.test(norm) || /\/programs\/pluggy\//.test(norm)) {
+    return { method: "manual", resolvedPath: resolved, rawPath: execPath };
+  }
+
+  return { method: "unknown", resolvedPath: resolved, rawPath: execPath };
+}
+
+/** Human-readable label for `--json` consumers and doctor output. */
+export function describeInstallMethod(method: InstallMethod): string {
+  switch (method) {
+    case "homebrew":
+      return "Homebrew";
+    case "scoop":
+      return "Scoop";
+    case "manual":
+      return "install script";
+    case "unknown":
+      return "unknown";
+  }
+}
+
+/** The command a user should run to upgrade a managed install, or `undefined` for self-update. */
+export function upgradeCommandFor(method: InstallMethod): string | undefined {
+  switch (method) {
+    case "homebrew":
+      return "brew upgrade pluggy";
+    case "scoop":
+      return "scoop update pluggy";
+    case "manual":
+    case "unknown":
+      return undefined;
+  }
+}
+
+/**
+ * Walk every directory on PATH looking for additional pluggy executables.
+ * Returns resolved (symlinks followed) paths, excluding `currentResolvedPath`
+ * and any duplicates that resolve to the same file. Used by `pluggy doctor`
+ * to warn when curl-installed and brew-installed pluggy binaries are
+ * shadowing each other.
+ */
+export function findOtherInstalls(currentResolvedPath: string): string[] {
+  const PATH = process.env.PATH ?? "";
+  if (PATH.length === 0) return [];
+
+  const exeName = process.platform === "win32" ? "pluggy.exe" : "pluggy";
+  const seen = new Set<string>([safeRealpath(currentResolvedPath)]);
+  const others: string[] = [];
+
+  for (const dir of PATH.split(delimiter)) {
+    if (dir.length === 0) continue;
+    const candidate = join(dir, exeName);
+    if (!existsSync(candidate)) continue;
+    try {
+      if (!statSync(candidate).isFile()) continue;
+    } catch {
+      continue;
+    }
+    const resolved = safeRealpath(candidate);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    others.push(resolved);
+  }
+
+  return others;
+}
+
+/** Trivially-mockable PATH separator export for tests on the wrong host OS. */
+export const PATH_SEP = sep;


### PR DESCRIPTION
## Summary

- Adds `src/install-method.ts` which classifies the running binary by inspecting `process.execPath` (after symlink/junction resolution): **Homebrew** (`/Cellar/pluggy/`), **Scoop** (`/scoop/apps/pluggy/`), the **install script** (`/.pluggy/bin/` or `/Programs/pluggy/`), or **unknown**.
- `pluggy upgrade` now refuses to self-update on Homebrew or Scoop installs and tells the user to run `brew upgrade pluggy` or `scoop update pluggy`. New `--force` flag overrides the guard.
- `pluggy doctor` surfaces the install method + resolved binary path in its Environment block, and warns when PATH contains other pluggy binaries shadowing the running one.
- This is the prerequisite for shipping `pluggy-sh/homebrew-tap` (and later a Scoop bucket): without the upgrade guard, `brew upgrade pluggy` and `pluggy upgrade` would race to overwrite the same file and corrupt the package manager's manifest.
- Docs updated: `docs/commands/upgrade.md` gains a "Managed installs" section and `--force` flag entry; `docs/commands/doctor.md` notes the new Environment line.

## Test plan

- [x] `vp test` (557 passed, 4 skipped — including 13 new tests in `src/install-method.test.ts` covering each install layout)
- [x] `vp check` (formatting, lint, type checks)
- [x] Manual: `bun build --compile --outfile=bin/pluggy ./src/index.ts && ./bin/pluggy doctor` → shows `install: unknown (...)` and warns about shadowing binaries on PATH
- [x] Manual: `./bin/pluggy upgrade --help` → `--force` listed
- [ ] Once merged + tagged: verify `pluggy upgrade` from a real Homebrew install (after the tap PR lands) prints the redirect message and exits non-zero