### PR TITLE
docs: reword 'single-binary' to 'self-contained' / 'standalone'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Vite+ (`vp`) drives the development loop. Bun produces the shipped CLI binary. S
 - `vp dev` / `vp pack` - library build during development
 - `bun build --compile --outfile=bin/pluggy ./src/index.ts` - standalone CLI binary for releases
 
-Vite+'s `pack` only emits JavaScript. The single-file executable is always produced with Bun's `--compile` flag, which is what ships to users via the install scripts.
+Vite+'s `pack` only emits JavaScript. The standalone executable is always produced with Bun's `--compile` flag, which is what ships to users via the install scripts.
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md
 
 ### Prerequisites
 
-- [Bun](https://bun.sh/) 1.3 or later (for producing the single-file binary via `bun build --compile`).
+- [Bun](https://bun.sh/) 1.3 or later (for producing the standalone binary via `bun build --compile`).
 - [Vite+](https://vite.plus/) (`vp`) for the day-to-day dev loop: install, check, lint, format, test.
 - Git.
 - A text editor or IDE.
@@ -43,7 +43,7 @@ By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md
    vp test
    ```
 
-4. Build and smoke-test the single-file binary:
+4. Build and smoke-test the standalone binary:
 
    ```bash
    bun build --compile --outfile=bin/pluggy ./src/index.ts

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # pluggy docs
 
-pluggy is a single-binary toolchain for Minecraft plugin development. Scaffold a project, install dependencies from Modrinth, Maven, local jars, or sibling workspaces, build a real plugin jar, and boot a live Paper, Spigot, Velocity, or Sponge server that rebuilds when you save.
+pluggy is a self-contained toolchain for Minecraft plugin development. Scaffold a project, install dependencies from Modrinth, Maven, local jars, or sibling workspaces, build a real plugin jar, and boot a live Paper, Spigot, Velocity, or Sponge server that rebuilds when you save.
 
 No global JVM toolchain, no Gradle wrapper, no `pom.xml`. One `project.json` per project.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ Manage it later with [`pluggy cache`](./commands/cache.md) or [`pluggy sdk`](./c
 
 ### macOS and Linux
 
-Pick either the install script or Homebrew. Both drop a single binary on your `PATH` and don't need `sudo`.
+Pick either the install script or Homebrew. Both drop the `pluggy` binary on your `PATH` and don't need `sudo`.
 
 Install script:
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,6 +1,6 @@
 # Uninstalling pluggy
 
-pluggy has no `pluggy uninstall` command. The install script drops a single binary on your `PATH`, edits one shell profile, and writes a cache the first time you build. To remove pluggy you reverse those three steps. This page lists the exact paths for each install method.
+pluggy has no `pluggy uninstall` command. The install script drops the `pluggy` binary on your `PATH`, edits one shell profile, and writes a cache the first time you build. To remove pluggy you reverse those three steps. This page lists the exact paths for each install method.
 
 If you only want to free disk space without removing the CLI, run [`pluggy cache clean`](./commands/cache.md) instead. That wipes the download cache and leaves the binary in place.
 

--- a/src/sdk/install.ts
+++ b/src/sdk/install.ts
@@ -128,7 +128,7 @@ async function downloadArchive(spec: JdkSpec, destPath: string): Promise<void> {
   await mkdir(dirname(destPath), { recursive: true });
   const tmpPath = `${destPath}.partial`;
   // We allocate a single buffer rather than streaming to disk because Bun's
-  // single-file binary doesn't ship a `Readable.fromWeb` polyfill that's
+  // standalone binary doesn't ship a `Readable.fromWeb` polyfill that's
   // reliable across platforms; and JDK archives are bounded (≈200 MB).
   // Worth revisiting if we ever cache larger artifacts.
   const buf = new Uint8Array(await res.arrayBuffer());


### PR DESCRIPTION
## Summary

- Top-of-docs pitch in `docs/README.md` now reads "self-contained toolchain" instead of "single-binary toolchain".
- Install/uninstall prose says the install methods drop "the `pluggy` binary on your `PATH`" instead of "a single binary".
- `CONTRIBUTING.md`, `CLAUDE.md`, and the comment in `src/sdk/install.ts` now refer to the Bun `--compile` output as the "standalone binary" / "standalone executable".

## Test plan

- [x] `vp check` (format, lint, type-check)
- [x] `grep` confirms no remaining `single-binary` / `single binary` / `single-file binary` / `single-file executable` mentions