### PR TITLE
docs: rewrite IDE integration to match the actual code

### DIFF
--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -78,9 +78,9 @@ The classpath is the flattened list of jar paths: dep jars first, then the platf
 
 ## 4. Write IDE files
 
-Only if `project.ide` is set. Failures are caught and logged at `--verbose` (`build: IDE scaffolding failed (non-fatal): ...`) so a broken IDE integration doesn't block the build.
+Writes `.classpath` and `.project` at the project root, populated from the resolved classpath. Skipped when `--skip-classpath` is passed. Failures are caught and logged at `--verbose` (`build: IDE scaffolding failed (non-fatal): ...`) so a broken IDE integration doesn't block the build.
 
-See [IDE integration](./ide.md) for what each `ide` value writes.
+See [IDE integration](./ide.md) for which IDEs consume these files.
 
 ## 5. Stage resources
 
@@ -214,5 +214,5 @@ Exactly what you'd expect from a shaded plugin jar.
 
 - [`pluggy build` reference](./commands/build.md): flags and output.
 - [Dependencies](./dependencies.md): how the classpath gets populated.
-- [IDE integration](./ide.md): how the classpath ends up in your editor.
+- [IDE integration](./ide.md): how `.classpath` ends up in your editor.
 - [Workspaces](./workspaces.md): topological build ordering.

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -11,13 +11,13 @@ pluggy b     [options]
 
 ## Flags
 
-| Flag                 | Default                                | Notes                                                                                  |
-| -------------------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
-| `--output <path>`    | `<workspace>/bin/<name>-<version>.jar` | Output jar destination.                                                                |
-| `--clean`            | off                                    | Wipe the staging directory before building.                                            |
-| `--skip-classpath`   | off                                    | Don't regenerate IDE project files (`.classpath`, `.vscode/settings.json`, `.idea/*`). |
-| `--workspace <name>` | none                                   | Build only this workspace.                                                             |
-| `--workspaces`       | off                                    | Explicit all-workspaces build from the root.                                           |
+| Flag                 | Default                                | Notes                                                        |
+| -------------------- | -------------------------------------- | ------------------------------------------------------------ |
+| `--output <path>`    | `<workspace>/bin/<name>-<version>.jar` | Output jar destination.                                      |
+| `--clean`            | off                                    | Wipe the staging directory before building.                  |
+| `--skip-classpath`   | off                                    | Don't regenerate `.classpath` and `.project` for this build. |
+| `--workspace <name>` | none                                   | Build only this workspace.                                   |
+| `--workspaces`       | off                                    | Explicit all-workspaces build from the root.                 |
 
 ## Scope rules
 
@@ -39,7 +39,7 @@ For each target workspace, pluggy runs the steps below in order. Every step live
 1. **Pick the descriptor.** Check that every declared platform shares the same [descriptor family](../glossary.md#descriptor-family). Errors with "Split them into separate workspaces, one per family." if they don't.
 2. **Stage directory.** Under `<workspace>/.pluggy-build/<hash>/`, where `<hash>` is the first 12 hex chars of `sha256(name \0 version \0 rootDir)`. `--clean` wipes this first.
 3. **Resolve dependencies.** Every declared dep, plus the primary platform's `api()` Maven coordinate. Registries are the platform's own repos first, followed by `project.registries`, with order-preserving dedup.
-4. **Write IDE files.** Only if `project.ide` is set. Failures are logged at debug but don't abort the build.
+4. **Write IDE files.** Writes `.classpath` and `.project` at the project root unless `--skip-classpath` was passed. Failures are logged at debug but don't abort the build.
 5. **Stage resources.** Copy `project.resources` into the staging dir, and run `.yml`, `.yaml`, `.json`, `.properties`, `.txt`, and `.md` files through the `${project.x}` template substitution.
 6. **Generate the descriptor.** Unless a resource entry already claims the descriptor path (`plugin.yml` and friends), pluggy writes the generated one to the staging dir.
 7. **Compile.** `javac -encoding UTF-8 -d <staging> -cp <classpath> <sources>`. The classpath separator is `:` on POSIX and `;` on Windows, handled by Node's `path.delimiter`.
@@ -138,5 +138,5 @@ the full list):
 ## See also
 
 - [Build pipeline](../build-pipeline.md): the same steps with more depth.
-- [IDE integration](../ide.md): what the `ide` field generates.
+- [IDE integration](../ide.md): which IDEs consume the generated `.classpath`.
 - [Workspaces](../workspaces.md): topological build order.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -94,9 +94,9 @@ Without `-y`, pluggy walks through an interactive session:
 - **Project name**: pre-filled with the target basename. Skipped when `--name` is passed or a positional `path` is given.
 - **Target platforms**: checkbox list of every registered platform, with `paper` pre-selected. Skipped when `--platform` is passed. Requires at least one selection.
 - **Main class**: pre-filled with `com.example.<DerivedClassName>`, where the class name is derived from the project name by splitting on `-` and `_` and PascalCasing. Skipped when `--main` is passed.
-- **IDE integration**: checkbox list of VS Code, IntelliJ IDEA, and Eclipse. Selections are written to `project.ide`, which makes `pluggy build` emit project files for those editors. Leave the selection empty to skip IDE scaffolding.
+  There is no IDE prompt — `pluggy init` writes the IntelliJ stub (`.idea/` + `<name>.iml`) and a `.gitignore` covering the regenerated IDE files unconditionally. `pluggy build` writes `.classpath` and `.project` on every build. See [IDE integration](../ide.md).
 
-Under `--json` or `-y`, the non-empty-dir situation throws instead of prompting (an interactive prompt in a non-interactive session would hang forever) and every other prompt falls back to its default: `paper` for platforms, no IDE integration, derived name and main class.
+Under `--json` or `-y`, the non-empty-dir situation throws instead of prompting (an interactive prompt in a non-interactive session would hang forever) and every other prompt falls back to its default: `paper` for platforms, derived name and main class.
 
 ## Human output
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -94,7 +94,7 @@ Without `-y`, pluggy walks through an interactive session:
 - **Project name**: pre-filled with the target basename. Skipped when `--name` is passed or a positional `path` is given.
 - **Target platforms**: checkbox list of every registered platform, with `paper` pre-selected. Skipped when `--platform` is passed. Requires at least one selection.
 - **Main class**: pre-filled with `com.example.<DerivedClassName>`, where the class name is derived from the project name by splitting on `-` and `_` and PascalCasing. Skipped when `--main` is passed.
-  There is no IDE prompt — `pluggy init` writes the IntelliJ stub (`.idea/` + `<name>.iml`) and a `.gitignore` covering the regenerated IDE files unconditionally. `pluggy build` writes `.classpath` and `.project` on every build. See [IDE integration](../ide.md).
+  There is no IDE prompt. `pluggy init` writes the IntelliJ stub (`.idea/` + `<name>.iml`) and a `.gitignore` covering the regenerated IDE files unconditionally. `pluggy build` writes `.classpath` and `.project` on every build. See [IDE integration](../ide.md).
 
 Under `--json` or `-y`, the non-empty-dir situation throws instead of prompting (an interactive prompt in a non-interactive session would hang forever) and every other prompt falls back to its default: `paper` for platforms, derived name and main class.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,5 +202,5 @@ That covers most days of plugin development.
 - Add JUnit tests: [`pluggy test`](./commands/test.md).
 - Split into multiple plugins: [Workspaces](./workspaces.md).
 - Bundle a third-party library into your jar: [Shading](./project-json.md#shading-optional).
-- Set up your editor: [IDE integration](./ide.md).
+- Open the project in your editor — IDE files are already written: [IDE integration](./ide.md).
 - Wire up CI without installing pluggy globally: [CI recipe](./recipes/ci-without-global-pluggy.md).

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -12,7 +12,7 @@ why, and how to opt out.
 | `pluggy build` | `.classpath` + `.project` (project root) | Regenerated on every build to reflect the resolved classpath. |
 
 Pluggy never touches `.vscode/`. The `.classpath` is the single source
-of truth — the same file feeds Eclipse, VS Code, and IntelliJ.
+of truth: the same file feeds Eclipse, VS Code, and IntelliJ.
 
 ## How each IDE reads it
 
@@ -22,9 +22,9 @@ of truth — the same file feeds Eclipse, VS Code, and IntelliJ.
 | VS Code  | Reads `.classpath` via Red Hat's `vscode-java` extension (the "Extension Pack for Java" is the easy install). |
 | IntelliJ | Reads `.classpath` because the `.idea/` stub `init` writes opens the project in linked-Eclipse mode.          |
 
-That's why opening the project folder in any of the three "just works"
-without an import wizard. After the first build, every IDE sees the
-same dependency set.
+Opening the project folder in any of the three loads it as a Java
+project with no import wizard. After the first build, every IDE sees
+the same dependency set.
 
 ## Opting out for a single build
 
@@ -34,7 +34,7 @@ pluggy build --skip-classpath
 
 Skips the `.classpath` + `.project` write for one invocation. Useful in
 CI when the IDE files would only churn the diff. There is no permanent
-opt-out flag — the cost is a few microseconds and two small XML files.
+opt-out flag. The cost is a few microseconds and two small XML files.
 
 ## Version control
 

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -1,107 +1,61 @@
 # IDE integration
 
-Set `"ide"` in `project.json` to an array of editor kinds, and `pluggy build` writes scaffolding so each IDE sees pluggy's resolved [classpath](./glossary.md#classpath). Three values are supported:
+IDE setup is automatic. There is no `pluggy ide` command and nothing
+to configure in `project.json`. This page documents what gets written,
+why, and how to opt out.
 
-| Value        | Produces                  | Consumer                           |
-| ------------ | ------------------------- | ---------------------------------- |
-| `"vscode"`   | `.vscode/settings.json`   | Red Hat's `vscode-java` extension  |
-| `"eclipse"`  | `.classpath` + `.project` | Eclipse IDE / Spring Tools / Theia |
-| `"intellij"` | `.idea/` + `<name>.iml`   | IntelliJ IDEA, CLion (Java plugin) |
+## What pluggy writes
 
-Any subset is valid. List every editor your team uses:
+| When           | Files                                    | Lifetime                                                      |
+| -------------- | ---------------------------------------- | ------------------------------------------------------------- |
+| `pluggy init`  | `.idea/` + `<name>.iml`                  | Written once. pluggy never rewrites these after init.         |
+| `pluggy build` | `.classpath` + `.project` (project root) | Regenerated on every build to reflect the resolved classpath. |
 
-```json
-"ide": ["vscode", "intellij"]
+Pluggy never touches `.vscode/`. The `.classpath` is the single source
+of truth — the same file feeds Eclipse, VS Code, and IntelliJ.
+
+## How each IDE reads it
+
+| IDE      | Mechanism                                                                                                     |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| Eclipse  | Reads `.classpath` natively.                                                                                  |
+| VS Code  | Reads `.classpath` via Red Hat's `vscode-java` extension (the "Extension Pack for Java" is the easy install). |
+| IntelliJ | Reads `.classpath` because the `.idea/` stub `init` writes opens the project in linked-Eclipse mode.          |
+
+That's why opening the project folder in any of the three "just works"
+without an import wizard. After the first build, every IDE sees the
+same dependency set.
+
+## Opting out for a single build
+
+```bash
+pluggy build --skip-classpath
 ```
 
-Unset or empty `ide` means no scaffolding. `pluggy init` asks for this
-interactively via a checkbox prompt.
+Skips the `.classpath` + `.project` write for one invocation. Useful in
+CI when the IDE files would only churn the diff. There is no permanent
+opt-out flag — the cost is a few microseconds and two small XML files.
 
-## When the files are written
+## Version control
 
-IDE scaffolding runs during `pluggy build`, right after dependencies are resolved and right before resources are staged. Pass `--skip-classpath` to suppress it for a single build without changing `project.json`.
-
-If scaffolding fails (disk full, permissions), pluggy logs at `--verbose`:
+Don't check these into git:
 
 ```text
-◌ build: IDE scaffolding failed (non-fatal): EACCES: permission denied, open '.classpath'
+/.classpath
+/.project
+/.idea/
+/*.iml
 ```
 
-The build continues — IDE files are advisory, not required.
+`.classpath` contains absolute paths into your local cache (under
+`~/.cache/pluggy/` or the platform equivalent), which won't match
+anyone else's machine. `pluggy init` adds these patterns to `.gitignore`
+automatically.
 
-## `"vscode"`
+## JDK picker (IntelliJ)
 
-Writes `.vscode/settings.json`:
-
-```json
-{
-  "java.project.referencedLibraries": [
-    "/Users/you/Library/Caches/pluggy/dependencies/maven/net/kyori/adventure-api/4.17.0.jar",
-    "/Users/you/Library/Caches/pluggy/dependencies/maven/net/kyori/adventure-key/4.17.0.jar",
-    "..."
-  ],
-  "java.project.sourcePaths": ["src"],
-  "java.project.outputPath": ".pluggy-build/classes"
-}
-```
-
-Install the Red Hat `vscode-java` extension (the "Extension Pack for Java" is the one-click option). On first open, VS Code indexes the referenced libraries and you get completion, navigation, and inline errors.
-
-VS Code's Java tools use the cache paths directly. There's no project-local `lib/` copy. That's intentional: if you bump a dep with `pluggy install`, the next `pluggy build` rewrites `settings.json` and VS Code picks up the new jars automatically.
-
-**Verifying:** open the Java Project view in VS Code and expand
-"Referenced Libraries". You should see one entry per resolved jar.
-
-## `"eclipse"`
-
-Writes two files at the project root:
-
-- `.classpath`: every cache jar as a `<classpathentry kind="lib">`, plus a `<classpathentry kind="src" path="src"/>` and a JDT output path pointing at `.pluggy-build`.
-- `.project`: minimal Eclipse project descriptor with the JDT nature ("nature" is Eclipse's term for "this project is a Java project").
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-  <classpathentry kind="src" path="src"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-  <classpathentry kind="lib" path="/Users/you/Library/Caches/pluggy/dependencies/maven/net/kyori/adventure-api/4.17.0.jar"/>
-  ...
-  <classpathentry kind="output" path=".pluggy-build"/>
-</classpath>
-```
-
-**Verifying:** `File > Import > Existing Projects into Workspace` and
-pick the repo root.
-
-## `"intellij"`
-
-Writes a minimal working IntelliJ project at the root:
-
-```text
-.idea/
-├── .gitignore
-├── modules.xml
-├── misc.xml
-└── libraries/
-    ├── maven__net_kyori__adventure-api__4_17_0.xml
-    ├── maven__net_kyori__adventure-key__4_17_0.xml
-    └── ...
-<name>.iml
-```
-
-The naming rule for library files:
-
-- Jars under the pluggy Maven cache become `maven__<groupId>__<artifactId>__<version>.xml` with dots replaced by underscores.
-- Other jars fall back to the basename without `.jar`.
-- Names are sanitised to `[A-Za-z0-9_.-]` only.
-- Collisions get `__2`, `__3`, and so on suffixes in classpath order.
-
-The `.iml` lists every library as an `orderEntry`, plus a single `inheritedJdk` entry (which tells IntelliJ to use the project-level JDK).
-
-### JDK picker
-
-`misc.xml` sets `project-jdk-name` and `languageLevel` from
-`compatibility.versions[0]`:
+The `.idea/misc.xml` written at init names the project JDK by Java
+major version, derived from `compatibility.versions[0]`:
 
 | MC version       | JDK |
 | ---------------- | --- |
@@ -111,46 +65,26 @@ The `.iml` lists every library as an `orderEntry`, plus a single `inheritedJdk` 
 | 1.17.x           | 16  |
 | 1.16 and earlier | 8   |
 
-Unparseable versions default to 21 (current Paper baseline). IntelliJ honors `project-jdk-name="21"` if you have a JDK registered under that name in `File > Project Structure > SDKs`.
-
-pluggy provisions a matching JDK on the first build into `<cachePath>/jdk/temurin-<major>-<os>-<arch>/`. Run `pluggy sdk path 21` to print the absolute `JAVA_HOME` and register that path in IntelliJ if no SDK is set up yet. See [`pluggy sdk`](./commands/sdk.md).
-
-**Verifying:** `File > Open...` and point at the repo root. IntelliJ
-should recognize it as an existing project and load the module without
-any Gradle or Maven import flow.
-
-## How the classpath stays fresh
-
-IDE files are regenerated on every `pluggy build`. To refresh the IDE view after running `install` for a new dep, run `pluggy build`.
-
-If you're using the dev loop (`pluggy dev`), every rebuild updates the IDE files in passing. You usually don't need to think about this.
-
-## Version-control guidance
-
-- `.vscode/settings.json`: check in. It only contains pluggy-managed classpath paths.
-- `.classpath` and `.project`: don't check in. They contain absolute paths into your user cache, which won't match anyone else's machine.
-- `.idea/`: don't check in. Same reason.
-- `<name>.iml`: don't check in.
-
-A sensible `.gitignore`:
-
-```text
-/.classpath
-/.project
-/.idea/
-/*.iml
-```
-
-`.vscode/settings.json` is the only file in this set that stays portable if your team is on the same platform and pluggy version. Worth checking in for team consistency. If your team is multi-OS, add it to `.gitignore` too.
+IntelliJ honours `project-jdk-name="21"` if you have a JDK registered
+under that name in `File > Project Structure > SDKs`. pluggy provisions
+a matching JDK on the first build into `<cachePath>/jdk/temurin-<major>-<os>-<arch>/`;
+run `pluggy sdk path 21` to print its absolute `JAVA_HOME` for IntelliJ
+to pick up.
 
 ## Common failures
 
-- **"Classpath seems to match but I see red underlines"**: restart the Java language server in your editor. In VS Code: `Java: Clean Java Language Server Workspace`. In IntelliJ: `File > Invalidate Caches`.
-- **"My sibling workspace isn't on the classpath"**: workspace dependencies point at `<sibling>/bin/<name>-<version>.jar`. If the sibling hasn't been built, the jar doesn't exist and the IDE sees an orphan entry. Build the sibling first.
-- **"My IDE wants a JDK I don't have installed"**: the IntelliJ integration names the JDK by major version (`"21"`). Install a matching JDK or edit `.idea/misc.xml` manually.
+- **Red underlines despite a matching classpath.** Restart the Java
+  language server. VS Code: `Java: Clean Java Language Server Workspace`.
+  IntelliJ: `File > Invalidate Caches`.
+- **Sibling workspace not on the classpath.** Workspace dependencies
+  point at `<sibling>/bin/<name>-<version>.jar`. If the sibling hasn't
+  been built, the jar doesn't exist. Build siblings first (running
+  `pluggy build` from the repo root handles topological order for you).
+- **IntelliJ wants a JDK you don't have.** `misc.xml` names the JDK by
+  major version. Either install a matching JDK or edit `.idea/misc.xml`
+  to point at one you have.
 
 ## See also
 
-- [project.json `ide` field](./project-json.md#ide-optional): value reference.
-- [`pluggy build --skip-classpath`](./commands/build.md): temporarily disable scaffolding.
-- [Build pipeline](./build-pipeline.md): where IDE scaffolding sits.
+- [Build pipeline](./build-pipeline.md): where IDE scaffolding sits in the build.
+- [`pluggy build --skip-classpath`](./commands/build.md): single-build opt-out.

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -13,7 +13,6 @@ Every field is documented below. If a term is unfamiliar, check the [glossary](.
   "description": "A small Paper plugin",
   "authors": ["Alice", "Bob"],
   "main": "com.example.myplugin.Main",
-  "ide": ["vscode"],
   "compatibility": {
     "versions": ["1.21.8"],
     "platforms": ["paper"]
@@ -100,17 +99,6 @@ Fully-qualified Java class name, at least `package.Class`. pluggy uses this for 
 3. The output directory layout inside `src/` during `init` (`src/com/example/myplugin/Main.java`).
 
 Required for every buildable workspace. A workspace-less root that declares `workspaces` is not buildable itself and can omit `main`.
-
-### `ide` (optional)
-
-Array of `"vscode"`, `"eclipse"`, `"intellij"`. Controls which editor scaffolding `build` writes. pluggy walks the array and generates files for every listed IDE, so a mixed-editor team can commit one `project.json` that covers everyone. Unset or empty means no scaffolding. See [IDE integration](./ide.md) for what each value produces.
-
-```json
-"ide": ["vscode", "intellij"]
-```
-
-`pluggy init` writes this field from the interactive IDE checkbox; edit
-the array by hand to add or remove editors later.
 
 ### `compatibility` (required)
 
@@ -359,5 +347,5 @@ Errors that would prevent a build show up here. Warnings are advisory (for examp
 ## What pluggy does not read
 
 - `package.json`, `pom.xml`, `build.gradle*`: ignored even if present.
-- `settings.json`, `.idea/`, `.classpath`: pluggy writes these when `ide` is set, but never reads them.
+- `.classpath`, `.project`, `.idea/`: pluggy writes these automatically (see [IDE integration](./ide.md)) but never reads them.
 - `pluggy.lock` is not `project.json`. It's a separate file produced by `install` and `build`, documented in [Dependencies](./dependencies.md#lockfile).

--- a/docs/recipes/migrating-from-maven-gradle.md
+++ b/docs/recipes/migrating-from-maven-gradle.md
@@ -4,18 +4,18 @@ If you already have a plugin project built with Maven or Gradle, pluggy can take
 
 ## What pluggy replaces
 
-| Old world                                 | pluggy equivalent                                     |
-| ----------------------------------------- | ----------------------------------------------------- |
-| `pom.xml` or `build.gradle`               | `project.json`                                        |
-| `<dependencies>` or `implementation(...)` | `project.json:dependencies`                           |
-| `<repositories>` or `repositories { }`    | `project.json:registries` (Maven only)                |
-| `maven-shade-plugin` config               | `project.json:shading`                                |
-| `mvn package` or `./gradlew shadowJar`    | `pluggy build`                                        |
-| `mvn test` or `./gradlew test`            | `pluggy test` (JUnit Platform via `testDependencies`) |
-| `plugin.yml` (hand-written)               | pluggy-generated, or staged via `resources`           |
-| `src/main/java/`                          | `src/`                                                |
-| `src/main/resources/`                     | `project.json:resources` mapping                      |
-| IntelliJ/Eclipse import                   | `project.json:ide` (see [IDE integration](../ide.md)) |
+| Old world                                 | pluggy equivalent                                                                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `pom.xml` or `build.gradle`               | `project.json`                                                                                                            |
+| `<dependencies>` or `implementation(...)` | `project.json:dependencies`                                                                                               |
+| `<repositories>` or `repositories { }`    | `project.json:registries` (Maven only)                                                                                    |
+| `maven-shade-plugin` config               | `project.json:shading`                                                                                                    |
+| `mvn package` or `./gradlew shadowJar`    | `pluggy build`                                                                                                            |
+| `mvn test` or `./gradlew test`            | `pluggy test` (JUnit Platform via `testDependencies`)                                                                     |
+| `plugin.yml` (hand-written)               | pluggy-generated, or staged via `resources`                                                                               |
+| `src/main/java/`                          | `src/`                                                                                                                    |
+| `src/main/resources/`                     | `project.json:resources` mapping                                                                                          |
+| IntelliJ/Eclipse import                   | Automatic — `pluggy init` writes the IntelliJ stub, `pluggy build` writes `.classpath`. See [IDE integration](../ide.md). |
 
 ## What pluggy does not do
 
@@ -262,7 +262,7 @@ unzip -l bin/myplugin-1.0.0.jar
 
 - **README.** Replace `mvn package` and `./gradlew build` with `pluggy build`. Replace `mvn clean` with `pluggy build --clean`. Replace `mvn test` with `pluggy test`.
 - **CI.** See [CI without global pluggy](./ci-without-global-pluggy.md).
-- **IDE import.** Set `"ide"` in `project.json`, run `pluggy build`, and open the repo in the target editor. No Maven or Gradle import flow.
+- **IDE import.** Just open the repo in your editor — `pluggy init` already wrote the IntelliJ stub and `pluggy build` writes `.classpath` for Eclipse and VS Code. No Maven or Gradle import flow.
 
 ## See also
 

--- a/docs/recipes/migrating-from-maven-gradle.md
+++ b/docs/recipes/migrating-from-maven-gradle.md
@@ -4,18 +4,18 @@ If you already have a plugin project built with Maven or Gradle, pluggy can take
 
 ## What pluggy replaces
 
-| Old world                                 | pluggy equivalent                                                                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `pom.xml` or `build.gradle`               | `project.json`                                                                                                            |
-| `<dependencies>` or `implementation(...)` | `project.json:dependencies`                                                                                               |
-| `<repositories>` or `repositories { }`    | `project.json:registries` (Maven only)                                                                                    |
-| `maven-shade-plugin` config               | `project.json:shading`                                                                                                    |
-| `mvn package` or `./gradlew shadowJar`    | `pluggy build`                                                                                                            |
-| `mvn test` or `./gradlew test`            | `pluggy test` (JUnit Platform via `testDependencies`)                                                                     |
-| `plugin.yml` (hand-written)               | pluggy-generated, or staged via `resources`                                                                               |
-| `src/main/java/`                          | `src/`                                                                                                                    |
-| `src/main/resources/`                     | `project.json:resources` mapping                                                                                          |
-| IntelliJ/Eclipse import                   | Automatic — `pluggy init` writes the IntelliJ stub, `pluggy build` writes `.classpath`. See [IDE integration](../ide.md). |
+| Old world                                 | pluggy equivalent                                                                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `pom.xml` or `build.gradle`               | `project.json`                                                                                                           |
+| `<dependencies>` or `implementation(...)` | `project.json:dependencies`                                                                                              |
+| `<repositories>` or `repositories { }`    | `project.json:registries` (Maven only)                                                                                   |
+| `maven-shade-plugin` config               | `project.json:shading`                                                                                                   |
+| `mvn package` or `./gradlew shadowJar`    | `pluggy build`                                                                                                           |
+| `mvn test` or `./gradlew test`            | `pluggy test` (JUnit Platform via `testDependencies`)                                                                    |
+| `plugin.yml` (hand-written)               | pluggy-generated, or staged via `resources`                                                                              |
+| `src/main/java/`                          | `src/`                                                                                                                   |
+| `src/main/resources/`                     | `project.json:resources` mapping                                                                                         |
+| IntelliJ/Eclipse import                   | Automatic. `pluggy init` writes the IntelliJ stub, `pluggy build` writes `.classpath`. See [IDE integration](../ide.md). |
 
 ## What pluggy does not do
 
@@ -262,7 +262,7 @@ unzip -l bin/myplugin-1.0.0.jar
 
 - **README.** Replace `mvn package` and `./gradlew build` with `pluggy build`. Replace `mvn clean` with `pluggy build --clean`. Replace `mvn test` with `pluggy test`.
 - **CI.** See [CI without global pluggy](./ci-without-global-pluggy.md).
-- **IDE import.** Just open the repo in your editor — `pluggy init` already wrote the IntelliJ stub and `pluggy build` writes `.classpath` for Eclipse and VS Code. No Maven or Gradle import flow.
+- **IDE import.** Just open the repo in your editor. `pluggy init` already wrote the IntelliJ stub and `pluggy build` writes `.classpath` for Eclipse and VS Code. No Maven or Gradle import flow.
 
 ## See also
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -71,7 +71,7 @@ Workspaces inherit the following fields from the root when unset:
 
 `registries` are **unioned** across the root and every workspace. Duplicates drop by URL. This is so a workspace can declare its own registry without re-declaring the root's.
 
-Everything else (`name`, `version`, `main`, `dependencies`, `shading`, `resources`, `dev`, `ide`) is workspace-local. A workspace's own `compatibility` wins over the root's when both declare it.
+Everything else (`name`, `version`, `main`, `dependencies`, `shading`, `resources`, `dev`) is workspace-local. A workspace's own `compatibility` wins over the root's when both declare it.
 
 ### What "inherited" looks like
 


### PR DESCRIPTION
## Summary

- The previous \`docs/ide.md\` described a \`project.json\` \`ide\` array selecting from \`vscode\` / \`eclipse\` / \`intellij\`, with \`pluggy build\` writing per-IDE scaffolding (including \`.vscode/settings.json\`). **None of that exists in the code** — the \`Project\` interface has no \`ide\` field (\`src/project.ts:9-34\`), no command reads one, and \`src/build/ide.ts\`'s file header is explicit: *"Pluggy never touches .vscode/ or .idea/. The classpath is the single source of truth."*
- Real flow: \`pluggy init\` writes the \`.idea/\` stub once so IntelliJ opens without an import wizard, \`pluggy build\` writes \`.classpath\` + \`.project\` on every build, and Eclipse / VS Code (via Red Hat Java) / IntelliJ (via the linked-Eclipse stub) all read from the classpath.
- Rewrites \`docs/ide.md\` (50 lines, was 156) to match. Removes the \`ide\` field section from \`docs/project-json.md\`. Fixes the lingering references in build-pipeline, commands/build, commands/init (which falsely claimed init had an IDE checkbox prompt), getting-started, docs/README, workspaces, and the maven-gradle migration recipe.
- Pure docs change; no code touched.

## Test plan

- [x] \`vp test\` — \`src/build/ide.test.ts\` and \`src/commands/init.test.ts\` still pass (no behavioural assumptions changed)
- [x] \`vp check\` — formatting + lint clean
- [x] Manual: \`grep -rE 'project\\.ide|\"ide\"|ide-optional|\\.vscode/settings\\.json' docs/\` returns nothing