### PR TITLE
fix(papermc): fall back to SNAPSHOT form when metadata fetch rejects

### DIFF
--- a/src/platform/papermc/papermc.test.ts
+++ b/src/platform/papermc/papermc.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vite-plus/test";
-import { download, versions } from "./papermc.ts";
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
+import { download, resolveApiVersion, versions } from "./papermc.ts";
 
 test("papermc versions", async () => {
   const result = await versions("paper");
@@ -14,4 +14,53 @@ test("papermc download latest version", async () => {
   expect(result.version).toBe(latestVersion);
   expect(result.build).toBeGreaterThan(0);
   expect(result.output instanceof ArrayBuffer).toBe(true);
+});
+
+describe("resolveApiVersion", () => {
+  const URL = "https://example.invalid/metadata.xml";
+  const original = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = original;
+  });
+
+  test("picks the highest build-stamped entry", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          "<metadata><versions>" +
+            "<version>1.21.11-R0.1-SNAPSHOT</version>" +
+            "<version>26.1.2.build.6-stable</version>" +
+            "<version>26.1.2.build.8-stable</version>" +
+            "<version>26.1.2.build.7-stable</version>" +
+            "</versions></metadata>",
+          { status: 200 },
+        ),
+    ) as typeof fetch;
+    await expect(resolveApiVersion(URL, "26.1.2")).resolves.toBe("26.1.2.build.8-stable");
+  });
+
+  test("falls back to <mc>-R0.1-SNAPSHOT when no build-stamped entry matches", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          "<metadata><versions><version>1.21.8-R0.1-SNAPSHOT</version></versions></metadata>",
+          {
+            status: 200,
+          },
+        ),
+    ) as typeof fetch;
+    await expect(resolveApiVersion(URL, "1.21.8")).resolves.toBe("1.21.8-R0.1-SNAPSHOT");
+  });
+
+  test("falls back to <mc>-R0.1-SNAPSHOT on non-2xx response", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("nope", { status: 503 })) as typeof fetch;
+    await expect(resolveApiVersion(URL, "1.21.8")).resolves.toBe("1.21.8-R0.1-SNAPSHOT");
+  });
+
+  test("falls back to <mc>-R0.1-SNAPSHOT when fetch itself rejects (offline)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+    await expect(resolveApiVersion(URL, "1.21.8")).resolves.toBe("1.21.8-R0.1-SNAPSHOT");
+  });
 });

--- a/src/platform/papermc/papermc.ts
+++ b/src/platform/papermc/papermc.ts
@@ -49,14 +49,23 @@ export function versions(project: Project): Promise<Version[]> {
  *
  * Fetches the artifact's top-level `maven-metadata.xml` and prefers the
  * highest build-stamped entry. Falls back to the SNAPSHOT form when no
- * build-stamped entry exists (or metadata isn't reachable) so the Maven
- * resolver surfaces a specific 404 instead of a cryptic "no match".
+ * build-stamped entry exists, the metadata is unreachable (non-2xx), or
+ * the fetch itself rejects (DNS, offline, TLS). The fallback keeps
+ * offline/cached Folia builds working: the Maven resolver can satisfy
+ * `<mc>-R0.1-SNAPSHOT` from a previously-installed cache without ever
+ * hitting the network. When upstream really is gone the resolver
+ * surfaces a precise 404 instead of a cryptic "no match".
  */
 export async function resolveApiVersion(metadataUrl: string, mcVersion: string): Promise<string> {
   const snapshotForm = `${mcVersion}-R0.1-SNAPSHOT`;
-  const res = await fetch(metadataUrl);
-  if (!res.ok) return snapshotForm;
-  const xml = await res.text();
+  let xml: string;
+  try {
+    const res = await fetch(metadataUrl);
+    if (!res.ok) return snapshotForm;
+    xml = await res.text();
+  } catch {
+    return snapshotForm;
+  }
   const all = Array.from(xml.matchAll(/<version>([^<]+)<\/version>/g), (m) => m[1]);
 
   const buildStamped = all.filter((v) => v.startsWith(`${mcVersion}.build.`));


### PR DESCRIPTION
## Summary

- `papermc.resolveApiVersion` handled `!res.ok` but let `fetch` rejections (DNS failure, offline, TLS) propagate. Since #40 routed `folia.api()` through this helper instead of the deterministic `${mc}-R0.1-SNAPSHOT` coordinate Folia used before, an offline build that could previously satisfy `folia-api` from the Maven cache started failing on the metadata fetch.
- Wraps the fetch in `try/catch` so the SNAPSHOT form falls through on any network error, restoring offline-cached-build behaviour. Sponge's equivalent helper already had this shape; this brings the PaperMC helper in line.
- Added unit tests covering all four resolution paths (build-stamped hit, no match, non-2xx, fetch reject), mocking `globalThis.fetch`.

## Test plan

- [x] `vp test src/platform/papermc/papermc.test.ts` (6 passed)
- [x] `vp check`
- [ ] CI