### PR TITLE
docs(ci): document pluggy-sh/setup-pluggy action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,6 @@ For GitHub Actions, consider using [`voidzero-dev/setup-vp`](https://github.com/
 ## Review Checklist for Agents
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.
-- [ ] Run `vp check` and `vp test` to validate changes.
+- [ ] Run `vp check` and `vp test` before every push, including docs-only changes. Oxfmt formats markdown too, so a missed `vp check` on a `.md` file fails CI just like a code change. Use `vp check --fix` to auto-fix formatting, then re-run `vp check` to confirm clean.
 - [ ] For release-shaped changes, verify `bun build --compile --outfile=bin/pluggy ./src/index.ts` still produces a working binary.
 <!--VITE PLUS END-->

--- a/docs/recipes/ci-without-global-pluggy.md
+++ b/docs/recipes/ci-without-global-pluggy.md
@@ -1,10 +1,60 @@
 # CI builds without pluggy installed globally
 
-CI runners usually don't have pluggy installed. You have two options: install it per job (simple, slightly slower) or check the binary into your CI image (fastest).
+CI runners usually don't have pluggy installed. You have three options: use the [`pluggy-sh/setup-pluggy`](https://github.com/pluggy-sh/setup-pluggy) GitHub Action (simplest on GitHub), install via the standalone script (works on any CI), or check the binary into your CI image (fastest).
 
-## Option 1: Install per job (recommended)
+## Option 1: `pluggy-sh/setup-pluggy` GitHub Action (recommended on GitHub Actions)
 
-pluggy's install script is standalone. On POSIX runners:
+The action installs pluggy, adds it to `PATH`, and restores the pluggy data-directory cache between runs.
+
+```yaml
+# .github/workflows/build.yml
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install pluggy
+        uses: pluggy-sh/setup-pluggy@v1
+
+      - name: Check project health
+        run: pluggy doctor
+
+      - name: Build
+        run: pluggy build --json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jar
+          path: bin/*.jar
+```
+
+Pin an exact pluggy version for reproducible builds:
+
+```yaml
+- uses: pluggy-sh/setup-pluggy@v1
+  with:
+    pluggy-version: '0.2.3'
+```
+
+The action's full input and output surface (cache toggling, cache key prefix, `pluggy-version` and `pluggy-path` outputs) is documented in the [setup-pluggy README](https://github.com/pluggy-sh/setup-pluggy#readme). It works on `ubuntu-*`, `macos-*`, and `windows-*` runners without per-OS workarounds.
+
+## Option 2: Install per job with the standalone script
+
+Use this on CIs other than GitHub Actions, or when you want to avoid an action dependency. pluggy's install script is standalone. On POSIX runners:
 
 ```yaml
 # .github/workflows/build.yml
@@ -57,7 +107,7 @@ Notes:
 - `pluggy doctor` catches config drift in a PR before the build attempts it and fails with a longer error.
 - `pluggy build --json` emits one envelope per workspace. A failed build exits `1` without terminating the step from an unrelated error.
 
-## Option 2: Pin a specific pluggy version
+## Option 3: Pin a specific pluggy version
 
 The install script always fetches `latest`. For reproducible builds, pin
 a tag:
@@ -72,7 +122,7 @@ echo "$HOME/.pluggy/bin" >> $GITHUB_PATH
 
 Bump `VERSION` when you want to move to a newer pluggy.
 
-## Option 3: Check the binary into a container image
+## Option 4: Check the binary into a container image
 
 For self-hosted runners or when you're already building a custom
 container:
@@ -88,7 +138,7 @@ For ARM runners, swap `-linux-amd64` for `-linux-arm64`.
 
 ## Windows runners
 
-The PowerShell install script adds the binary to your user `PATH`, which doesn't propagate to the same job step. Either fully qualify the path or add the directory to `$env:PATH` explicitly:
+`pluggy-sh/setup-pluggy@v1` already handles `PATH` on `windows-*` runners. If you skip the action and call the PowerShell install script directly, the binary lands in your user `PATH`, which doesn't propagate to the same job step. Either fully qualify the path or add the directory to `$env:PATH` explicitly:
 
 ```yaml
 - name: Install pluggy

--- a/docs/recipes/ci-without-global-pluggy.md
+++ b/docs/recipes/ci-without-global-pluggy.md
@@ -47,7 +47,7 @@ Pin an exact pluggy version for reproducible builds:
 ```yaml
 - uses: pluggy-sh/setup-pluggy@v1
   with:
-    pluggy-version: '0.2.3'
+    pluggy-version: "0.2.3"
 ```
 
 The action's full input and output surface (cache toggling, cache key prefix, `pluggy-version` and `pluggy-path` outputs) is documented in the [setup-pluggy README](https://github.com/pluggy-sh/setup-pluggy#readme). It works on `ubuntu-*`, `macos-*`, and `windows-*` runners without per-OS workarounds.


### PR DESCRIPTION
## Summary

- Add a recommended Option 1 to `docs/recipes/ci-without-global-pluggy.md` covering [`pluggy-sh/setup-pluggy`](https://github.com/pluggy-sh/setup-pluggy) with a full workflow example, version pinning, and a link to the action's README.
- Renumber the existing curl-script / pin-version / Dockerfile options to 2-4 and reword the intro to reflect three options.
- Update the Windows-runners note to point to setup-pluggy as the primary path; the manual `$GITHUB_PATH` workaround is now framed as a fallback for the standalone script.
- Strengthen the "Review Checklist for Agents" bullet in `CLAUDE.md` to require `vp check` before every push (including docs-only changes), since Oxfmt formats markdown too.

## Test plan

- [x] `vp check` (clean for tracked files; only gitignored `.context/` files flagged locally)
- [x] Manual: rendered the diff and confirmed headings, code fences, and links read cleanly.
