### PR TITLE
docs: friendlier on-ramp across troubleshooting, project.json, dependencies, build

### DIFF
--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -4,25 +4,11 @@ A full walkthrough of what `pluggy build` does between reading `project.json` an
 
 ## The high-level sequence
 
-```text
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│  pick         │ → │  stage        │ → │  resolve      │
-│  descriptor   │   │  directory    │   │  dependencies │
-└───────────────┘   └───────────────┘   └───────────────┘
-                                              │
-                     ┌────────────────────────┘
-                     ↓
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│  write IDE    │ → │  stage        │ → │  generate     │
-│  files        │   │  resources    │   │  descriptor   │
-└───────────────┘   └───────────────┘   └───────────────┘
-                                              │
-                     ┌────────────────────────┘
-                     ↓
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│  compile      │ → │  apply        │ → │  zip          │
-│  (javac)      │   │  shading      │   │  to jar       │
-└───────────────┘   └───────────────┘   └───────────────┘
+```mermaid
+flowchart LR
+    A[pick descriptor] --> B[stage directory] --> C[resolve dependencies]
+    C --> D[write IDE files] --> E[stage resources] --> F[generate descriptor]
+    F --> G[compile with javac] --> H[apply shading] --> I[zip to jar]
 ```
 
 Each box corresponds to a module under `src/build/`.

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -63,23 +63,6 @@ Rebuild triggered for 2 workspaces (core, plugin)
 
 `--watch` is for tight iteration loops. For a running test server that reloads on rebuild, use [`pluggy dev`](./dev.md).
 
-## Pipeline
-
-For each target workspace, pluggy runs the steps below in order. Every step lives in its own module under `src/build/`.
-
-1. **Pick the descriptor.** Check that every declared platform shares the same [descriptor family](../glossary.md#descriptor-family). Errors with "Split them into separate workspaces, one per family." if they don't.
-2. **Stage directory.** Under `<workspace>/.pluggy-build/<hash>/`, where `<hash>` is the first 12 hex chars of `sha256(name \0 version \0 rootDir)`. `--clean` wipes this first.
-3. **Resolve dependencies.** Every declared dep, plus the primary platform's `api()` Maven coordinate. Registries are the platform's own repos first, followed by `project.registries`, with order-preserving dedup.
-4. **Write IDE files.** Writes `.classpath` and `.project` at the project root unless `--skip-classpath` was passed. Failures are logged at debug but don't abort the build.
-5. **Stage resources.** Copy `project.resources` into the staging dir, and run `.yml`, `.yaml`, `.json`, `.properties`, `.txt`, and `.md` files through the `${project.x}` template substitution.
-6. **Generate the descriptor.** Unless a resource entry already claims the descriptor path (`plugin.yml` and friends), pluggy writes the generated one to the staging dir.
-7. **Compile.** `javac -encoding UTF-8 -d <staging> -cp <classpath> <sources>`. The classpath separator is `:` on POSIX and `;` on Windows, handled by Node's `path.delimiter`.
-8. **Shade.** For each entry in `project.shading`, unzip the matching `include` entries from the dep jar and write them into the staging dir. `exclude` is subtracted after.
-9. **Zip.** Walk the staging dir, sort entries lexicographically, write a zip with forward-slashed entry paths.
-10. **Platform compile-check.** For every non-primary platform declared in `compatibility.platforms` (`platforms[1..]`), pluggy runs `checkPlatformCompile`: a `javac` invocation against that platform's API jar with no artifacts emitted. The primary platform was already compiled in step 7, so this catches cases where your source is Paper-clean but references a symbol missing on Spigot, Folia, or a Bungee-family platform. A failing check logs a warning and sets the exit code to `1`, but the primary jar still ships.
-
-The output jar is written to `<output>` after the staging dir is zipped.
-
 ## Output
 
 Human, single workspace:
@@ -152,6 +135,25 @@ Exit code is `0` when everything succeeds, `1` otherwise.
 ## Single-workspace vs multi-workspace failure
 
 Single-workspace builds rethrow the first exception. The CLI's top-level handler prints it. Multi-workspace builds continue past a failed workspace, report everyone's status in the summary, and exit `1` if anything failed.
+
+## Pipeline
+
+You can skip this section unless you're debugging a build failure or planning a `shading` rule. For typical use, the high-level summary at the top of this page is enough.
+
+For each target workspace, pluggy runs the steps below in order:
+
+1. **Pick the descriptor.** Check that every declared platform shares the same [descriptor family](../glossary.md#descriptor-family). Errors with "Split them into separate workspaces, one per family." if they don't.
+2. **Stage directory.** Under `<workspace>/.pluggy-build/<hash>/`, where `<hash>` is the first 12 hex chars of `sha256(name \0 version \0 rootDir)`. `--clean` wipes this first.
+3. **Resolve dependencies.** Every declared dep, plus the primary platform's `api()` Maven coordinate. Registries are the platform's own repos first, followed by `project.registries`, with order-preserving dedup.
+4. **Write IDE files.** Writes `.classpath` and `.project` at the project root unless `--skip-classpath` was passed. Failures are logged at debug but don't abort the build.
+5. **Stage resources.** Copy `project.resources` into the staging dir, and run `.yml`, `.yaml`, `.json`, `.properties`, `.txt`, and `.md` files through the `${project.x}` template substitution.
+6. **Generate the descriptor.** Unless a resource entry already claims the descriptor path (`plugin.yml` and friends), pluggy writes the generated one to the staging dir.
+7. **Compile.** `javac -encoding UTF-8 -d <staging> -cp <classpath> <sources>`. The classpath separator is `:` on POSIX and `;` on Windows, handled by Node's `path.delimiter`.
+8. **Shade.** For each entry in `project.shading`, unzip the matching `include` entries from the dep jar and write them into the staging dir. `exclude` is subtracted after.
+9. **Zip.** Walk the staging dir, sort entries lexicographically, write a zip with forward-slashed entry paths.
+10. **Platform compile-check.** For every non-primary platform declared in `compatibility.platforms` (`platforms[1..]`), pluggy runs `checkPlatformCompile`: a `javac` invocation against that platform's API jar with no artifacts emitted. The primary platform was already compiled in step 7, so this catches cases where your source is Paper-clean but references a symbol missing on Spigot, Folia, or a Bungee-family platform. A failing check logs a warning and sets the exit code to `1`, but the primary jar still ships.
+
+The output jar is written to `<output>` after the staging dir is zipped.
 
 ## Error cases
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,6 +1,14 @@
 # Dependencies
 
-Four [source kinds](./glossary.md#source-kind), one grammar, one [lockfile](./glossary.md#lockfile). Every dependency you install ends up in one of these four categories.
+A dependency is anything your plugin needs at build time or runtime that isn't your own source code. pluggy resolves dependencies from four [source kinds](./glossary.md#source-kind), records them in `project.json:dependencies`, and pins exact versions in [`pluggy.lock`](./glossary.md#lockfile).
+
+Most installs look like this:
+
+```text
+pluggy install worldedit
+```
+
+The CLI works out the source kind from the identifier, resolves the latest stable version, and writes both files for you. The four source kinds and the full identifier grammar are below.
 
 ## Source kinds
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -171,10 +171,6 @@ Top-level entries have non-empty `declaredBy`. Pure transitives have `declaredBy
 
 The file is written atomically: pluggy creates a `.<pid>.<rand>.tmp` sibling and `rename`s over the target. Entries are sorted by key so diffs are deterministic. Trailing LF.
 
-### Migrating from version 1
-
-Version 1 lockfiles nested transitives inline (`transitives: LockfileEntry[]`). Version 2 flattens everything by name. Lockfiles are regenerated on the next `pluggy install`, so the migration is automatic. Delete `pluggy.lock` and run `pluggy install` if you hit a parse error from a stale file.
-
 ### When pluggy rewrites it
 
 - `pluggy install`: on a single-identifier run, adds or updates that one entry. On a bare `install`, resolves anything stale and prunes orphans.

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -1,10 +1,30 @@
 # `project.json` reference
 
-This is the one file pluggy reads. It lives at the repo root, or at the root of each [workspace](./glossary.md#workspace) in a monorepo. pluggy walks up from the current directory until it finds one, then walks back down (if workspaces are declared) to classify which workspace you're sitting in.
+`project.json` is the one file pluggy reads to configure your plugin. It lives at the repo root, or at the root of each [workspace](./glossary.md#workspace) in a monorepo.
 
-Every field is documented below. If a term is unfamiliar, check the [glossary](./glossary.md).
+Every field is documented below. If a term is unfamiliar, check the [glossary](./glossary.md). For a guided walkthrough of a first plugin, see [getting started](./getting-started.md).
 
-## Shape
+## The smallest `project.json`
+
+Four fields are required to build a plugin. `pluggy init` writes them for you, but a hand-rolled minimum looks like this:
+
+```json
+{
+  "name": "my_plugin",
+  "version": "1.0.0",
+  "main": "com.example.myplugin.Main",
+  "compatibility": {
+    "versions": ["1.21.8"],
+    "platforms": ["paper"]
+  }
+}
+```
+
+That's enough for `pluggy build` to produce a jar and `pluggy dev` to start a server. Everything in the full shape below is optional and documented per field further down.
+
+## Full shape
+
+The example below uses every supported field. Use it as a reference of what's possible, not a template to copy.
 
 ```json
 {
@@ -67,8 +87,6 @@ Every field is documented below. If a term is unfamiliar, check the [glossary](.
   "workspaces": []
 }
 ```
-
-No field in this example is unique to that structure. You'll see them one at a time below.
 
 ## Fields
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Common failures, grouped by command and stage. Error messages here are copied verbatim from the code, with placeholders (`<...>`) for interpolated values. If a term is unfamiliar, check the [glossary](./glossary.md).
+Find your error here, then read the fix. Entries are grouped by the command that surfaces them, with the exact error message shown verbatim under each section so you can Ctrl-F the text pluggy printed. Placeholders in error messages use `<...>` for interpolated values. If a term is unfamiliar, check the [glossary](./glossary.md).
 
 ## Error format
 
@@ -34,30 +34,46 @@ Exit codes: `2` for user input problems (`UserError`), `1` for runtime failures 
 
 ## `pluggy init`
 
-### `Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.`
+### Invalid project name
 
-`--name` must match `^[a-zA-Z0-9_-]+$`. Dots and Unicode aren't allowed. This is enforced by `init` and checked again by `doctor`.
+Pick a name made of letters, digits, underscores, and hyphens only. `--name` must match `^[a-zA-Z0-9_-]+$`. Dots and Unicode aren't allowed. This is enforced by `init` and checked again by `doctor`.
 
-### `Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).`
+```text
+Invalid project name: "<name>". Only alphanumeric characters, underscores, and hyphens are allowed.
+```
+
+### Invalid main class
 
 `--main` must be a dotted Java class path with at least one dot (`package.Class`). Single-word class names aren't accepted. Java requires a package for production plugin classes.
 
-### Network errors during init or dev
+```text
+Invalid main class: "<main>". It must be a valid Java classpath (e.g., com.example.Main).
+```
+
+### Network errors during `init` or `dev`
 
 `pluggy init` calls `getVersions()` on every selected platform in parallel and picks the highest version they all publish. If your network is offline or the upstream is down:
 
 - Pass `--mc-version <semver>` to skip the network call entirely.
-- Or just put a version in `project.json` after `init` completes.
+- Or set a version in `project.json` after `init` completes.
 
-### `No compatible Minecraft version found across platforms: <list>.`
+### No compatible Minecraft version across platforms
 
 pluggy couldn't find a Minecraft version that every selected platform publishes. Most often this is a short-lived gap where one provider publishes a new release before another (for example Paper ships `26.1.2` hours or days before Spigot's BuildTools catches up). Either drop the platform that's lagging, or pin the version yourself with `--mc-version`.
 
-### `Platform "<b>" cannot be combined with "<a>" because they target different plugin families ...`
+```text
+No compatible Minecraft version found across platforms: <list>.
+```
+
+### Platforms from different families on `--platform`
 
 `--platform` was given values from two different descriptor families (for example `paper` and `velocity`). A single plugin jar can only target one family: server plugins (`paper`, `folia`, `spigot`, `bukkit`), BungeeCord proxy plugins (`waterfall`, `travertine`), Velocity plugins, or Sponge plugins. Re-run init for the second family in a sibling directory, or split an existing monorepo using [workspaces](./workspaces.md#multi-family-monorepos).
 
-### BuildTools fails mid-init or during `pluggy dev` on a freshly scaffolded spigot project
+```text
+Platform "<b>" cannot be combined with "<a>" because they target different plugin families ...
+```
+
+### BuildTools fails on a fresh spigot project
 
 pluggy provisions a JDK matching the chosen Minecraft version's class-file range, so a build mismatch normally can't happen. If BuildTools still errors out (typically `FileNotFoundException ... DataComponentPatch.java`), the most likely cause is `JAVA_HOME` taking precedence and pointing at a toolchain that doesn't satisfy the range. Unset `JAVA_HOME` to force pluggy to provision its own JDK, or pin the JDK explicitly with [`pluggy sdk use`](./commands/sdk.md#use).
 
@@ -65,28 +81,43 @@ pluggy provisions a JDK matching the chosen Minecraft version's class-file range
 
 ## `pluggy install` / `pluggy remove`
 
-### `install: at the workspace root, pass --workspace <name> to pick a target for "<plugin>"`
+### `install` at the workspace root needs `--workspace`
 
 You ran `pluggy install <identifier>` at a multi-workspace root. pluggy doesn't know which workspace to add the dep to. Pass `--workspace <name>` to choose one.
 
-### `install: --workspaces and a specific [plugin] are mutually exclusive, pick one workspace with --workspace <name>`
+```text
+install: at the workspace root, pass --workspace <name> to pick a target for "<plugin>"
+```
 
-Same idea. You can't add one dep to every workspace in one command.
+### `--workspaces` plus a specific plugin
 
-### `install: conflicting declarations of "<name>" across workspaces: <source>@<v1> vs <source>@<v2>`
+You can't add one dep to every workspace in one command. Pick a single workspace with `--workspace <name>` instead.
+
+```text
+install: --workspaces and a specific [plugin] are mutually exclusive, pick one workspace with --workspace <name>
+```
+
+### Conflicting dep versions across workspaces
 
 Two workspaces declare the same dep with different versions. Bulk install refuses to pick a winner. Align the versions in `project.json` by hand, then rerun.
 
-### `Maven: no registries configured for "<g>:<a>:<v>". Declare a Maven registry in project.json:registries.`
+```text
+install: conflicting declarations of "<name>" across workspaces: <source>@<v1> vs <source>@<v2>
+```
 
-Maven deps need at least one entry in `project.json:registries`. Maven
-Central is a common default:
+### No Maven registries configured
+
+Maven deps need at least one entry in `project.json:registries`. Maven Central is a common default:
 
 ```json
 "registries": ["https://repo1.maven.org/maven2/"]
 ```
 
-### `Maven: could not resolve "<coord>" from any configured registry. Tried: ...`
+```text
+Maven: no registries configured for "<g>:<a>:<v>". Declare a Maven registry in project.json:registries.
+```
+
+### Maven coordinate not found
 
 The artifact wasn't found at any registry in your list. The "Tried:" block shows the exact URL for each attempt and the HTTP response. Use that to diagnose.
 
@@ -96,59 +127,111 @@ Common causes:
 - Missing registry for a non-Central artifact (for example PaperMC's Maven repo for `paper-api`).
 - 401 on a private registry with missing or wrong credentials.
 
-### `Modrinth: version "<v>" not found for slug "<slug>". available: <top-3>, ...`
+```text
+Maven: could not resolve "<coord>" from any configured registry. Tried: ...
+```
+
+### Modrinth version not found
 
 The exact version string doesn't exist. Modrinth uses the plugin's declared `version_number`, which may not be a clean semver. Check `pluggy info <slug>` or `https://modrinth.com/plugin/<slug>/versions` to see the real strings.
 
-### `Modrinth: version "<v>" of "<slug>" is a <type> release; pass --beta to install pre-releases`
+```text
+Modrinth: version "<v>" not found for slug "<slug>". available: <top-3>, ...
+```
+
+### Modrinth pre-release needs `--beta`
 
 You asked for a specific pre-release without `--beta`. Re-run with `--beta` to accept alpha and beta versions.
 
-### `remove: "<plugin>" is not declared in <workspace> (<path>)`
+```text
+Modrinth: version "<v>" of "<slug>" is a <type> release; pass --beta to install pre-releases
+```
 
-You asked to remove something that isn't there. Check `pluggy list` for the actual dep names. The key in `dependencies` is what remove wants, not the slug.
+### Removing a plugin that isn't installed
 
-### `remove: at the workspace root, pass --workspace <name> or --workspaces to disambiguate`
+You asked to remove something that isn't there. Check `pluggy list` for the actual dep names. The key in `dependencies` is what `remove` wants, not the slug.
+
+```text
+remove: "<plugin>" is not declared in <workspace> (<path>)
+```
+
+### `remove` at the workspace root needs `--workspace`
 
 At a multi-workspace root, `remove` refuses to guess. Pick one workspace with `--workspace <name>` or confirm "all" with `--workspaces`.
 
+```text
+remove: at the workspace root, pass --workspace <name> or --workspaces to disambiguate
+```
+
 ## `pluggy build`
 
-### `build: project "<name>" declares platforms from different descriptor families ("<a>" uses "<path1>", "<b>" uses "<path2>"). Split them into separate workspaces, one per family.`
+### Mixed descriptor families in `compatibility.platforms`
 
-`compatibility.platforms` contains a mix of Bukkit-family (paper, folia, spigot, bukkit), BungeeCord-family (waterfall, travertine), Velocity, and Sponge. One plugin, one descriptor. Move the others into separate workspaces. See [Workspaces > Multi-family monorepos](./workspaces.md#multi-family-monorepos).
+`compatibility.platforms` contains a mix of Bukkit-family (paper, folia, spigot, bukkit), BungeeCord-family (waterfall, travertine), Velocity, and Sponge. One plugin, one descriptor. Move the others into separate workspaces. See [Multi-family monorepos](./workspaces.md#multi-family-monorepos).
 
-### `compile: javac exited with code <n> for project "<name>" (last 40 lines): ...`
+```text
+build: project "<name>" declares platforms from different descriptor families ("<a>" uses "<path1>", "<b>" uses "<path2>"). Split them into separate workspaces, one per family.
+```
+
+### `javac` compile errors
 
 Standard Java compile errors. pluggy surfaces the last 40 stderr lines verbatim. Fix the errors in your editor and re-run.
 
-### `compile: no .java sources found under "<dir>" for project "<name>"`
+```text
+compile: javac exited with code <n> for project "<name>" (last 40 lines): ...
+```
+
+### No Java sources found
 
 The workspace's `src/` directory is empty or missing. pluggy expects sources to live under `<workspace>/src/`.
 
-### `compile: failed to spawn javac for project "<name>": spawn <path> ENOENT`
+```text
+compile: no .java sources found under "<dir>" for project "<name>"
+```
+
+### `javac` not found
 
 The cached JDK pluggy resolved is missing or its slot was deleted out of band. Run `pluggy sdk install` to repopulate the cache, or `pluggy sdk path <major>` to verify the slot exists. The `<path>` in the error is the absolute `javac` pluggy expected.
 
 If the spawn is for `javac` (no path prefix), pluggy fell back to `PATH` because `compileJava` was invoked without a resolved JDK. That's normally unreachable from CLI commands. File an issue with the surrounding output.
 
-### `shade: workspace dependency "<name>" has not been built yet, expected jar at "<path>". Build the sibling workspace first (topological order is the caller's responsibility).`
+```text
+compile: failed to spawn javac for project "<name>": spawn <path> ENOENT
+```
+
+### Sibling workspace not built yet
 
 You're shading a `workspace:` dep from inside a workspace. From the repo root, `pluggy build` orders workspaces topologically and the sibling builds first. Run from the root, or run `pluggy build --workspace <dep>` first then the dependent.
 
-### `resources: source path "<rel>" (key "<key>") does not exist at "<abs>"`
+```text
+shade: workspace dependency "<name>" has not been built yet, expected jar at "<path>". Build the sibling workspace first (topological order is the caller's responsibility).
+```
+
+### Resource path missing
 
 A `resources` entry points at a file or directory that doesn't exist. Check the path relative to the project root.
 
+```text
+resources: source path "<rel>" (key "<key>") does not exist at "<abs>"
+```
+
 ## `pluggy dev`
 
-### `java not found` from the dev server spawn
+### `java` not found at dev server start
 
 Same root cause as the `javac` entry above: the JDK slot is missing. `pluggy dev` runs the server JVM with the same JDK that compiled it. Run `pluggy sdk install` to repopulate.
 
-### `sdk: <distribution> JDK <major> is not installed and PLUGGY_NO_AUTO_INSTALL=1.`
+```text
+java not found
+```
+
+### JDK not installed in CI mode
 
 The CI escape hatch is set and the cache is cold. Pre-warm with `pluggy sdk install` in a step before the failing command, or unset the env var. The error already includes the exact command to run.
+
+```text
+sdk: <distribution> JDK <major> is not installed and PLUGGY_NO_AUTO_INSTALL=1.
+```
 
 ### Server hangs on first startup
 
@@ -166,29 +249,45 @@ Check the server logs in `dev/logs/latest.log`. Common causes:
 
 Some changes can't be applied to a running JVM: adding a supertype, changing a class hierarchy, or rewriting a method that's already on the call stack. pluggy falls back automatically to either `/reload` or a full restart, depending on `dev.hotswap.fallback`. If you keep hitting this, bump `dev.hotswap.fallback` to `"restart"` so the server starts clean every time.
 
-### `/reload` misbehaves but full restart is fine
+### `/reload` misbehaves but full restart works
 
 Don't use `--reload`. Bukkit's `/reload` has known reliability problems with stateful plugins. Full restart is slower but correct.
 
 ## `pluggy doctor`
 
-### `✗ Java toolchain: java not found or failed to run: spawn java ENOENT`
+### `java` not on `PATH`
 
 `doctor` probes the host's `java` for visibility, separately from the JDK pluggy provisions for builds. Builds still work without `java` on `PATH`. Install a JDK to silence this check, or rely on the `Project JDK` check below for a pluggy-managed verdict.
 
-### `! Project JDK: temurin <major> not yet installed, pluggy will fetch on first build.`
+```text
+✗ Java toolchain: java not found or failed to run: spawn java ENOENT
+```
+
+### Project JDK not yet installed
 
 The required JDK isn't cached, but auto-install is on. The next `pluggy build` will download it. Pre-install with `pluggy sdk install <major>` if you want the download to happen now.
 
-### `✗ Project JDK: temurin <major> not installed and PLUGGY_NO_AUTO_INSTALL=1`
+```text
+! Project JDK: temurin <major> not yet installed, pluggy will fetch on first build.
+```
+
+### Project JDK missing in CI mode
 
 The CI escape hatch is set and the cache is cold. Pre-warm with the exact command in the message, or unset the env var.
 
-### `! Java toolchain: Java <x>, BuildTools requires Java <y>+`
+```text
+✗ Project JDK: temurin <major> not installed and PLUGGY_NO_AUTO_INSTALL=1
+```
+
+### Host Java older than BuildTools floor
 
 The host `java` is older than the floor declared by the cached `BuildTools.jar` (read from its `Build-Jdk-Spec` manifest attribute). This is a warning. pluggy uses its own provisioned JDK for the build, so the host version usually doesn't matter. Fix this if a tool outside pluggy depends on the host `java`.
 
-### `✗ Cache reachability: cache is not writable: <path> (<errno>)`
+```text
+! Java toolchain: Java <x>, BuildTools requires Java <y>+
+```
+
+### Cache directory not writable
 
 The cache directory exists but pluggy can't write to it. Typical causes:
 
@@ -196,47 +295,75 @@ The cache directory exists but pluggy can't write to it. Typical causes:
 - Disk full.
 - Filesystem mounted read-only.
 
-### `! Registry <url>: unreachable: <errno>`
+```text
+✗ Cache reachability: cache is not writable: <path> (<errno>)
+```
+
+### Registry unreachable
 
 A declared Maven registry didn't respond to a `HEAD` with a 2xx, 3xx, or 4xx. This is a warning. Some registries legitimately reject HEAD. Try `pluggy install maven:<coord>@<version>` to see the real error from the resolver.
 
-### `✗ Workspace graph: workspace dependency cycle detected: <a> -> <b> -> <a>`
+```text
+! Registry <url>: unreachable: <errno>
+```
+
+### Workspace dependency cycle
 
 Two workspaces depend on each other through `workspace:`. This is a build-order impossibility. Break the cycle by extracting a third workspace that both sides depend on.
 
+```text
+✗ Workspace graph: workspace dependency cycle detected: <a> -> <b> -> <a>
+```
+
 ## Lockfile
 
-### `Failed to parse lockfile at <path>: <json-error>`
+### Lockfile won't parse
 
 `pluggy.lock` is malformed. Usually a merge conflict marker left over from a rebase. Delete the file and run `pluggy install --force` to regenerate.
 
-### `Unsupported lockfile version: <n> (at <path>; expected 1)`
+```text
+Failed to parse lockfile at <path>: <json-error>
+```
+
+### Lockfile version too new
 
 Someone wrote a newer-format lockfile with a newer pluggy. Upgrade pluggy with `pluggy upgrade`.
 
-### `Invalid lockfile entry "<key>" at <path>: ...`
+```text
+Unsupported lockfile version: <n> (at <path>; expected 1)
+```
+
+### Invalid lockfile entry
 
 Manual edit that broke the schema. Delete the entry and rerun `pluggy install`.
 
+```text
+Invalid lockfile entry "<key>" at <path>: ...
+```
+
 ## Environment
 
-### `Error: ENOSPC: no space left on device`
+### Out of disk space
 
 The cache directory is full. `pluggy doctor` and `pluggy cache info` report the current size. Wipe with [`pluggy cache clean`](./commands/cache.md). pluggy rebuilds on the next command.
+
+```text
+Error: ENOSPC: no space left on device
+```
 
 ### Windows: `pluggy` not recognized after install
 
 The install script adds the binary directory to your user `PATH`, but open terminals don't see the update until they restart. Open a fresh terminal.
 
-### macOS: "cannot be opened because the developer cannot be verified"
+### macOS: Gatekeeper blocks the binary
 
-Gatekeeper is blocking an unsigned binary. Run:
+Gatekeeper is blocking an unsigned binary because macOS sees it as quarantined. Clear the quarantine attribute:
 
 ```bash
 xattr -d com.apple.quarantine ~/.pluggy/bin/pluggy
 ```
 
-Or bypass once through `System Settings > Privacy & Security`.
+Or bypass once through **System Settings > Privacy & Security**.
 
 ## Still stuck?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -330,7 +330,7 @@ Failed to parse lockfile at <path>: <json-error>
 Someone wrote a newer-format lockfile with a newer pluggy. Upgrade pluggy with `pluggy upgrade`.
 
 ```text
-Unsupported lockfile version: <n> (at <path>; expected 1)
+Unsupported lockfile version: <n> (at <path>; expected 2)
 ```
 
 ### Invalid lockfile entry

--- a/docs/your-first-monorepo.md
+++ b/docs/your-first-monorepo.md
@@ -1,0 +1,199 @@
+# Your first monorepo
+
+By the end of this tutorial you'll have one repository with two plugin projects in it: a `core` workspace that publishes a shared interface, and a `plugin` workspace that consumes it. You'll build both with one command and learn the shape of the [`workspace:`](./glossary.md#workspace) dependency that ties them together.
+
+This is the smallest useful monorepo. For a full multi-module layout with shading and addons, see the [shared-API recipe](./recipes/monorepo-shared-api.md). For the underlying reference, see [Workspaces](./workspaces.md).
+
+If a word here feels unfamiliar, check the [glossary](./glossary.md).
+
+## When you'd want this
+
+A single plugin is one `project.json` at the repo root. You don't need a monorepo unless one of the following is true:
+
+- Two plugins want to share Java types (an `api` module).
+- You ship a Paper plugin and a Velocity plugin in one repository.
+- You manage a family of plugins that release on their own cadence.
+
+For anything else, stay with one plugin. You can always split later.
+
+## Create the layout
+
+```text
+my-network/
+├── project.json          (root, not buildable)
+├── core/
+│   ├── project.json
+│   └── src/com/example/core/Greeter.java
+└── plugin/
+    ├── project.json
+    └── src/com/example/plugin/Main.java
+```
+
+From an empty directory:
+
+```bash
+mkdir -p my-network/core/src/com/example/core
+mkdir -p my-network/plugin/src/com/example/plugin
+cd my-network
+```
+
+## The root project.json
+
+The root tells pluggy where the workspaces live. It doesn't build anything itself; it has no `main`.
+
+Write `project.json`:
+
+```json
+{
+  "name": "my_network",
+  "version": "0.0.0",
+  "compatibility": {
+    "versions": ["1.21.8"],
+    "platforms": ["paper"]
+  },
+  "workspaces": ["core", "plugin"]
+}
+```
+
+The `compatibility` block here is inherited by both workspaces, so neither has to repeat it. Paths in `workspaces` are forward-slashed and relative to the repo root.
+
+## The core workspace
+
+`core` publishes a single interface that the plugin will use. It's a real plugin from pluggy's point of view, but it doesn't have to do anything at runtime.
+
+Write `core/project.json`:
+
+```json
+{
+  "name": "core",
+  "version": "1.0.0",
+  "main": "com.example.core.CorePlugin"
+}
+```
+
+Write `core/src/com/example/core/Greeter.java`:
+
+```java
+package com.example.core;
+
+public interface Greeter {
+    String greet(String name);
+}
+```
+
+Write `core/src/com/example/core/CorePlugin.java`:
+
+```java
+package com.example.core;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class CorePlugin extends JavaPlugin {}
+```
+
+`CorePlugin` exists because `main` is required for every buildable workspace. It produces a loadable jar even though it has no behaviour of its own.
+
+## The plugin workspace
+
+`plugin` depends on `core` through the `workspace:` source kind. At resolve time, pluggy points at `core`'s built jar so the compiler can find the `Greeter` interface.
+
+Write `plugin/project.json`:
+
+```json
+{
+  "name": "plugin",
+  "version": "1.0.0",
+  "main": "com.example.plugin.Main",
+  "dependencies": {
+    "core": {
+      "source": "workspace:core",
+      "version": "*"
+    }
+  }
+}
+```
+
+The `version` field is ignored for `workspace:` deps; `core`'s own `project.json:version` is authoritative. Use `"*"` as the conventional placeholder.
+
+Write `plugin/src/com/example/plugin/Main.java`:
+
+```java
+package com.example.plugin;
+
+import com.example.core.Greeter;
+import net.kyori.adventure.text.Component;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin implements Listener, Greeter {
+    @Override
+    public void onEnable() {
+        getServer().getPluginManager().registerEvents(this, this);
+    }
+
+    @Override
+    public String greet(String name) {
+        return "Hi, " + name + ", welcome to my-network.";
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        event.joinMessage(Component.text(greet(event.getPlayer().getName())));
+    }
+}
+```
+
+The plugin implements `Greeter` (from `core`) and uses it on player join.
+
+## Build both at once
+
+From the repo root:
+
+```text
+$ pluggy build
+build core
+✓ core: /Users/you/my-network/core/bin/core-1.0.0.jar (1.1 KB, 1701ms)
+build plugin
+✓ plugin: /Users/you/my-network/plugin/bin/plugin-1.0.0.jar (2.4 KB, 1812ms)
+```
+
+pluggy sorted the two workspaces topologically. `core` builds first because `plugin` depends on it; `plugin` builds second against the just-built `core-1.0.0.jar`.
+
+If you'd run `pluggy build` from inside `plugin/` before ever building `core`, pluggy would have stopped with a clear error:
+
+```text
+shade: workspace dependency "core" has not been built yet, expected jar at "/Users/you/my-network/core/bin/core-1.0.0.jar". Build the sibling workspace first.
+```
+
+Running from the root is the simplest way to avoid that. You can also build a single workspace and its prerequisites explicitly with `pluggy build --workspace plugin` at the root.
+
+## Run the dev server
+
+`pluggy dev` runs one server at a time, so you pick a workspace:
+
+```bash
+cd plugin
+pluggy dev
+```
+
+(`pluggy dev --workspace plugin` from the root works too.)
+
+The server loads `plugin`'s jar only. `core` lives on `plugin`'s classpath because `plugin` depends on it, so the `Greeter` types are available at runtime, but `core` itself isn't installed as a separate plugin. That's normal: in this layout `core` is a library, not a plugin you'd run on its own.
+
+Connect to `localhost` from Minecraft and you'll see your greeting in chat.
+
+## What you just learned
+
+- A monorepo is just multiple `project.json` files pointed at from a root that lists them in `workspaces`.
+- One workspace depends on another with `"source": "workspace:<name>"`.
+- `pluggy build` at the root respects the dependency graph; a workspace builds after its prerequisites.
+
+## Next steps
+
+- Bundle `core`'s classes into `plugin`'s jar so you can ship one file: [Shading](./project-json.md#shading-optional).
+- Add an addon that consumes `core` without depending on `plugin`: [shared-API recipe](./recipes/monorepo-shared-api.md).
+- Ship a Paper plugin and a Velocity plugin in one repo: [Multi-family monorepos](./workspaces.md#multi-family-monorepos).
+- Inspect the workspace graph: [`pluggy graph`](./commands/graph.md).
+- See the full workspace reference for inheritance, opt-outs, and selection flags: [Workspaces](./workspaces.md).

--- a/docs/your-first-plugin.md
+++ b/docs/your-first-plugin.md
@@ -1,0 +1,136 @@
+# Your first plugin
+
+By the end of this tutorial your plugin will greet every player when they join the server, and you'll know the basic loop of edit → save → see it in-game. It assumes you've finished [Getting started](./getting-started.md), so `pluggy init` has already scaffolded a project with an empty `Main.java`.
+
+If a word here feels unfamiliar, check the [glossary](./glossary.md).
+
+## What you have right now
+
+After `pluggy init`, your project looks like this:
+
+```text
+my-plugin/
+├── project.json
+├── pluggy.lock
+└── src/
+    ├── config.yml
+    └── com/example/myplugin/Main.java
+```
+
+`Main.java` already extends `JavaPlugin`, the base class every Bukkit-style plugin uses. Its `onEnable` method is empty. The plugin loads, but does nothing.
+
+```java
+package com.example.myplugin;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin {
+    @Override
+    public void onEnable() {}
+
+    @Override
+    public void onDisable() {}
+}
+```
+
+The next step is to make it react to something happening on the server.
+
+## React to a player joining
+
+Paper, Spigot, and Bukkit all expose events: a player joins, a block breaks, a chat message is sent. Your plugin handles an event by:
+
+1. Implementing the marker interface `Listener`.
+2. Annotating a method with `@EventHandler` and accepting the event class as its single argument.
+3. Registering the listener with the plugin manager when the plugin starts.
+
+Replace the contents of `Main.java` with:
+
+```java
+package com.example.myplugin;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin implements Listener {
+    @Override
+    public void onEnable() {
+        getServer().getPluginManager().registerEvents(this, this);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Component greeting = Component.text(
+            "Welcome to the server, " + event.getPlayer().getName() + "!"
+        );
+        event.joinMessage(greeting);
+    }
+}
+```
+
+A few things worth knowing about that code:
+
+- `Component` is Paper's modern text type, from the bundled Kyori Adventure library. You don't need to install it, Paper ships it.
+- `event.joinMessage(...)` overwrites the default "Player joined the game" message for this join.
+- `getServer().getPluginManager().registerEvents(this, this)` registers `Main` (which now implements `Listener`) with the plugin manager so the `@EventHandler` method gets called.
+
+## See it in-game
+
+Start the dev server. The first run downloads a Paper server jar and accepts Mojang's [EULA](./glossary.md#eula) on your behalf:
+
+```bash
+pluggy dev
+```
+
+Once the server prints `Done (...)! For help, type "help"`, open Minecraft, click **Multiplayer**, **Direct Connect**, and connect to `localhost`. (Offline mode is on by default in `dev`, so any account works.)
+
+You should see your greeting in chat as you spawn:
+
+```text
+Welcome to the server, Notch!
+```
+
+## The edit loop
+
+Leave `pluggy dev` running and change the greeting in your editor:
+
+```java
+Component greeting = Component.text(
+    "Hello, " + event.getPlayer().getName() + ", glad you're here."
+);
+```
+
+Save. pluggy debounces 200 ms, rebuilds the jar, swaps it in, and restarts the server. Reconnect from the Minecraft client and you'll see the new message. This is the tight loop: write code, save, see it work.
+
+Press Ctrl+C in the terminal once to stop the server gracefully. A second Ctrl+C within two seconds force-kills it.
+
+## What's actually shipping
+
+Run `pluggy build` to produce a release jar:
+
+```text
+$ pluggy build
+Building my_plugin
+✓ my_plugin → /Users/you/my-plugin/bin/my_plugin-1.0.0.jar (4.5 KB, 2103ms)
+```
+
+The jar contains:
+
+- Your compiled `Main.class`.
+- An auto-generated `plugin.yml` derived from `project.json`.
+- The `config.yml` file `init` scaffolded.
+
+No Adventure jar, no Paper jar. Paper ships those at runtime, so bundling them would just be duplicated bytes on disk and unpredictable class loading.
+
+## Next steps
+
+You've written a plugin that reacts to a real Minecraft event. From here, common next moves:
+
+- Add a slash command. The auto-generated `plugin.yml` doesn't model `commands:`, so override it with a hand-written one through [`project.resources`](./project-json.md#resources-optional).
+- Read a configuration value. Your scaffold's `src/config.yml` is already shipped into the jar; load it with `getConfig().getString("key")` in `onEnable`.
+- Handle more events. Paper's API exposes events for every server-side action; see the [Paper docs](https://docs.papermc.io/paper/dev/getting-started/paper-plugins) for the full list.
+- Pull in a third-party library: [adding adventure-api](./recipes/paper-with-adventure.md), or browse the rest of the [recipes](./recipes/).
+- Split into multiple plugins that share code: [Your first monorepo](./your-first-monorepo.md).
+- Add JUnit tests: [`pluggy test`](./commands/test.md).


### PR DESCRIPTION
## Summary

Four focused rewrites driven by an audit of the docs against `conventions/DOCUMENTATION.md` and a real reader who described the docs as overwhelming. Each commit is one file and independently reviewable.

- **`docs/troubleshooting.md`** — every H3 was a verbatim full-sentence error message, making the right-hand on-page nav unscannable. Headings are now short titles; the verbatim error text moves to a fenced code block under each section so `Ctrl-F` against the exact error pluggy prints still lands. No content removed.
- **`docs/project-json.md`** — added a `## The smallest project.json` section showing the four required fields (`name`, `version`, `main`, `compatibility`) so a first-time reader has something runnable before the kitchen-sink example. Relabelled the full example as a reference of what's possible.
- **`docs/dependencies.md`** — replaced the cold opener (jumped into a source-kind grammar table) with a one-line definition plus the most common command (\`pluggy install worldedit\`). Existing structure unchanged below.
- **`docs/commands/build.md`** — moved the 10-step Pipeline section past \`Output\` / \`JSON output\` / single-vs-multi failure, and added a one-line gate so a reader who just wants to use the command knows they can skip it. No content removed.

The audit also flagged things outside this PR's scope (workspaces-vs-tutorial split, glossary cross-linking discipline, dev-server reorganisation). Happy to follow up if this lands well.

## Verification

- \`vp check\` clean (oxfmt + lint + types).
- \`vp test\` — 667 passed, 4 skipped, no regressions.
- \`git grep build.md#pipeline\` — no internal links to the moved anchor.

## Out of scope, on purpose

- No content was removed from any page. Every \`E_*\` code, hint, and prose paragraph is preserved.
- No new pages added; recommended new pages (e.g. "first plugin checklist", "monorepo starter") are left for follow-up if this direction is welcome.