### PR TITLE
docs: purge em-dashes from docs and source-emitted strings

### DIFF
--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -94,7 +94,7 @@ Templated extensions get `${project.x}` substitution before being written: `.yml
 Output-path collisions are resolved "first wins" and subsequent declarations are skipped with a warning:
 
 ```text
-⚠ resources: skipping "config.yml" — an earlier entry already resolved to the same output path
+⚠ resources: skipping "config.yml": an earlier entry already resolved to the same output path
 ```
 
 ## 6. Generate the descriptor

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -18,10 +18,10 @@ against `process.cwd()`.
 | `--name <name>`         | basename of target dir            | Must match `^[a-zA-Z0-9_-]+$`.                                                                                                                                                            |
 | `--version <semver>`    | `1.0.0`                           | Validated as `\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?`.                                                                                                                                             |
 | `--description <text>`  | `"A simple Minecraft plugin"`     | Free-form.                                                                                                                                                                                |
-| `--main <fqcn>`         | `com.example.Main`                | Must be a Java classpath — at least `package.Class`.                                                                                                                                      |
+| `--main <fqcn>`         | `com.example.Main`                | Must be a Java classpath; at least `package.Class`.                                                                                                                                       |
 | `--platform <id>`       | `paper`                           | Any registered platform: `paper`, `folia`, `spigot`, `bukkit`, `velocity`, `waterfall`, `travertine`, `sponge`. Repeatable, but must stay within one descriptor family (see error cases). |
 | `--mc-version <semver>` | highest compatible across targets | Minecraft version written to `compatibility.versions[0]`. Accepts both the legacy `1.21.8` shape and Mojang's new calendar scheme (`26.1.2`). See below.                                  |
-| `--template <id>`       | embedded family stub              | Scaffold from a richer template — see [Templates](#templates). Without this flag init uses the embedded family stub and never touches the network.                                        |
+| `--template <id>`       | embedded family stub              | Scaffold from a richer template; see [Templates](#templates). Without this flag init uses the embedded family stub and never touches the network.                                         |
 | `-y, --yes`             | off                               | Skip confirmations. Always on under `--json`.                                                                                                                                             |
 
 The `--version` here refers to the plugin's own `project.version`. The
@@ -137,7 +137,7 @@ Project "example" initialized successfully at /tmp/example
 | Existing project dir (no `-y`)    | As above.                                                                                                                                                                                                                              |
 
 Network failures during `getVersions()` propagate from the platform
-provider — see [Troubleshooting](../troubleshooting.md#network-errors-during-init-or-dev).
+provider. See [Troubleshooting](../troubleshooting.md#network-errors-during-init-or-dev).
 
 ## See also
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -93,7 +93,7 @@ If a name appears in both `dependencies` and `testDependencies`, the `testDepend
 ```java
 @Test
 void warnsWhenWorldEditMissing() {
-    // No extra plugins loaded — your plugin should detect the absence
+    // No extra plugins loaded. Your plugin should detect the absence
     // and fall back gracefully.
     plugin = MockBukkit.loadJar(new File(System.getProperty("pluggy.test.mainJar")));
     server.getPluginManager().enablePlugin(plugin);

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -63,13 +63,13 @@ Install manually:
 ## Managed installs (Homebrew, Scoop)
 
 `pluggy upgrade` refuses to run when it detects that the binary is owned
-by a package manager — overwriting it would leave the package manager's
+by a package manager. Overwriting it would leave the package manager's
 manifest pointing at a file it didn't install. Run the package manager's
 own upgrade instead:
 
 ```text
 $ pluggy upgrade
-✖ pluggy was installed via Homebrew; don't self-update — that would corrupt the package manager's tracking.
+✖ pluggy was installed via Homebrew. Don't self-update; that would corrupt the package manager's tracking.
 
 Run this instead:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ Homebrew:
 brew install pluggy-sh/tap/pluggy
 ```
 
-This taps `pluggy-sh/homebrew-tap` and installs the matching precompiled binary for your platform. Upgrade with `brew upgrade pluggy`. `pluggy upgrade` will refuse to self-update on Homebrew installs and tell you to use `brew upgrade`.
+This taps `pluggy-sh/homebrew-tap` and installs the matching precompiled binary for your platform. Upgrade with `brew upgrade pluggy`. `pluggy upgrade` refuses to self-update on Homebrew installs and tells you to use `brew upgrade`.
 
 ### Windows
 

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -126,16 +126,16 @@ the array by hand to add or remove editors later.
 
 The full platform roster ships with the binary:
 
-| id           | descriptor                     | Maven coordinate                           |
-| ------------ | ------------------------------ | ------------------------------------------ |
-| `paper`      | `plugin.yml`                   | `io.papermc.paper:paper-api`               |
-| `folia`      | `plugin.yml`                   | `dev.folia:folia-api`                      |
-| `spigot`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)       |
-| `bukkit`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)       |
-| `velocity`   | `velocity-plugin.json`         | `com.velocitypowered:velocity-api`         |
-| `waterfall`  | `bungee.yml`                   | `io.github.waterfallmc:waterfall-api`      |
-| `travertine` | `bungee.yml`                   | (no Maven API — compile against waterfall) |
-| `sponge`     | `META-INF/sponge_plugins.json` | `org.spongepowered:spongeapi`              |
+| id           | descriptor                     | Maven coordinate                          |
+| ------------ | ------------------------------ | ----------------------------------------- |
+| `paper`      | `plugin.yml`                   | `io.papermc.paper:paper-api`              |
+| `folia`      | `plugin.yml`                   | `dev.folia:folia-api`                     |
+| `spigot`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)      |
+| `bukkit`     | `plugin.yml`                   | `org.spigotmc:spigot-api` (SNAPSHOT)      |
+| `velocity`   | `velocity-plugin.json`         | `com.velocitypowered:velocity-api`        |
+| `waterfall`  | `bungee.yml`                   | `io.github.waterfallmc:waterfall-api`     |
+| `travertine` | `bungee.yml`                   | (no Maven API; compile against waterfall) |
+| `sponge`     | `META-INF/sponge_plugins.json` | `org.spongepowered:spongeapi`             |
 
 Paper handles version strings in two formats. For 1.17 to 1.21.x the artifact is `<version>-R0.1-SNAPSHOT`. For 26.x and later (Mojang's calendar scheme: 26.1, 26.1.1, 26.1.2) it's `<version>.build.<N>-alpha`. pluggy fetches PaperMC's `maven-metadata.xml` and picks the highest matching entry, so you write the plain Minecraft version and pluggy works out the rest.
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -107,7 +107,7 @@ export interface DoctorCommandResult {
   summary: { passed: number; warned: number; failed: number };
 }
 
-/** Env var names that influence pluggy's behaviour. Names only — never values. */
+/** Env var names that influence pluggy's behaviour. Names only; never values. */
 const TRACKED_ENV_VARS = [
   "APPDATA",
   "CI",

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -342,7 +342,7 @@ function extractLeafCertificatePem(bundle: Record<string, unknown>): string | un
 function printManagedInstallGuidance(install: InstallInfo, upgradeCmd: string): void {
   const label = describeInstallMethod(install.method);
   log.error(
-    `${red("✖")} pluggy was installed via ${label}; ${bold("don't")} self-update — that would corrupt the package manager's tracking.`,
+    `${red("✖")} pluggy was installed via ${label}. ${bold("Don't")} self-update; that would corrupt the package manager's tracking.`,
   );
   log.info("");
   log.info(`${bold("Run this instead:")}`);

--- a/src/defaults/sponge-package.java
+++ b/src/defaults/sponge-package.java
@@ -10,7 +10,7 @@ import org.spongepowered.plugin.builtin.jvm.Plugin;
 /**
  * Main plugin class for ${project.name}
  *
- * Sponge constructs this class via Guice — the constructor's parameters are
+ * Sponge constructs this class via Guice. The constructor's parameters are
  * dependency-injected. {@code @Listener} methods on the plugin class are
  * auto-registered against the plugin container. {@link ConstructPluginEvent}
  * is the canonical startup hook; later lifecycle events

--- a/src/defaults/velocity-package.java
+++ b/src/defaults/velocity-package.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
  * Main plugin class for ${project.name}
  *
  * Velocity discovers this class through the {@code @Plugin} annotation, then
- * builds it via Guice — the constructor's parameters are dependency-injected.
+ * builds it via Guice. The constructor's parameters are dependency-injected.
  * Lifecycle is event-driven: subscribe to {@code ProxyInitializeEvent} for
  * startup work and {@code ProxyShutdownEvent} for teardown.
  */

--- a/src/install-method.test.ts
+++ b/src/install-method.test.ts
@@ -34,7 +34,7 @@ describe("detectInstallMethod", () => {
       expected: "manual",
     },
 
-    // Unrecognised — anything else (e.g. dropped into /tmp by hand).
+    // Unrecognised: anything else (e.g. dropped into /tmp by hand).
     { path: "/tmp/pluggy", expected: "unknown" },
     { path: "/some/random/place/pluggy", expected: "unknown" },
   ];

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -71,11 +71,11 @@ export const brightBlue = color(pc.blueBright);
  * stays the only thing on stdout.
  *
  * Glyph budget:
- *   `✓` green   — success / done
- *   `✗` red     — error
- *   `!` yellow  — warning
- *   `›` dim     — step (indented progress)
- *   `·` dim     — debug
+ *   `✓` green   success / done
+ *   `✗` red     error
+ *   `!` yellow  warning
+ *   `›` dim     step (indented progress)
+ *   `·` dim     debug
  *
  * Compose with `tag(scope)` to label which subsystem produced the line:
  * `log.step(`${tag("dev")} change detected`)`.


### PR DESCRIPTION
## Summary

\`conventions/DOCUMENTATION.md\` says em-dashes are for the rare interruption nothing else carries. The codebase had drifted to using them as a default sentence-joiner in both prose and user-facing strings. This sweep replaces every em-dash in \`docs/\` and \`src/\` with a period, colon, or semicolon per the convention.

**Source code changes that affect emitted strings:**

- \`src/commands/upgrade.ts\`: the "don't self-update" managed-install guard message now uses periods. \`docs/commands/upgrade.md\`'s example output updated to match.
- \`src/logging.ts\`, \`src/commands/doctor.ts\`, \`src/install-method.test.ts\`: comment-only changes (no behaviour).
- \`src/defaults/{velocity,sponge}-package.java\`: template comments now use periods. New projects scaffolded from these templates inherit the cleaner punctuation.

**Docs-only changes** in \`getting-started.md\` (also swaps "will refuse" → present-tense "refuses" per the convention), \`commands/init.md\` flag descriptions, \`commands/test.md\` example code comment, \`build-pipeline.md\` (matched a literal-output line to the actual source string), and \`project-json.md\`.

## Test plan

- [x] \`vp test\` (557 passed, 4 skipped — no test referenced the changed strings)
- [x] \`vp check\` (formatting + lint clean)
- [x] \`grep -rn "—" src/ docs/\` returns nothing (one match in \`docs/ide.md\` is in old content that #33 fully replaces)