### PR TITLE
fix(sdk): honor pinned JDK in run + accept distribution+major args

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -16,12 +16,15 @@
  */
 
 import { spawn } from "node:child_process";
+import { delimiter, join } from "node:path";
 import process from "node:process";
 
 import { Command, InvalidArgumentError } from "commander";
 
 import { bold, dim, emit, emitErr, log } from "../logging.ts";
 import { runWorkspaces, type RunResult } from "../runner.ts";
+import { getCachedJdk } from "../sdk/index.ts";
+import { selectJdkForProject } from "../sdk/resolve.ts";
 import { replace } from "../template.ts";
 import {
   resolveWorkspaceContext,
@@ -225,10 +228,13 @@ async function runOne(
   const extraLabel = extraArgs.length > 0 ? ` ${dim(`+ ${extraArgs.join(" ")}`)}` : "";
   log.info(`${dim(prefix)} ${bold(scriptName)}: ${expanded}${extraLabel}`);
 
+  const env = await projectJdkEnv(node);
+
   return new Promise<RunOneResult>((resolveP, rejectP) => {
     const child = spawn(cmd, args, {
       cwd: node.root,
       stdio: ["ignore", "pipe", "pipe"],
+      env,
     });
 
     const onLine = (stream: "stdout" | "stderr") => (chunk: Buffer | string) => {
@@ -249,6 +255,25 @@ async function runOne(
       resolveP({ expanded: argv, exitCode });
     });
   });
+}
+
+/**
+ * Build the child env for a workspace, prepending the project's pinned JDK
+ * to `PATH` and setting `JAVA_HOME` when a matching JDK is already cached.
+ *
+ * Cache-only by design: `pluggy run` shouldn't trigger a 200 MB JDK download
+ * for a script that may not even invoke Java. `pluggy build` / `pluggy dev`
+ * are the commands that auto-install.
+ */
+async function projectJdkEnv(node: WorkspaceNode): Promise<NodeJS.ProcessEnv> {
+  const base = { ...process.env };
+  const selection = await selectJdkForProject(node.project);
+  const cached = getCachedJdk(selection.major, selection.distribution);
+  if (cached === undefined) return base;
+  base.JAVA_HOME = cached.javaHome;
+  const binDir = join(cached.javaHome, "bin");
+  base.PATH = base.PATH !== undefined ? `${binDir}${delimiter}${base.PATH}` : binDir;
+  return base;
 }
 
 /**

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -148,11 +148,17 @@ function listSubcommand(): Command {
 function pathSubcommand(): Command {
   return new Command("path")
     .description("Print JAVA_HOME for a cached JDK. Exits 1 if not installed.")
-    .argument("<major>", "Java major release.")
-    .option("--distribution <name>", "JDK distribution.", parseDistribution, "temurin")
-    .action(async function action(this: Command, majorArg: string, options) {
-      const major = parseMajor(majorArg);
-      const distribution = options.distribution as AllowedDistribution;
+    .argument("<major-or-distribution>", "Java major release, or distribution if <major> follows.")
+    .argument("[major]", "Java major release (when the first arg is a distribution).")
+    .option("--distribution <name>", "JDK distribution.", parseDistribution, undefined)
+    .action(async function action(
+      this: Command,
+      firstArg: string,
+      secondArg: string | undefined,
+      options,
+    ) {
+      const { major, distribution: positional } = splitMajorAndDistribution(firstArg, secondArg);
+      const distribution = resolveDistribution(positional, options.distribution) ?? "temurin";
 
       const cached = getCachedJdk(major, distribution);
       if (cached === undefined) {
@@ -193,12 +199,18 @@ function pathSubcommand(): Command {
 function useSubcommand(): Command {
   return new Command("use")
     .description("Pin a JDK in the current project.json so teammates land on the same one.")
-    .argument("<major>", "Java major release.")
+    .argument("<major-or-distribution>", "Java major release, or distribution if <major> follows.")
+    .argument("[major]", "Java major release (when the first arg is a distribution).")
     .option("--distribution <name>", "JDK distribution.", parseDistribution, undefined)
-    .action(async function action(this: Command, majorArg: string, options) {
+    .action(async function action(
+      this: Command,
+      firstArg: string,
+      secondArg: string | undefined,
+      options,
+    ) {
       const globalOpts = this.optsWithGlobals() as SdkGlobalOpts;
-      const major = parseMajor(majorArg);
-      const distribution = options.distribution as AllowedDistribution | undefined;
+      const { major, distribution: positional } = splitMajorAndDistribution(firstArg, secondArg);
+      const distribution = resolveDistribution(positional, options.distribution);
 
       const project = loadProject(globalOpts);
 
@@ -228,11 +240,17 @@ function removeSubcommand(): Command {
   return new Command("remove")
     .alias("rm")
     .description("Delete a cached JDK.")
-    .argument("<major>", "Java major release.")
-    .option("--distribution <name>", "JDK distribution.", parseDistribution, "temurin")
-    .action(async function action(this: Command, majorArg: string, options) {
-      const major = parseMajor(majorArg);
-      const distribution = options.distribution as AllowedDistribution;
+    .argument("<major-or-distribution>", "Java major release, or distribution if <major> follows.")
+    .argument("[major]", "Java major release (when the first arg is a distribution).")
+    .option("--distribution <name>", "JDK distribution.", parseDistribution, undefined)
+    .action(async function action(
+      this: Command,
+      firstArg: string,
+      secondArg: string | undefined,
+      options,
+    ) {
+      const { major, distribution: positional } = splitMajorAndDistribution(firstArg, secondArg);
+      const distribution = resolveDistribution(positional, options.distribution) ?? "temurin";
 
       const removed = await removeJdk(major, distribution);
 
@@ -256,6 +274,42 @@ function parseMajor(value: string): number {
     throw new InvalidArgumentError(`"${value}" is not a valid Java major release`);
   }
   return n;
+}
+
+/**
+ * Split the two positional slots into `{ major, distribution }`. Mirrors how
+ * `sdk list` formats entries (`<distribution> <major>`) so users can copy a
+ * line straight off the listing. Two shapes:
+ *   pluggy sdk use 21
+ *   pluggy sdk use temurin 21
+ * Commander can't model `[opt] <req>` directly (single args always fill the
+ * first slot), so we accept `<first> [second]` and disambiguate here.
+ */
+function splitMajorAndDistribution(
+  first: string,
+  second: string | undefined,
+): { major: number; distribution: AllowedDistribution | undefined } {
+  if (second === undefined) {
+    return { major: parseMajor(first), distribution: undefined };
+  }
+  return { major: parseMajor(second), distribution: parseDistribution(first) };
+}
+
+/**
+ * Reconcile a distribution from the positional `[distribution]` arg and the
+ * `--distribution` option. Errors when both are given and disagree so users
+ * don't get a silent winner.
+ */
+function resolveDistribution(
+  positional: AllowedDistribution | undefined,
+  fromOption: AllowedDistribution | undefined,
+): AllowedDistribution | undefined {
+  if (positional !== undefined && fromOption !== undefined && positional !== fromOption) {
+    throw new InvalidArgumentError(
+      `distribution given twice and disagrees: "${positional}" vs --distribution ${fromOption}`,
+    );
+  }
+  return positional ?? fromOption;
 }
 
 function loadProject(globalOpts: SdkGlobalOpts): ResolvedProject {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,10 +137,21 @@ try {
     process.exit(0);
   }
 
+  // Input errors take precedence over commander's hardcoded `exitCode = 1` on
+  // InvalidArgumentError so they exit 2 (CLI-usage convention), matching the
+  // treatment of UserError.
   const exitCode =
-    error.exitCode ?? (error instanceof UserError || error instanceof InvalidArgumentError ? 2 : 1);
+    error instanceof UserError || error instanceof InvalidArgumentError ? 2 : (error.exitCode ?? 1);
 
-  if (error.code?.startsWith("commander.") && !wantsJson) {
+  // Commander prints its own parse-time errors before throwing and rewraps
+  // them as plain CommanderError instances; suppress to avoid double-printing.
+  // Action-thrown InvalidArgumentError is *not* printed by commander, so let
+  // those fall through to emitError below.
+  if (
+    error.code?.startsWith("commander.") &&
+    !(error instanceof InvalidArgumentError) &&
+    !wantsJson
+  ) {
     process.exit(exitCode);
   }
 


### PR DESCRIPTION
## Summary

- `pluggy sdk use|path|remove` now accept `<distribution> <major>` as well as `<major>`, matching how `sdk list` formats entries (`temurin 17`). `--distribution` still works; conflicts between the positional and the option throw `InvalidArgumentError`.
- `pluggy run <script>` now prepends the project's cached, pinned JDK to `PATH` and sets `JAVA_HOME` for the spawned child, so scripts see the same Java as `build` / `dev`. Cache-only — running a script never triggers a JDK download.
- Top-level error handler in `src/index.ts` no longer swallows `InvalidArgumentError` thrown from action bodies (commander never prints those), and now actually exits 2 for `InvalidArgumentError` / `UserError` as the existing fallback intended (commander hardcodes `exitCode=1`, which short-circuited the fallback).

## Test plan

- [x] `vp check`
- [x] `vp test` (658 passed, 4 skipped, unchanged)
- [x] Manual via `playground/`:
  - `pluggy sdk use temurin 17`, `pluggy sdk use 21`, and `--distribution` conflict path
  - `pluggy run fish` (script `java --version`) with `jdk.major: 17` pinned → resolves Temurin 17, not system OpenJDK 25
  - `pluggy sdk use abc` now prints the error (was silent) and exits 2